### PR TITLE
evolve: add post-push review loop to both Evolve SOPs

### DIFF
--- a/fx_alfred/rules/FXA-0000-REF-Document-Index.md
+++ b/fx_alfred/rules/FXA-0000-REF-Document-Index.md
@@ -20,6 +20,7 @@
 | 2108 | PRP | Deduplicate Total Issues In Validate Cmd |
 | 2109 | CHG | Deduplicate Total Issues In Validate Cmd |
 | 2110 | CHG | Add Completion Checklist To Evolve SOP |
+| 2111 | CHG | Add Post Push Review Loop To Evolve SOPs |
 
 ---
 

--- a/fx_alfred/rules/FXA-2111-CHG-Add-Post-Push-Review-Loop-To-Evolve-SOPs.md
+++ b/fx_alfred/rules/FXA-2111-CHG-Add-Post-Push-Review-Loop-To-Evolve-SOPs.md
@@ -1,0 +1,40 @@
+# CHG-2111: Add-Post-Push-Review-Loop-To-Evolve-SOPs
+
+**Applies to:** FXA project
+**Last updated:** 2026-04-06
+**Last reviewed:** 2026-04-06
+**Status:** Completed
+**Date:** 2026-04-06
+**Requested by:** Frank
+**Priority:** Medium
+**Change Type:** Normal
+
+---
+
+## What
+
+Insert a "Phase 6.5: Post-Push Review Loop" into both FXA-2148 (Evolve-SOP) and FXA-2149 (Evolve-CLI). After the PR is opened, the agent waits for CI and automated reviews (e.g. GitHub Copilot), categorizes comments, fixes actionable items, re-runs the hard gate, pushes, and repeats — up to 3 iterations. Renumber Phase 7 (Completion Checklist) accordingly.
+
+## Why
+
+PR #36 received 4 Copilot review comments that were valid but required a manual follow-up cycle. The agent had already moved on to the completion checklist. An automated review loop closes this gap: the agent self-iterates until CI passes and all actionable review comments are resolved, before presenting the final checklist to the human.
+
+## Impact Analysis
+
+- **Systems affected:** FXA-2148-SOP-Evolve-SOP.md, FXA-2149-SOP-Evolve-CLI.md
+- **Rollback plan:** Revert the commit
+
+## Implementation Plan
+
+1. Add Phase 6.5 to FXA-2149 with steps: wait, check CI + comments, categorize, fix, re-gate, push, loop (max 3)
+2. Add Phase 6.5 to FXA-2148 with same structure, adapted for SOP gates
+3. Renumber Phase 7 → Phase 8 in both files
+4. Update Change History in both SOPs
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-04-06 | Initial version | Frank + Claude |

--- a/rules/FXA-2148-SOP-Evolve-SOP.md
+++ b/rules/FXA-2148-SOP-Evolve-SOP.md
@@ -86,6 +86,8 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
 
 ### Phase 7: Post-Push Review Loop
 
+> **Loop limit:** Steps 24–27 repeat at most **3 iterations** in total (counting both CI-wait retries and actionable-fix cycles). If the limit is reached, go to Step 28.
+
 24. **Wait for CI + automated reviews** — sleep 3 minutes after PR is opened (or after each fix-push), then:
     ```bash
     gh pr checks <PR-number>
@@ -95,13 +97,13 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
     - **Actionable** — valid issue, fix it
     - **Advisory** — noted, no code change needed (reply explaining why)
     - **False positive** — reply with reasoning, no change
-26. **If CI is not green** — go to Step 24 (wait and re-check). CI must be green before exiting the loop.
+26. **If CI is not green** — go to Step 24 (counts as one iteration).
 27. **If actionable items exist:**
     a. Fix the issues — fixes must be **mechanical** (doc wording, formatting, metadata). If a fix requires substantive content changes, stop the loop and re-run Phase 5 Step 20 (code review gate) instead.
     b. Re-run hard gate (`af --root /path/to/fx_alfred validate` must pass with 0 issues on modified documents)
     c. Commit + push
-    d. Go to Step 24 (max **3 iterations** total)
-28. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain after 3 iterations, list them in the completion checklist for human review.
+    d. Go to Step 24.
+28. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain, list them in the completion checklist for human review.
 
 ### Phase 8: Completion Checklist
 

--- a/rules/FXA-2148-SOP-Evolve-SOP.md
+++ b/rules/FXA-2148-SOP-Evolve-SOP.md
@@ -84,9 +84,27 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
 22. **Push branch** — `git push -u origin <branch>`
 23. **Open PR** — `gh pr create --title "evolve: <change-title>" --body "<run log summary: signals, scores, change>"` — body auto-populated from run log REF
 
-### Phase 7: Completion Checklist
+### Phase 7: Post-Push Review Loop
 
-24. **Display checklist** — After all phases complete (or on early exit at Step 11), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
+24. **Wait for CI + automated reviews** — sleep 3 minutes after PR is opened (or after each fix-push), then:
+    ```bash
+    gh pr checks <PR-number>
+    gh api repos/{owner}/{repo}/pulls/<PR-number>/comments
+    ```
+25. **Categorize each review comment:**
+    - **Actionable** — valid issue, fix it
+    - **Advisory** — noted, no code change needed (reply explaining why)
+    - **False positive** — reply with reasoning, no change
+26. **If actionable items exist:**
+    a. Fix the issues
+    b. Re-run hard gate (`af validate` must pass with 0 issues on modified documents)
+    c. Commit + push
+    d. Go to Step 24 (max **3 iterations** total)
+27. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain after 3 iterations, list them in the completion checklist for human review.
+
+### Phase 8: Completion Checklist
+
+28. **Display checklist** — After all phases complete (or on early exit at Step 11), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
 
 ```
 ## Evolve-SOP Run Checklist
@@ -102,6 +120,7 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
 - [ ] **Hard gate (af validate)** — <PASS/FAIL>
 - [ ] **Code review gate** — Codex <score> / Gemini <score> — <PASS/FIX>
 - [ ] **PR opened** — <URL>
+- [ ] **Post-push review loop** — <N iterations, N comments fixed / N advisory / N false positive>
 ```
 
 If a step was skipped due to early exit (e.g., no candidate passed), mark remaining items as `— SKIPPED (reason)`.
@@ -131,3 +150,4 @@ claude -p "Follow the SOP at $(af --root /path/to/fx_alfred where FXA-2148)"
 | 2026-03-30 | D1: move gh issue create + git checkout to start of Phase 5 (before PRP); D3: fix af where identifier in example | Frank + Claude |
 | 2026-04-01 | CHG FXA-2174: Define "review gate" in Prohibited Actions | Claude Code |
 | 2026-04-06 | CHG FXA-2110: Add Phase 7 Completion Checklist — mandatory post-run audit trail | Frank + Claude |
+| 2026-04-06 | CHG FXA-2111: Add Phase 7 Post-Push Review Loop; renumber Checklist to Phase 8 | Frank + Claude |

--- a/rules/FXA-2148-SOP-Evolve-SOP.md
+++ b/rules/FXA-2148-SOP-Evolve-SOP.md
@@ -89,7 +89,7 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
 24. **Wait for CI + automated reviews** — sleep 3 minutes after PR is opened (or after each fix-push), then:
     ```bash
     gh pr checks <PR-number>
-    gh api repos/{owner}/{repo}/pulls/<PR-number>/comments
+    gh api --paginate repos/{owner}/{repo}/pulls/<PR-number>/comments
     ```
 25. **Categorize each review comment:**
     - **Actionable** — valid issue, fix it

--- a/rules/FXA-2148-SOP-Evolve-SOP.md
+++ b/rules/FXA-2148-SOP-Evolve-SOP.md
@@ -95,16 +95,17 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
     - **Actionable** — valid issue, fix it
     - **Advisory** — noted, no code change needed (reply explaining why)
     - **False positive** — reply with reasoning, no change
-26. **If actionable items exist:**
+26. **If CI is not green** — go to Step 24 (wait and re-check). CI must be green before exiting the loop.
+27. **If actionable items exist:**
     a. Fix the issues — fixes must be **mechanical** (doc wording, formatting, metadata). If a fix requires substantive content changes, stop the loop and re-run Phase 5 Step 20 (code review gate) instead.
-    b. Re-run hard gate (`af validate` must pass with 0 issues on modified documents)
+    b. Re-run hard gate (`af --root /path/to/fx_alfred validate` must pass with 0 issues on modified documents)
     c. Commit + push
     d. Go to Step 24 (max **3 iterations** total)
-27. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain after 3 iterations, list them in the completion checklist for human review.
+28. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain after 3 iterations, list them in the completion checklist for human review.
 
 ### Phase 8: Completion Checklist
 
-28. **Display checklist** — After all phases complete (or on early exit at Step 11), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
+29. **Display checklist** — After all phases complete (or on early exit at Step 11), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
 
 ```
 ## Evolve-SOP Run Checklist

--- a/rules/FXA-2148-SOP-Evolve-SOP.md
+++ b/rules/FXA-2148-SOP-Evolve-SOP.md
@@ -96,7 +96,7 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
     - **Advisory** — noted, no code change needed (reply explaining why)
     - **False positive** — reply with reasoning, no change
 26. **If actionable items exist:**
-    a. Fix the issues
+    a. Fix the issues — fixes must be **mechanical** (doc wording, formatting, metadata). If a fix requires substantive content changes, stop the loop and re-run Phase 5 Step 20 (code review gate) instead.
     b. Re-run hard gate (`af validate` must pass with 0 issues on modified documents)
     c. Commit + push
     d. Go to Step 24 (max **3 iterations** total)

--- a/rules/FXA-2149-SOP-Evolve-CLI.md
+++ b/rules/FXA-2149-SOP-Evolve-CLI.md
@@ -95,7 +95,7 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
 27. **Wait for CI + automated reviews** — sleep 3 minutes after PR is opened (or after each fix-push), then:
     ```bash
     gh pr checks <PR-number>
-    gh api repos/{owner}/{repo}/pulls/<PR-number>/comments
+    gh api --paginate repos/{owner}/{repo}/pulls/<PR-number>/comments
     ```
 28. **Categorize each review comment:**
     - **Actionable** — valid issue, fix it

--- a/rules/FXA-2149-SOP-Evolve-CLI.md
+++ b/rules/FXA-2149-SOP-Evolve-CLI.md
@@ -90,9 +90,27 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
 25. **Push branch** — `git push -u origin <branch>`
 26. **Open PR** — `gh pr create --title "evolve: <change-title>" --body "<run log summary: signals, scores, change>"` — body auto-populated from run log REF
 
-### Phase 7: Completion Checklist
+### Phase 7: Post-Push Review Loop
 
-27. **Display checklist** — After all phases complete (or on early exit at Step 12), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
+27. **Wait for CI + automated reviews** — sleep 3 minutes after PR is opened (or after each fix-push), then:
+    ```bash
+    gh pr checks <PR-number>
+    gh api repos/{owner}/{repo}/pulls/<PR-number>/comments
+    ```
+28. **Categorize each review comment:**
+    - **Actionable** — valid issue, fix it
+    - **Advisory** — noted, no code change needed (reply explaining why)
+    - **False positive** — reply with reasoning, no change
+29. **If actionable items exist:**
+    a. Fix the issues
+    b. Re-run hard gate (`pytest` must pass 100% + `ruff check` must return 0 issues)
+    c. Commit + push
+    d. Go to Step 27 (max **3 iterations** total)
+30. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain after 3 iterations, list them in the completion checklist for human review.
+
+### Phase 8: Completion Checklist
+
+31. **Display checklist** — After all phases complete (or on early exit at Step 12), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
 
 ```
 ## Evolve-CLI Run Checklist
@@ -109,6 +127,7 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
 - [ ] **README check** — <UPDATED commit SHA / N/A: reason>
 - [ ] **Code review gate** — Codex <score> / Gemini <score> — <PASS/FIX>
 - [ ] **PR opened** — <URL>
+- [ ] **Post-push review loop** — <N iterations, N comments fixed / N advisory / N false positive>
 ```
 
 If a step was skipped due to early exit (e.g., no candidate passed), mark remaining items as `— SKIPPED (reason)`.
@@ -140,3 +159,4 @@ claude -p "Follow the SOP at $(af --root /path/to/fx_alfred where FXA-2149)"
 | 2026-04-01 | CHG FXA-2174: Define "review gate" in Prohibited Actions | Claude Code |
 | 2026-04-04 | Step 12: commit+push run log on no-op; Phase 5: "top candidate" not "for each" (retro FXA-2195) | Claude Code |
 | 2026-04-06 | CHG FXA-2107: Add Phase 7 Completion Checklist — mandatory post-run audit trail | Frank + Claude |
+| 2026-04-06 | CHG FXA-2111: Add Phase 7 Post-Push Review Loop; renumber Checklist to Phase 8 | Frank + Claude |

--- a/rules/FXA-2149-SOP-Evolve-CLI.md
+++ b/rules/FXA-2149-SOP-Evolve-CLI.md
@@ -92,6 +92,8 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
 
 ### Phase 7: Post-Push Review Loop
 
+> **Loop limit:** Steps 27–30 repeat at most **3 iterations** in total (counting both CI-wait retries and actionable-fix cycles). If the limit is reached, go to Step 31.
+
 27. **Wait for CI + automated reviews** — sleep 3 minutes after PR is opened (or after each fix-push), then:
     ```bash
     gh pr checks <PR-number>
@@ -101,13 +103,13 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
     - **Actionable** — valid issue, fix it
     - **Advisory** — noted, no code change needed (reply explaining why)
     - **False positive** — reply with reasoning, no change
-29. **If CI is not green** — go to Step 27 (wait and re-check). CI must be green before exiting the loop.
+29. **If CI is not green** — go to Step 27 (counts as one iteration).
 30. **If actionable items exist:**
     a. Fix the issues — fixes must be **mechanical** (test ordering, variable names, doc wording, style). If a fix requires substantive logic changes, stop the loop and re-run Phase 5 Step 23 (code review gate) instead.
     b. Re-run hard gate (`pytest` must pass 100% + `ruff check` must return 0 issues)
     c. Commit + push
-    d. Go to Step 27 (max **3 iterations** total)
-31. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain after 3 iterations, list them in the completion checklist for human review.
+    d. Go to Step 27.
+31. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain, list them in the completion checklist for human review.
 
 ### Phase 8: Completion Checklist
 

--- a/rules/FXA-2149-SOP-Evolve-CLI.md
+++ b/rules/FXA-2149-SOP-Evolve-CLI.md
@@ -102,7 +102,7 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
     - **Advisory** — noted, no code change needed (reply explaining why)
     - **False positive** — reply with reasoning, no change
 29. **If actionable items exist:**
-    a. Fix the issues — fixes must be **mechanical** (test ordering, variable names, doc wording, style). If a fix requires substantive logic changes, stop the loop and re-run Phase 5 Step 24 (code review gate) instead.
+    a. Fix the issues — fixes must be **mechanical** (test ordering, variable names, doc wording, style). If a fix requires substantive logic changes, stop the loop and re-run Phase 5 Step 23 (code review gate) instead.
     b. Re-run hard gate (`pytest` must pass 100% + `ruff check` must return 0 issues)
     c. Commit + push
     d. Go to Step 27 (max **3 iterations** total)

--- a/rules/FXA-2149-SOP-Evolve-CLI.md
+++ b/rules/FXA-2149-SOP-Evolve-CLI.md
@@ -101,16 +101,17 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
     - **Actionable** — valid issue, fix it
     - **Advisory** — noted, no code change needed (reply explaining why)
     - **False positive** — reply with reasoning, no change
-29. **If actionable items exist:**
+29. **If CI is not green** — go to Step 27 (wait and re-check). CI must be green before exiting the loop.
+30. **If actionable items exist:**
     a. Fix the issues — fixes must be **mechanical** (test ordering, variable names, doc wording, style). If a fix requires substantive logic changes, stop the loop and re-run Phase 5 Step 23 (code review gate) instead.
     b. Re-run hard gate (`pytest` must pass 100% + `ruff check` must return 0 issues)
     c. Commit + push
     d. Go to Step 27 (max **3 iterations** total)
-30. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain after 3 iterations, list them in the completion checklist for human review.
+31. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain after 3 iterations, list them in the completion checklist for human review.
 
 ### Phase 8: Completion Checklist
 
-31. **Display checklist** — After all phases complete (or on early exit at Step 12), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
+32. **Display checklist** — After all phases complete (or on early exit at Step 12), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
 
 ```
 ## Evolve-CLI Run Checklist

--- a/rules/FXA-2149-SOP-Evolve-CLI.md
+++ b/rules/FXA-2149-SOP-Evolve-CLI.md
@@ -102,7 +102,7 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
     - **Advisory** — noted, no code change needed (reply explaining why)
     - **False positive** — reply with reasoning, no change
 29. **If actionable items exist:**
-    a. Fix the issues
+    a. Fix the issues — fixes must be **mechanical** (test ordering, variable names, doc wording, style). If a fix requires substantive logic changes, stop the loop and re-run Phase 5 Step 24 (code review gate) instead.
     b. Re-run hard gate (`pytest` must pass 100% + `ruff check` must return 0 issues)
     c. Commit + push
     d. Go to Step 27 (max **3 iterations** total)

--- a/rules/FXA-2149-SOP-Evolve-CLI.md
+++ b/rules/FXA-2149-SOP-Evolve-CLI.md
@@ -105,7 +105,7 @@ The `fx_alfred` CLI currently improves only through manual human-initiated sessi
     - **False positive** — reply with reasoning, no change
 29. **If CI is not green** — go to Step 27 (counts as one iteration).
 30. **If actionable items exist:**
-    a. Fix the issues — fixes must be **mechanical** (test ordering, variable names, doc wording, style). If a fix requires substantive logic changes, stop the loop and re-run Phase 5 Step 23 (code review gate) instead.
+    a. Fix the issues — fixes must be **mechanical** (test ordering, variable names, doc wording, style). If a fix requires substantive logic changes, stop the loop and re-run Phase 5 from Step 22 (hard gate) instead.
     b. Re-run hard gate (`pytest` must pass 100% + `ruff check` must return 0 issues)
     c. Commit + push
     d. Go to Step 27.


### PR DESCRIPTION
## Summary

- Add Phase 7 (Post-Push Review Loop) to both FXA-2148 and FXA-2149
- After PR open: wait 3 min → check CI + review comments → categorize → fix actionable → re-gate → push → repeat (max 3 iterations)
- Renumber Completion Checklist from Phase 7 → Phase 8
- CHG FXA-2111

## Motivation

PR #36 received 4 valid Copilot comments that required manual follow-up. This loop automates the fix-push-check cycle.

## Changes to both SOPs

| Phase | Steps | Description |
|-------|-------|-------------|
| 7 (new) | Wait + categorize + fix + re-gate + push | Max 3 iterations |
| 8 (was 7) | Completion Checklist | Now includes review loop result |

## Test plan

- [x] Both SOPs have consistent Phase 7/8 structure
- [x] Checklist template includes review loop line item
- [ ] Verify in next evolve run

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)