### PR TITLE
evolve: extract atomic_write helper

### DIFF
--- a/src/fx_alfred/commands/_helpers.py
+++ b/src/fx_alfred/commands/_helpers.py
@@ -1,5 +1,8 @@
 """Shared helpers for CLI commands — wraps core functions with Click error handling."""
 
+import os
+import tempfile
+from pathlib import Path
 from typing import Any
 
 import click
@@ -54,3 +57,31 @@ def render_section_content(content: Any) -> str:
         return content
     else:
         return str(content)
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write content to a file atomically using temp file + os.replace.
+
+    Creates a temporary file in the same directory, writes content to it,
+    then atomically replaces the target file. On failure, cleans up the
+    temporary file without modifying the original.
+
+    Args:
+        path: Target file path to write to.
+        content: String content to write.
+
+    Raises:
+        OSError: If file operations fail (propagated after cleanup).
+    """
+    fd, tmp_path_str = tempfile.mkstemp(dir=str(path.parent), suffix=".md.tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp_path_str, str(path))
+    except Exception:
+        # Clean up temp file on any failure
+        try:
+            os.unlink(tmp_path_str)
+        except OSError:
+            pass
+        raise

--- a/src/fx_alfred/commands/fmt_cmd.py
+++ b/src/fx_alfred/commands/fmt_cmd.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 import difflib
-import os
 import re
-import tempfile
 from pathlib import Path
 
 import click
 
-from fx_alfred.commands._helpers import find_or_fail, scan_or_fail
+from fx_alfred.commands._helpers import atomic_write, find_or_fail, scan_or_fail
 from fx_alfred.context import root_option
 from fx_alfred.core.normalize import sort_metadata
 from fx_alfred.core.parser import (
@@ -393,20 +391,7 @@ def fmt_cmd(
             click.echo(f"{doc.prefix}-{doc.acid} needs formatting")
         elif write_:
             # Write changes in-place
-            # Atomic write
-            fd, tmp_path_str = tempfile.mkstemp(
-                dir=str(file_path.parent), suffix=".md.tmp"
-            )
-            try:
-                with os.fdopen(fd, "w") as f:
-                    f.write(new_content)
-                os.replace(tmp_path_str, str(file_path))
-            except Exception:
-                try:
-                    os.unlink(tmp_path_str)
-                except OSError:
-                    pass
-                raise
+            atomic_write(file_path, new_content)
 
             click.echo(f"Formatted {doc.prefix}-{doc.acid}")
         else:

--- a/src/fx_alfred/commands/update_cmd.py
+++ b/src/fx_alfred/commands/update_cmd.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import os
 import re
 import sys
-import tempfile
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -13,7 +11,7 @@ from typing import Any
 import click
 import yaml
 
-from fx_alfred.commands._helpers import find_or_fail, render_section_content, scan_or_fail, validate_spec_status
+from fx_alfred.commands._helpers import atomic_write, find_or_fail, render_section_content, scan_or_fail, validate_spec_status
 from fx_alfred.context import root_option
 from fx_alfred.core.normalize import slugify
 from fx_alfred.core.document import FILENAME_PATTERN
@@ -395,19 +393,8 @@ def update_cmd(
             click.echo(f"\nRename: {file_path.name} -> {new_filename}")
         return
 
-    # Atomic write: temp file -> rename
-    fd, tmp_path_str = tempfile.mkstemp(dir=str(file_path.parent), suffix=".md.tmp")
-    try:
-        with os.fdopen(fd, "w") as f:
-            f.write(new_content)
-        os.replace(tmp_path_str, str(file_path))
-    except Exception:
-        # Clean up temp file on failure
-        try:
-            os.unlink(tmp_path_str)
-        except OSError:
-            pass
-        raise
+    # Atomic write
+    atomic_write(file_path, new_content)
 
     # ── Step 7: Post-write — rename file and auto-index ─────────────────────
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from unittest.mock import patch
 
 import click
@@ -122,3 +123,70 @@ def test_validate_spec_status_invalid():
 
     with pytest.raises(click.ClickException, match="not allowed"):
         validate_spec_status(DocType.SOP, "Nonexistent")
+
+
+# ── atomic_write tests ───────────────────────────────────────────────────
+
+
+def test_atomic_write_success(tmp_path):
+    """atomic_write writes content and file matches expected content."""
+    from fx_alfred.commands._helpers import atomic_write
+
+    file_path = tmp_path / "test.md"
+    content = "# Test Document\n\nHello, world!\n"
+
+    atomic_write(file_path, content)
+
+    assert file_path.exists()
+    assert file_path.read_text() == content
+
+
+def test_atomic_write_cleanup_on_failure(tmp_path):
+    """atomic_write removes temp file when os.replace raises OSError."""
+    from unittest.mock import patch
+
+    from fx_alfred.commands._helpers import atomic_write
+
+    file_path = tmp_path / "test.md"
+    content = "test content"
+
+    # Track temp files created
+    temp_files = []
+
+    original_mkstemp = __import__("tempfile").mkstemp
+
+    def track_mkstemp(*args, **kwargs):
+        fd, path = original_mkstemp(*args, **kwargs)
+        temp_files.append(path)
+        return fd, path
+
+    with (
+        patch("tempfile.mkstemp", side_effect=track_mkstemp),
+        patch("os.replace", side_effect=OSError("replace failed")),
+    ):
+        with pytest.raises(OSError, match="replace failed"):
+            atomic_write(file_path, content)
+
+    # Verify temp file was cleaned up
+    for temp_path in temp_files:
+        assert not Path(temp_path).exists(), f"Temp file {temp_path} should be removed"
+
+
+def test_atomic_write_preserves_existing(tmp_path):
+    """atomic_write preserves existing file content when os.replace fails."""
+    from unittest.mock import patch
+
+    from fx_alfred.commands._helpers import atomic_write
+
+    file_path = tmp_path / "test.md"
+    original_content = "# Original\n\nOriginal content.\n"
+    file_path.write_text(original_content)
+
+    new_content = "# New\n\nNew content.\n"
+
+    with patch("os.replace", side_effect=OSError("replace failed")):
+        with pytest.raises(OSError, match="replace failed"):
+            atomic_write(file_path, new_content)
+
+    # Original file should be unchanged
+    assert file_path.read_text() == original_content


### PR DESCRIPTION
## Summary
- Extract duplicated atomic file-write pattern into `atomic_write()` helper in `_helpers.py`
- Replaces identical 8-line patterns in `fmt_cmd.py` and `update_cmd.py`
- 3 new unit tests (success, cleanup on failure, preserves existing)

## Signals (Run FXA-2161)
- Tests: 389 passed (now 392), 0 failures
- Lint: ruff clean
- Evidence: `os.replace` appears in exactly 2 files (repo-wide search)

## Review
- PRP FXA-2162: Codex 9.3, Gemini 10.0 (R3)
- Code: Codex 9.7, Gemini 10.0

## Test plan
- [x] 392 tests pass (including 3 new atomic_write tests)
- [x] ruff check clean
- [x] Call-site regression: fmt_cmd and update_cmd tests pass unchanged

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)