### PR TITLE
chore: add CI workflow and dev dependency group

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -e '.[dev]'
+      - run: ruff check .
+      - run: pytest --tb=short

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -e ".[dev]" 2>/dev/null || pip install -e .
-      - run: pip install pytest ruff pyright build
+      - run: pip install -e ".[dev]"
+      - run: pip install build
       - run: ruff check .
       - run: pyright src/
       - run: pytest -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ license = "MIT"
 dependencies = ["click>=8.0", "pyyaml>=6.0"]
 
 [project.optional-dependencies]
-evolve = ["pytest-json-report", "pytest-cov"]
+dev = ["pytest>=9.0", "ruff>=0.15", "pyright"]
+evolve = ["pytest>=9.0", "pytest-json-report", "pytest-cov"]
 
 [project.scripts]
 af = "fx_alfred.cli:cli"


### PR DESCRIPTION
## Summary

- Add `[dev]` optional-dependency group: `pytest>=9.0`, `ruff>=0.15`, `pyright`
- Fix `[evolve]` group to include `pytest>=9.0` (plugins depend on it)
- Add `.github/workflows/ci.yml` — runs `ruff check` + `pytest` on push to main and PRs
- Simplify `publish.yml` — replace `pip install -e ".[dev]" 2>/dev/null || pip install -e .` fallback with clean `pip install -e ".[dev]"`

## Why

Previously `pytest`, `ruff`, and `pyright` were installed ad-hoc in CI with no declared dependency group. The `[evolve]` group had pytest plugins but not pytest itself.

## Test plan

- [x] `pytest --tb=short` — 387 passed
- [x] `ruff check .` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)