### PR TITLE
Fix malformed Change History row parsing and add regression coverage

### DIFF
--- a/src/fx_alfred/core/parser.py
+++ b/src/fx_alfred/core/parser.py
@@ -216,11 +216,17 @@ def parse_metadata(content: str) -> ParsedDocument:
             # Strip leading/trailing pipes, then split on unescaped pipes
             inner = stripped[1:-1]
             cells = [c.strip() for c in re.split(r"(?<!\\)\|", inner)]
+            # Change History data rows must have exactly 3 columns.
+            # If a malformed row appears, stop parsing rows and keep remaining text.
+            if len(cells) != 3:
+                data_done = True
+                trailing_lines.append(line)
+                continue
             rows.append(
                 HistoryRow(
-                    date=cells[0] if cells else "",
-                    change=cells[1] if len(cells) > 1 else "",
-                    by=cells[2] if len(cells) > 2 else "",
+                    date=cells[0],
+                    change=cells[1],
+                    by=cells[2],
                 )
             )
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,6 @@ def sample_project(tmp_path):
     (rules_dir / "ALF-0000-REF-Document-Index.md").write_text("# ALF Index")
     (rules_dir / "ALF-2201-PRP-AF-CLI-Tool.md").write_text("# AF CLI")
     (rules_dir / "ALF-2202-SOP-Another-Doc.md").write_text("# Another Doc")
-    (rules_dir / "README.md").write_text("# Readme")  # should be ignored
+    (rules_dir / "README.md").write_text("# README")  # should be ignored
 
     return tmp_path

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,6 @@
-"""Tests for fx_alfred.core.parser — H1_PATTERN named groups."""
+"""Tests for fx_alfred.core.parser."""
 
-from fx_alfred.core.parser import H1_PATTERN
+from fx_alfred.core.parser import H1_PATTERN, parse_metadata
 
 
 def test_h1_pattern_named_groups_extract_type_code_and_acid():
@@ -23,3 +23,27 @@ def test_h1_pattern_still_works_as_boolean_match():
     assert H1_PATTERN.match("# REF-0001: Glossary") is not None
     assert H1_PATTERN.match("Not a heading") is None
     assert H1_PATTERN.match("## SOP-1000: Wrong level") is None
+
+
+def test_parse_metadata_stops_history_rows_on_malformed_table_row():
+    """Malformed history rows should remain trailing text, not parsed row data."""
+    content = """# SOP-1300: Update Document
+**Status:** Active
+---
+
+## Change History
+
+| Date | Change | By |
+|---|---|---|
+| 2026-01-01 | Initial version | Alice |
+| malformed-row |
+Trailing note
+"""
+
+    parsed = parse_metadata(content)
+
+    assert len(parsed.history_rows) == 1
+    assert parsed.history_rows[0].date == "2026-01-01"
+    assert parsed.history_rows[0].change == "Initial version"
+    assert parsed.history_rows[0].by == "Alice"
+    assert parsed.trailing.startswith("| malformed-row |")

--- a/tests/test_status_cmd.py
+++ b/tests/test_status_cmd.py
@@ -36,7 +36,7 @@ def test_status_shows_by_source(sample_project, monkeypatch):
     pkg_count = int(pkg_match.group(1))
     assert pkg_count >= 20, f"Expected at least 20 PKG docs, got {pkg_count}"
 
-    # PRJ should have exactly 2 documents (ALF-2201, ALF-2202)
+    # PRJ should have exactly 3 documents (ALF-0000, ALF-2201, ALF-2202)
     prj_match = re.search(r"PRJ:\s*(\d+)", result.output)
     assert prj_match, "PRJ count not found in output"
     prj_count = int(prj_match.group(1))


### PR DESCRIPTION
### Motivation
- The Change History parser could coerce malformed table rows into partial `HistoryRow` entries, corrupting parsed output when table rows did not have exactly three columns.
- Add regression coverage to prevent future regressions and make tests reflect current project fixtures and expectations.

### Description
- Update `parse_metadata` in `src/fx_alfred/core/parser.py` to stop parsing Change History table rows when a data row does not contain exactly three columns and to preserve that line and any following lines in `trailing` instead of treating them as a parsed row. 
- Simplify `HistoryRow` construction to rely on validated `cells` (no conditional indexing) when rows are accepted.
- Add a regression test `test_parse_metadata_stops_history_rows_on_malformed_table_row` in `tests/test_parser.py` to cover the malformed-row behavior. 
- Fix a small test fixture capitalization in `tests/conftest.py` (`# Readme` -> `# README`) and update a stale test comment in `tests/test_status_cmd.py` to match the asserted PRJ document count.

### Testing
- Ran `PYTHONPATH=src pytest -q tests/test_parser.py tests/test_status_cmd.py::test_status_shows_by_source tests/conftest.py`, which completed successfully: `5 passed`.
- Ran `PYTHONPATH=src pytest -q tests/test_fmt_cmd.py::test_fmt_table_alignment tests/test_parser.py`, which completed successfully: `4 passed`.
- Confirmed project modules compile with `python -m compileall -q src tests` with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d38f0c7f0883248011b672207ac625)