### PR TITLE
evolve: extract duplicated helpers + add gate detection tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ requires-python = ">=3.10"
 license = "MIT"
 dependencies = ["click>=8.0", "pyyaml>=6.0"]
 
+[project.optional-dependencies]
+evolve = ["pytest-json-report", "pytest-cov"]
+
 [project.scripts]
 af = "fx_alfred.cli:cli"
 

--- a/src/fx_alfred/commands/_helpers.py
+++ b/src/fx_alfred/commands/_helpers.py
@@ -1,5 +1,7 @@
 """Shared helpers for CLI commands — wraps core functions with Click error handling."""
 
+from typing import Any
+
 import click
 
 from fx_alfred.context import get_root
@@ -11,6 +13,7 @@ from fx_alfred.core.scanner import (
     find_document,
     scan_documents,
 )
+from fx_alfred.core.schema import ALLOWED_STATUSES, DocType
 
 
 def scan_or_fail(ctx: click.Context) -> list[Document]:
@@ -28,3 +31,26 @@ def find_or_fail(docs: list[Document], identifier: str) -> Document:
         return find_document(docs, identifier)
     except (DocumentNotFoundError, AmbiguousDocumentError) as e:
         raise click.ClickException(str(e)) from e
+
+
+def validate_spec_status(doc_type: DocType, status: str) -> None:
+    """Validate status for the given document type."""
+    allowed = ALLOWED_STATUSES.get(doc_type, [])
+    if status not in allowed:
+        allowed_str = ", ".join(allowed)
+        raise click.ClickException(
+            f"Status '{status}' not allowed for {doc_type.value}; allowed: {allowed_str}"
+        )
+
+
+def render_section_content(content: Any) -> str:
+    """Render section content to markdown text."""
+    if isinstance(content, list):
+        lines = []
+        for item in content:
+            lines.append(f"- {item}")
+        return "\n".join(lines)
+    elif isinstance(content, str):
+        return content
+    else:
+        return str(content)

--- a/src/fx_alfred/commands/create_cmd.py
+++ b/src/fx_alfred/commands/create_cmd.py
@@ -7,12 +7,11 @@ from typing import Any
 import click
 import yaml
 
-from fx_alfred.commands._helpers import scan_or_fail
+from fx_alfred.commands._helpers import render_section_content, scan_or_fail, validate_spec_status
 from fx_alfred.context import get_root, root_option
 from fx_alfred.core.normalize import slugify
 from fx_alfred.core.schema import (
     DocType,
-    ALLOWED_STATUSES,
     REQUIRED_METADATA,
     REQUIRED_SECTIONS,
 )
@@ -112,16 +111,6 @@ def _validate_spec_doc_type(type_str: str) -> DocType:
         )
 
 
-def _validate_spec_status(doc_type: DocType, status: str) -> None:
-    """Validate status for the given document type."""
-    allowed = ALLOWED_STATUSES.get(doc_type, [])
-    if status not in allowed:
-        allowed_str = ", ".join(allowed)
-        raise click.ClickException(
-            f"Status '{status}' not allowed for {doc_type.value}; allowed: {allowed_str}"
-        )
-
-
 def _validate_spec_required_metadata(
     doc_type: DocType, metadata: dict[str, Any]
 ) -> None:
@@ -144,19 +133,6 @@ def _validate_spec_required_sections(
             raise click.ClickException(
                 f"Required section '{section}' missing for {doc_type.value}"
             )
-
-
-def _render_section_content(content: Any) -> str:
-    """Render section content to markdown text."""
-    if isinstance(content, list):
-        lines = []
-        for item in content:
-            lines.append(f"- {item}")
-        return "\n".join(lines)
-    elif isinstance(content, str):
-        return content
-    else:
-        return str(content)
 
 
 def _generate_spec_document(
@@ -195,7 +171,7 @@ def _generate_spec_document(
     for section_name, section_content in sections.items():
         lines.append(f"## {section_name}")
         lines.append("")
-        rendered = _render_section_content(section_content)
+        rendered = render_section_content(section_content)
         lines.append(rendered)
         lines.append("")
 
@@ -385,7 +361,7 @@ def create_cmd(
 
         # Validate status if provided
         if "Status" in spec_metadata:
-            _validate_spec_status(doc_type_enum, spec_metadata["Status"])
+            validate_spec_status(doc_type_enum, spec_metadata["Status"])
 
         # Resolve write base
         write_base = _resolve_write_base(ctx, layer, subdir)

--- a/src/fx_alfred/commands/update_cmd.py
+++ b/src/fx_alfred/commands/update_cmd.py
@@ -13,7 +13,7 @@ from typing import Any
 import click
 import yaml
 
-from fx_alfred.commands._helpers import find_or_fail, scan_or_fail
+from fx_alfred.commands._helpers import find_or_fail, render_section_content, scan_or_fail, validate_spec_status
 from fx_alfred.context import root_option
 from fx_alfred.core.normalize import slugify
 from fx_alfred.core.document import FILENAME_PATTERN
@@ -23,7 +23,7 @@ from fx_alfred.core.parser import (
     parse_metadata,
     render_document,
 )
-from fx_alfred.core.schema import DocType, ALLOWED_STATUSES
+from fx_alfred.core.schema import DocType
 
 
 def _is_interactive() -> bool:
@@ -42,29 +42,6 @@ def _get_doc_type(doc_type_code: str) -> DocType | None:
         return DocType(doc_type_code)
     except ValueError:
         return None
-
-
-def _validate_spec_status(doc_type: DocType, status: str) -> None:
-    """Validate status for the given document type."""
-    allowed = ALLOWED_STATUSES.get(doc_type, [])
-    if status not in allowed:
-        allowed_str = ", ".join(allowed)
-        raise click.ClickException(
-            f"Status '{status}' not allowed for {doc_type.value}; allowed: {allowed_str}"
-        )
-
-
-def _render_section_content(content: Any) -> str:
-    """Render section content to markdown text."""
-    if isinstance(content, list):
-        lines = []
-        for item in content:
-            lines.append(f"- {item}")
-        return "\n".join(lines)
-    elif isinstance(content, str):
-        return content
-    else:
-        return str(content)
 
 
 def _replace_section_in_body(
@@ -270,7 +247,7 @@ def update_cmd(
     # Validate effective Status (after CLI override) — only when a spec file is involved.
     # Plain --field/--status CLI updates are not status-validated here.
     if has_spec and "Status" in field_updates and doc_type_enum:
-        _validate_spec_status(doc_type_enum, field_updates["Status"])
+        validate_spec_status(doc_type_enum, field_updates["Status"])
 
     # Validate that CLI-requested fields exist (spec may add new ones)
     existing_keys = {mf.key for mf in parsed.metadata_fields}
@@ -368,7 +345,7 @@ def update_cmd(
 
     if spec_section_updates:
         for section_name, section_content in spec_section_updates.items():
-            rendered = _render_section_content(section_content)
+            rendered = render_section_content(section_content)
             new_body, found = _replace_section_in_body(
                 parsed.body, section_name, rendered
             )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -65,3 +65,60 @@ def test_find_or_fail_raises_on_ambiguous():
     )
     with pytest.raises(click.ClickException, match="Ambiguous"):
         find_or_fail([doc1, doc2], "1000")
+
+
+# ── Extracted helper tests (FXA-2157) ─────────────────────────────────────
+
+
+def test_render_section_content_importable():
+    """render_section_content can be imported from _helpers."""
+    from fx_alfred.commands._helpers import render_section_content
+
+    assert callable(render_section_content)
+
+
+def test_validate_spec_status_importable():
+    """validate_spec_status can be imported from _helpers."""
+    from fx_alfred.commands._helpers import validate_spec_status
+
+    assert callable(validate_spec_status)
+
+
+def test_render_section_content_list():
+    """render_section_content renders a list as markdown bullets."""
+    from fx_alfred.commands._helpers import render_section_content
+
+    result = render_section_content(["one", "two"])
+    assert result == "- one\n- two"
+
+
+def test_render_section_content_string():
+    """render_section_content passes through a string."""
+    from fx_alfred.commands._helpers import render_section_content
+
+    assert render_section_content("hello") == "hello"
+
+
+def test_render_section_content_other():
+    """render_section_content converts non-str/list to str."""
+    from fx_alfred.commands._helpers import render_section_content
+
+    assert render_section_content(42) == "42"
+
+
+def test_validate_spec_status_valid():
+    """validate_spec_status accepts a valid status without raising."""
+    from fx_alfred.commands._helpers import validate_spec_status
+    from fx_alfred.core.schema import DocType
+
+    # Should not raise
+    validate_spec_status(DocType.SOP, "Active")
+
+
+def test_validate_spec_status_invalid():
+    """validate_spec_status raises ClickException for invalid status."""
+    from fx_alfred.commands._helpers import validate_spec_status
+    from fx_alfred.core.schema import DocType
+
+    with pytest.raises(click.ClickException, match="not allowed"):
+        validate_spec_status(DocType.SOP, "Nonexistent")

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 from fx_alfred.cli import cli
+from fx_alfred.commands.plan_cmd import _parse_steps_for_json
 
 
 def _create_sop_with_steps(rules_dir: Path, prefix: str, acid: str, title: str) -> Path:
@@ -167,3 +168,50 @@ def test_plan_human_mode_no_rules(sample_project, monkeypatch):
     result = runner.invoke(cli, ["plan", "--human", "TST-5001"], catch_exceptions=False)
     assert result.exit_code == 0
     assert "## RULES" not in result.output
+
+
+# ── Gate detection tests for _parse_steps_for_json (FXA-2157) ─────────────
+
+
+class TestParseStepsForJsonGateDetection:
+    """Direct unit tests for _parse_steps_for_json gate detection logic."""
+
+    def test_plain_step_gate_false(self):
+        """Numbered step without markers has gate: false."""
+        result = _parse_steps_for_json("1. Do something")
+        assert len(result) == 1
+        assert result[0]["index"] == 1
+        assert result[0]["text"] == "Do something"
+        assert result[0]["gate"] is False
+
+    def test_step_with_checkmark_gate_true(self):
+        """Step ending with literal ✓ has gate: true."""
+        result = _parse_steps_for_json("1. Verify all tests pass ✓")
+        assert len(result) == 1
+        assert result[0]["gate"] is True
+
+    def test_step_with_gate_marker_gate_true(self):
+        """Step containing [GATE] has gate: true."""
+        result = _parse_steps_for_json("1. Review approved [GATE]")
+        assert len(result) == 1
+        assert result[0]["gate"] is True
+
+    def test_heading_prefix_parsed(self):
+        """Step with ### heading prefix is parsed correctly."""
+        result = _parse_steps_for_json("### 1. First step with heading")
+        assert len(result) == 1
+        assert result[0]["index"] == 1
+        assert result[0]["text"] == "First step with heading"
+        assert result[0]["gate"] is False
+
+    def test_mixed_content_only_numbered_extracted(self):
+        """Only numbered steps are extracted from mixed content."""
+        text = "Some intro text\n1. First step\nRandom line\n2. Second step\n\nAnother paragraph"
+        result = _parse_steps_for_json(text)
+        assert len(result) == 2
+        assert result[0]["index"] == 1
+        assert result[1]["index"] == 2
+
+    def test_empty_input_returns_empty_list(self):
+        """Empty input returns []."""
+        assert _parse_steps_for_json("") == []


### PR DESCRIPTION
## Summary

- **FXA-2157**: Extract `_render_section_content()` and `_validate_spec_status()` from `create_cmd.py` and `update_cmd.py` into shared `_helpers.py`
- Add 6 unit tests for `_parse_steps_for_json()` gate detection logic (`[GATE]`, `✓` markers)
- Add 7 tests for the extracted helper functions

## Evolve-CLI Run FXA-2155

| Signal | Result |
|--------|--------|
| Tests | 374/374 pass |
| Ruff | 0 issues |
| Coverage | 93% (plan_cmd.py 85%) |

**Candidates evaluated:** 6 generated, 2 implemented (scores 9.20, 9.55), 4 deferred.

## Review Trail

| Phase | Reviewer | Score | Verdict |
|-------|----------|-------|---------|
| PRP R1 | Codex | 7.2 | FIX |
| PRP R1 | Gemini | 9.9 | PASS |
| PRP R2 | Codex | 9.1 | PASS |
| PRP R2 | Gemini | 9.5 | PASS |
| Code R1 | Codex | 10.0 | PASS |
| Code R1 | Gemini | 9.3 | PASS |

## Test plan

- [x] `pytest` — 387 passed (374 + 13 new)
- [x] `ruff check` — 0 issues
- [x] Gate detection: `[GATE]` → true, `✓` → true, plain → false
- [x] Helper extraction: imports work, behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)