### PR TITLE
evolve: replace assert with ClickException in create_cmd.py

### DIFF
--- a/src/fx_alfred/commands/create_cmd.py
+++ b/src/fx_alfred/commands/create_cmd.py
@@ -373,7 +373,11 @@ def create_cmd(
         if final_acid is None and final_area is not None:
             final_acid = _next_acid_in_area(docs, final_prefix, str(final_area))
 
-        assert final_acid is not None
+        if final_acid is None:
+            raise click.ClickException(
+                "ACID resolution failed for spec-file mode "
+                "(neither acid nor area resolved to a valid ACID)"
+            )
 
         # Check for duplicate
         for existing_doc in docs:
@@ -445,8 +449,11 @@ def create_cmd(
             raise click.ClickException("--area must be exactly 2 digits (e.g., 21)")
         acid = _next_acid_in_area(docs, prefix, area)
 
-    # acid is guaranteed non-None here
-    assert acid is not None
+    if acid is None:
+        raise click.ClickException(
+            "ACID resolution failed for CLI mode "
+            "(neither --acid nor --area resolved to a valid ACID)"
+        )
 
     doc_type_lower = doc_type.lower()
 

--- a/tests/test_create_cmd.py
+++ b/tests/test_create_cmd.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -945,3 +946,75 @@ def test_template_field_order(tmp_path, monkeypatch, doc_type, acid):
     assert field_positions["Last reviewed"] < field_positions["Status"], (
         f"{doc_type}: 'Last reviewed' must come before 'Status'"
     )
+
+
+# ── CHG FXA-2160: Replace assert with ClickException ────────────────────────
+
+
+def test_spec_mode_acid_none_raises_click_exception(tmp_path, monkeypatch):
+    """When _next_acid_in_area returns None in spec-file mode, raise ClickException."""
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    # Create a minimal spec file that uses --area (triggers _next_acid_in_area)
+    spec_file = tmp_path / "spec.yaml"
+    spec_file.write_text(
+        "type: SOP\n"
+        "prefix: TST\n"
+        "area: '21'\n"
+        "title: Test Spec\n"
+        "metadata:\n"
+        "  Applies to: test\n"
+        "  Last updated: '2026-01-01'\n"
+        "  Last reviewed: '2026-01-01'\n"
+        "  Status: Active\n"
+        "sections:\n"
+        "  What Is It?: A test SOP\n"
+        "  Why: Testing\n"
+        "  When to Use: Always\n"
+        "  When NOT to Use: Never\n"
+        "  Steps: Step 1\n"
+    )
+
+    runner = CliRunner()
+
+    # Mock _next_acid_in_area to return None (simulating unexpected failure)
+    with patch(
+        "fx_alfred.commands.create_cmd._next_acid_in_area", return_value=None
+    ):
+        result = runner.invoke(
+            cli,
+            ["create", "--spec", str(spec_file)],
+        )
+        assert result.exit_code != 0
+        assert "spec-file mode" in result.output
+
+
+def test_cli_mode_acid_none_raises_click_exception(tmp_path, monkeypatch):
+    """When _next_acid_in_area returns None in CLI mode, raise ClickException."""
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    runner = CliRunner()
+
+    # Mock _next_acid_in_area to return None (simulating unexpected failure)
+    with patch(
+        "fx_alfred.commands.create_cmd._next_acid_in_area", return_value=None
+    ):
+        result = runner.invoke(
+            cli,
+            [
+                "create",
+                "sop",
+                "--prefix",
+                "TST",
+                "--area",
+                "21",
+                "--title",
+                "CLI Test",
+            ],
+        )
+        assert result.exit_code != 0
+        assert "CLI mode" in result.output


### PR DESCRIPTION
## Summary

- Replace two `assert ... is not None` in `create_cmd.py` (lines 376, 449) with `click.ClickException` raises
- Python `-O` strips assertions — these now work in optimized mode with distinct error messages per code path
- 2 new tests covering both spec-file and CLI-args modes; 389 total tests pass, 0 ruff issues

## Evolve-CLI Run

| Item | ID | Score |
|------|----|-------|
| Run log | FXA-2158 | — |
| PRP | FXA-2159 | Gemini 9.5, Codex 9.0 |
| CHG | FXA-2160 | Gemini 9.4, Codex 9.2 |
| Issue | #4 | — |

## Test plan

- [x] pytest: 389 pass
- [x] ruff check: 0 issues
- [x] Both assert sites replaced with ClickException
- [x] Error messages are distinct (spec-file mode vs CLI mode)
- [x] TDD: red/green/refactor cycle completed
- [x] Code review: both Codex and Gemini >= 9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)