### PR TITLE
feat(FXA-2205 PR4): af plan --task auto-composition (final)

### DIFF
--- a/rules/FXA-2148-SOP-Evolve-SOP.md
+++ b/rules/FXA-2148-SOP-Evolve-SOP.md
@@ -4,12 +4,14 @@
 **Last updated:** 2026-03-30
 **Last reviewed:** 2026-03-30
 **Status:** Active
+**Task tags:** [evolve, sop, refactor-sop, improve-sop]
 
 ---
 
 ## What Is It?
 
 An automated self-improvement procedure that periodically discovers improvements to alfred SOPs and documents, evaluates candidates using a weighted rubric, implements approved changes through the standard PRP/CHG lifecycle, and opens a PR for human review.
+
 
 ## Why
 
@@ -22,16 +24,19 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
 - Operator wants to run a SOP improvement cycle manually (Phase 1)
 - Scheduled via cron (Phase 2)
 
+
 ## When NOT to Use
 
 - An evolve PR is already open (`gh pr list --label evolve` returns results — skip run)
 - Operator is mid-session with uncommitted changes to `alfred_ops/rules/`
+
 
 ## Prerequisites
 
 - `gh auth login` pre-configured
 - `/trinity` USR-layer skill available (Codex + Gemini reviewers)
 - `af` installed and accessible with `--root /path/to/fx_alfred`
+
 
 ## Steps
 
@@ -146,10 +151,10 @@ claude -p "Follow the SOP at $(af --root /path/to/fx_alfred where FXA-2148)"
 
 ## Change History
 
-| Date | Change | By |
-|------|--------|----|
-| 2026-03-30 | Initial version from FXA-2145 PRP (approved R9), CHG FXA-2147 | Frank + Claude |
+| Date       | Change                                                                                                           | By             |
+|------------|------------------------------------------------------------------------------------------------------------------|----------------|
+| 2026-03-30 | Initial version from FXA-2145 PRP (approved R9), CHG FXA-2147                                                    | Frank + Claude |
 | 2026-03-30 | D1: move gh issue create + git checkout to start of Phase 5 (before PRP); D3: fix af where identifier in example | Frank + Claude |
-| 2026-04-01 | CHG FXA-2174: Define "review gate" in Prohibited Actions | Claude Code |
-| 2026-04-06 | CHG FXA-2110: Add Phase 7 Completion Checklist — mandatory post-run audit trail | Frank + Claude |
-| 2026-04-06 | CHG FXA-2111: Add Phase 7 Post-Push Review Loop; renumber Checklist to Phase 8 | Frank + Claude |
+| 2026-04-01 | CHG FXA-2174: Define "review gate" in Prohibited Actions                                                         | Claude Code    |
+| 2026-04-06 | CHG FXA-2110: Add Phase 7 Completion Checklist — mandatory post-run audit trail                                  | Frank + Claude |
+| 2026-04-06 | CHG FXA-2111: Add Phase 7 Post-Push Review Loop; renumber Checklist to Phase 8                                   | Frank + Claude |

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -16,7 +16,9 @@ from fx_alfred.core.parser import (
     extract_section,
     parse_metadata,
 )
+from fx_alfred.core.compose import resolve_sops_from_task
 from fx_alfred.core.mermaid import render_mermaid
+from fx_alfred.core.schema import TASK_TAGS
 from fx_alfred.core.workflow import (
     LoopSignature,
     WorkflowSignature,
@@ -28,6 +30,66 @@ from fx_alfred.core.workflow import (
 
 # Heading search order for step extraction
 _STEP_HEADINGS = ("Steps", "Rule", "Rules", "Concepts")
+
+
+def _gather_all_sops(
+    docs: list[Document],
+) -> list[tuple[Document, frozenset[str], bool]]:
+    """Gather all SOPs with their task tags and always-included status.
+
+    Returns list of (Document, task_tags_frozenset, always_included_bool).
+    """
+    result: list[tuple[Document, frozenset[str], bool]] = []
+
+    for doc in docs:
+        if doc.type_code != "SOP":
+            continue
+
+        try:
+            content = doc.resolve_resource().read_text()
+            parsed = parse_metadata(content)
+        except (OSError, MalformedDocumentError):
+            continue
+
+        # Extract Task tags
+        task_tags: frozenset[str] = frozenset()
+        field_map = {mf.key: mf.value for mf in parsed.metadata_fields}
+        raw_tags = field_map.get(TASK_TAGS)
+        if raw_tags:
+            # Parse tag list: "[tag1, tag2]" or "tag1, tag2"
+            raw = raw_tags.strip()
+            if raw.startswith("[") and raw.endswith("]"):
+                raw = raw[1:-1]
+            tags = [t.strip().lower() for t in raw.split(",") if t.strip()]
+            task_tags = frozenset(tags)
+
+        # Extract Always included
+        always_included = False
+        raw_always = field_map.get("Always included")
+        if raw_always:
+            always_included = raw_always.strip().lower() == "true"
+
+        result.append((doc, task_tags, always_included))
+
+    return result
+
+
+def _format_composed_from_header(provenance: dict[str, list[str]]) -> str:
+    """Format the 'Composed from:' header with provenance markers.
+
+    Markers: (always), (auto), (explicit).
+    """
+    parts: list[str] = []
+
+    for doc_id in provenance.get("always", []):
+        parts.append(f"{doc_id}(always)")
+    for doc_id in provenance.get("explicit", []):
+        parts.append(f"{doc_id}(explicit)")
+    for doc_id in provenance.get("auto", []):
+        parts.append(f"{doc_id}(auto)")
+
+    return "Composed from: " + " → ".join(parts)
+
 
 _LLM_RULES = """\
 ## RULES
@@ -355,6 +417,12 @@ def _build_mermaid_phases(
     is_flag=True,
     help="Append Mermaid flowchart of composed plan",
 )
+@click.option(
+    "--task",
+    "task_description",
+    default=None,
+    help="Auto-compose SOPs by matching Task tags against task description",
+)
 @click.pass_context
 def plan_cmd(
     ctx: click.Context,
@@ -363,15 +431,34 @@ def plan_cmd(
     output_json: bool,
     output_todo: bool,
     output_graph: bool,
+    task_description: str | None,
 ) -> None:
     """Generate workflow checklist from SOPs."""
+    # Scan documents first (needed for --task resolution)
+    docs = scan_or_fail(ctx)
+
+    # Handle --task flag for auto-composition
+    composed_from_provenance: dict[str, list[str]] | None = None
+
+    if task_description is not None:
+        # Auto-compose SOPs via tag matching
+        all_sops = _gather_all_sops(docs)
+        positional_list = list(sop_ids)
+        try:
+            resolved_ids, composed_from_provenance = resolve_sops_from_task(
+                task_description, all_sops, positional_list
+            )
+        except click.ClickException:
+            # Re-raise with proper exit code
+            raise
+        # Convert resolved IDs back to tuple for processing
+        sop_ids = tuple(resolved_ids)
+
     if not sop_ids:
         raise click.UsageError("Usage: af plan SOP_ID [SOP_ID ...]")
 
     if output_json and human:
         raise click.UsageError("--json and --human are mutually exclusive")
-
-    docs = scan_or_fail(ctx)
 
     # ── First pass: parse all SOPs and collect workflow signatures ──
     phase_info: list[
@@ -451,7 +538,11 @@ def plan_cmd(
         if not todo_items:
             return
 
-        # Header (same for both human and default modes)
+        # Header (with Composed from if task was used)
+        if composed_from_provenance:
+            header = _format_composed_from_header(composed_from_provenance)
+            click.echo(f"# {header}")
+            click.echo()
         click.echo("# Flat TODO — Follow each item in order")
         click.echo()
         click.echo("\n".join(todo_items))
@@ -510,10 +601,13 @@ def plan_cmd(
                         }
                     )
 
-        has_new_keys = output_todo or output_graph
+        has_new_keys = (
+            output_todo or output_graph or (composed_from_provenance is not None)
+        )
+        schema_ver = "2" if has_new_keys else "1"
 
         result = {
-            "schema_version": "2" if has_new_keys else "1",
+            "schema_version": schema_ver,
             "sop_ids": list(sop_ids),
             "phases": phases_json,
             "composition_valid": composition_valid,
@@ -529,6 +623,9 @@ def plan_cmd(
                 for e in edges
             ],
         }
+
+        if composed_from_provenance:
+            result["composed_from"] = composed_from_provenance
 
         if output_todo:
             result["todo"] = todo_json
@@ -570,7 +667,11 @@ def plan_cmd(
     if not phases_text:
         return
 
-    # Header
+    # Header (with Composed from if task was used)
+    if composed_from_provenance:
+        header = _format_composed_from_header(composed_from_provenance)
+        click.echo(f"# {header}")
+        click.echo()
     if human:
         click.echo("\n".join(phases_text))
     else:

--- a/src/fx_alfred/core/compose.py
+++ b/src/fx_alfred/core/compose.py
@@ -16,6 +16,11 @@ from dataclasses import dataclass
 import click
 
 from fx_alfred.core.document import Document
+from fx_alfred.core.scanner import (
+    AmbiguousDocumentError,
+    DocumentNotFoundError,
+    find_document,
+)
 from fx_alfred.core.parser import parse_metadata
 from fx_alfred.core.workflow import parse_workflow_signature
 
@@ -308,13 +313,21 @@ def resolve_sops_from_task(
         if always_included:
             always_set.add(f"{doc.prefix}-{doc.acid}")
 
-    # 6. Validate positional IDs exist, then build candidates
-    doc_map_for_validation = {f"{d.prefix}-{d.acid}": d for d, _, _ in all_sops}
+    # 6. Validate positional IDs (accept both PREFIX-ACID and ACID-only).
+    # Use find_document so --task is additive with existing `af plan <id>`
+    # positional semantics. Normalize to PREFIX-ACID for downstream union.
+    all_docs = [doc for doc, _, _ in all_sops]
+    normalized_positional: list[str] = []
     for sop_id in positional_ids:
-        if sop_id not in doc_map_for_validation:
-            raise click.ClickException(f"SOP '{sop_id}' not found")
+        try:
+            doc = find_document(all_docs, sop_id)
+        except DocumentNotFoundError:
+            raise click.ClickException(f"SOP '{sop_id}' not found") from None
+        except AmbiguousDocumentError as e:
+            raise click.ClickException(str(e)) from None
+        normalized_positional.append(f"{doc.prefix}-{doc.acid}")
 
-    positional_set = set(positional_ids)
+    positional_set = set(normalized_positional)
     candidates = positional_set | tag_cands | always_set
 
     # 7. Empty result check

--- a/src/fx_alfred/core/compose.py
+++ b/src/fx_alfred/core/compose.py
@@ -284,7 +284,7 @@ def resolve_sops_from_task(
     ------
     click.ClickException:
         If tag matching produces nothing and no positional IDs given
-        (candidates == always_set only), exit code 2.
+        (tag_cands is empty and positional_set is empty), exit code 2.
     """
     # 1. Tokenize (as set for probing)
     tokens = tokenize(task_description)
@@ -318,7 +318,12 @@ def resolve_sops_from_task(
     candidates = positional_set | tag_cands | always_set
 
     # 7. Empty result check
-    if candidates == always_set and not positional_set:
+    # Only fail if NO user intent signals (tags or positional IDs).
+    # Always-included SOPs alone do not count as a plan — they are a baseline,
+    # not a signal. Previously this checked `candidates == always_set`, which
+    # wrongly fired when an always-included SOP also had a matching Task tag
+    # (because tag_cands ⊆ always_set keeps set equality True).
+    if not tag_cands and not positional_set:
         exc = click.ClickException(
             f'--task "{task_description}" matched 0 tagged SOPs. '
             "No routing fallback in v1.\n"

--- a/src/fx_alfred/core/compose.py
+++ b/src/fx_alfred/core/compose.py
@@ -1,0 +1,372 @@
+"""Auto-composition helpers for `af plan --task`.
+
+Pure stdlib. No filesystem access. Operates on already-parsed
+Document objects and workflow metadata to resolve SOP ordering
+via tag matching and topological sort.
+
+FXA-2205 PR4.
+"""
+
+from __future__ import annotations
+
+import string
+from collections import deque
+from dataclasses import dataclass
+
+import click
+
+from fx_alfred.core.document import Document
+from fx_alfred.core.parser import parse_metadata
+from fx_alfred.core.workflow import parse_workflow_signature
+
+# Verbatim from FXA-2205 §C1
+STOPWORDS: frozenset[str] = frozenset(
+    {
+        "a",
+        "an",
+        "the",
+        "is",
+        "are",
+        "was",
+        "were",
+        "be",
+        "been",
+        "being",
+        "to",
+        "for",
+        "of",
+        "in",
+        "on",
+        "at",
+        "by",
+        "with",
+        "from",
+        "and",
+        "or",
+        "but",
+        "if",
+        "then",
+        "else",
+        "this",
+        "that",
+        "these",
+        "those",
+        "it",
+        "its",
+        "do",
+        "does",
+        "did",
+        "please",
+        "need",
+        "needs",
+        "needed",
+    }
+)
+
+
+def tokenize(task: str) -> frozenset[str]:
+    """Tokenize a task description for tag matching.
+
+    Algorithm:
+    1. Lowercase the input.
+    2. Split on whitespace.
+    3. Strip string.punctuation from each token.
+    4. Drop tokens in STOPWORDS.
+    5. Drop empty tokens.
+    6. Return deduplicated frozenset.
+
+    Determinism guarantee: same input → same output.
+    """
+    lowered = task.lower()
+    raw_tokens = lowered.split()
+
+    tokens: set[str] = set()
+    for raw in raw_tokens:
+        # Strip punctuation (but keep hyphens, underscores, etc. inside tokens)
+        stripped = raw.strip(string.punctuation)
+        # Drop stopwords
+        if stripped in STOPWORDS:
+            continue
+        # Drop empty
+        if not stripped:
+            continue
+        tokens.add(stripped)
+
+    return frozenset(tokens)
+
+
+def tokenize_ordered(task: str) -> list[str]:
+    """Tokenize a task description preserving original order.
+
+    Same algorithm as tokenize() but returns a list with original order
+    preserved (minus deduplication - keeps first occurrence).
+    Used for bigram generation.
+    """
+    lowered = task.lower()
+    raw_tokens = lowered.split()
+
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_tokens:
+        stripped = raw.strip(string.punctuation)
+        if stripped in STOPWORDS:
+            continue
+        if not stripped:
+            continue
+        if stripped not in seen:
+            tokens.append(stripped)
+            seen.add(stripped)
+
+    return tokens
+
+
+def bigrams(tokens_list: list[str]) -> frozenset[str]:
+    """Build hyphen-joined bigrams from adjacent token pairs.
+
+    Input is a LIST (preserves order) of tokens.
+    Output is a frozenset of "{a}-{b}" strings for adjacent pairs.
+    """
+    if len(tokens_list) < 2:
+        return frozenset()
+
+    pairs: set[str] = set()
+    for i in range(len(tokens_list) - 1):
+        pair = f"{tokens_list[i]}-{tokens_list[i + 1]}"
+        pairs.add(pair)
+
+    return frozenset(pairs)
+
+
+# Layer priority for tiebreak: PKG (highest) → USR → PRJ (lowest)
+_LAYER_PRIORITY = {"pkg": 0, "usr": 1, "prj": 2}
+
+
+@dataclass(frozen=True)
+class _DocNode:
+    """Internal node for topological sort."""
+
+    doc: Document
+    doc_id: str  # "PREFIX-ACID"
+
+    def __lt__(self, other: "_DocNode") -> bool:
+        """Comparison for deterministic tiebreak: layer priority, then ASCII doc_id."""
+        self_prio = _LAYER_PRIORITY.get(self.doc.source, 99)
+        other_prio = _LAYER_PRIORITY.get(other.doc.source, 99)
+        if self_prio != other_prio:
+            return self_prio < other_prio
+        return self.doc_id < other.doc_id
+
+
+def compose_order(
+    candidates: list[Document],
+    workflow_edges: dict[str, tuple[str | None, str | None]] | None = None,
+) -> list[Document]:
+    """Order SOP candidates via Kahn's topological sort.
+
+    Edges are derived from Workflow input/output metadata:
+    - If SOP-A's output matches SOP-B's input, there's an edge A → B.
+    - workflow_edges is an optional pre-computed map:
+        {doc_id: (workflow_input, workflow_output)}.
+      If not provided, all docs are treated as independent.
+
+    Deterministic tiebreak: layer priority (PKG → USR → PRJ), then ASCII doc_id.
+
+    Fail-closed on TRUE cycle (raises ClickException with cycle nodes).
+
+    Returns ordered list of Document objects.
+    """
+    if len(candidates) <= 1:
+        return list(candidates)
+
+    # Build doc_id → Document map
+    doc_map: dict[str, Document] = {}
+    for doc in candidates:
+        doc_id = f"{doc.prefix}-{doc.acid}"
+        doc_map[doc_id] = doc
+
+    doc_ids = list(doc_map.keys())
+
+    # If no workflow edges provided, treat as independent
+    if workflow_edges is None:
+        # Sort by layer priority, then ASCII
+        nodes = [_DocNode(doc_map[d], d) for d in doc_ids]
+        nodes.sort()
+        return [n.doc for n in nodes]
+
+    # Build adjacency list: edge from A to B means A must come before B
+    # A → B if A.output == B.input (typed edge)
+    adjacency: dict[str, set[str]] = {d: set() for d in doc_ids}
+    in_degree: dict[str, int] = {d: 0 for d in doc_ids}
+
+    # Find edges
+    for a_id, (a_in, a_out) in workflow_edges.items():
+        if a_id not in doc_map:
+            continue
+        if not a_out:
+            continue
+        for b_id, (b_in, b_out) in workflow_edges.items():
+            if b_id not in doc_map:
+                continue
+            if a_id == b_id:
+                continue
+            if not b_in:
+                continue
+            if a_out == b_in:
+                # Edge: a_id → b_id
+                adjacency[a_id].add(b_id)
+                in_degree[b_id] += 1
+
+    # Kahn's algorithm
+    # Use sorted list for deterministic tiebreak
+    available = sorted([_DocNode(doc_map[d], d) for d in doc_ids if in_degree[d] == 0])
+    queue = deque(available)
+    result: list[Document] = []
+
+    while queue:
+        node = queue.popleft()
+        result.append(node.doc)
+
+        # Find neighbors to update
+        neighbors = sorted(
+            [
+                _DocNode(doc_map[n], n)
+                for n in adjacency[node.doc_id]
+                if in_degree[n] > 0
+            ]
+        )
+        for neighbor in neighbors:
+            in_degree[neighbor.doc_id] -= 1
+            if in_degree[neighbor.doc_id] == 0:
+                # Insert in sorted position (keep deterministic order)
+                queue.append(neighbor)
+                # Re-sort queue to maintain priority
+                queue = deque(sorted(queue))
+
+    # Check for cycle
+    if len(result) != len(doc_ids):
+        # Find cycle nodes
+        remaining = [d for d in doc_ids if doc_map[d] not in result]
+        cycle_nodes = ", ".join(sorted(remaining))
+        raise click.ClickException(f"Workflow cycle detected among: {cycle_nodes}")
+
+    return result
+
+
+def resolve_sops_from_task(
+    task_description: str,
+    all_sops: list[tuple[Document, frozenset[str], bool]],
+    positional_ids: list[str],
+) -> tuple[list[str], dict[str, list[str]]]:
+    """Resolve ordered SOP IDs from a task description.
+
+    Full C1 algorithm from FXA-2205 §C1.
+
+    Parameters
+    ----------
+    task_description:
+        Natural language task string (e.g., "implement FXA-2117 PRP").
+    all_sops:
+        List of (Document, task_tags, always_included) tuples.
+        - Document: the SOP document object.
+        - task_tags: frozenset of lowercase tag strings (may be empty).
+        - always_included: True if this SOP has Always included: true.
+    positional_ids:
+        List of explicit "PREFIX-ACID" strings from command line.
+
+    Returns
+    -------
+    tuple of (ordered_sop_ids, provenance):
+        - ordered_sop_ids: list of "PREFIX-ACID" strings in composition order.
+        - provenance: dict with keys "always", "auto", "explicit", each a list
+          of "PREFIX-ACID" strings in the order they were resolved.
+
+    Raises
+    ------
+    click.ClickException:
+        If tag matching produces nothing and no positional IDs given
+        (candidates == always_set only), exit code 2.
+    """
+    # 1. Tokenize (as set for probing)
+    tokens = tokenize(task_description)
+
+    # 2. Build bigrams from original-ordered tokens
+    tokens_list = tokenize_ordered(task_description)
+    bg = bigrams(tokens_list)
+
+    # 3. Probes = tokens ∪ bigrams
+    probes = tokens | bg
+
+    # 4. Tag candidates
+    tag_cands: set[str] = set()
+    for doc, task_tags, _ in all_sops:
+        if task_tags and task_tags & probes:
+            tag_cands.add(f"{doc.prefix}-{doc.acid}")
+
+    # 5. Always-included
+    always_set: set[str] = set()
+    for doc, _, always_included in all_sops:
+        if always_included:
+            always_set.add(f"{doc.prefix}-{doc.acid}")
+
+    # 6. Validate positional IDs exist, then build candidates
+    doc_map_for_validation = {f"{d.prefix}-{d.acid}": d for d, _, _ in all_sops}
+    for sop_id in positional_ids:
+        if sop_id not in doc_map_for_validation:
+            raise click.ClickException(f"SOP '{sop_id}' not found")
+
+    positional_set = set(positional_ids)
+    candidates = positional_set | tag_cands | always_set
+
+    # 7. Empty result check
+    if candidates == always_set and not positional_set:
+        exc = click.ClickException(
+            f'--task "{task_description}" matched 0 tagged SOPs. '
+            "No routing fallback in v1.\n"
+            "Try: af plan <SOP_ID> ... explicitly, or tag a relevant SOP with `Task tags:`."
+        )
+        exc.exit_code = 2
+        raise exc
+
+    # 8. Order via compose_order with workflow edges
+    # Build doc map for ordering
+    doc_map = {f"{d.prefix}-{d.acid}": d for d, _, _ in all_sops}
+    candidate_docs = [doc_map[d] for d in candidates if d in doc_map]
+
+    # Build workflow edges map from Workflow input/output metadata
+    workflow_edges: dict[str, tuple[str | None, str | None]] = {}
+    for doc in candidate_docs:
+        doc_id = f"{doc.prefix}-{doc.acid}"
+        try:
+            content_raw = doc.resolve_resource().read_text()
+            parsed = parse_metadata(content_raw)
+            sig = parse_workflow_signature(parsed)
+            if sig is not None:
+                workflow_edges[doc_id] = (sig.input or None, sig.output or None)
+            else:
+                workflow_edges[doc_id] = (None, None)
+        except Exception:
+            # If parsing fails, treat as untyped
+            workflow_edges[doc_id] = (None, None)
+
+    ordered_docs = compose_order(candidate_docs, workflow_edges)
+
+    # 9. Build provenance
+    provenance: dict[str, list[str]] = {
+        "always": [],
+        "auto": [],
+        "explicit": [],
+    }
+
+    ordered_ids = []
+    for doc in ordered_docs:
+        doc_id = f"{doc.prefix}-{doc.acid}"
+        ordered_ids.append(doc_id)
+
+        if doc_id in always_set:
+            provenance["always"].append(doc_id)
+        elif doc_id in positional_set:
+            provenance["explicit"].append(doc_id)
+        elif doc_id in tag_cands:
+            provenance["auto"].append(doc_id)
+
+    return ordered_ids, provenance

--- a/src/fx_alfred/core/normalize.py
+++ b/src/fx_alfred/core/normalize.py
@@ -52,6 +52,7 @@ KNOWN_OPTIONAL_ORDER = [
     "Workflow provides",
     "Workflow loops",
     "Always included",
+    "Task tags",
     "Tags",
 ]
 

--- a/src/fx_alfred/core/schema.py
+++ b/src/fx_alfred/core/schema.py
@@ -58,6 +58,9 @@ WORKFLOW_LOOPS = "Workflow loops"
 # FXA-2205: Always-included flag — SOP-only, optional.
 ALWAYS_INCLUDED = "Always included"
 
+# FXA-2205 PR4: Task tags — SOP-only, optional.
+TASK_TAGS = "Task tags"
+
 _WORKFLOW_FIELDS = [
     WORKFLOW_INPUT,
     WORKFLOW_OUTPUT,
@@ -66,7 +69,8 @@ _WORKFLOW_FIELDS = [
 ]
 
 OPTIONAL_METADATA: dict[DocType, list[str]] = {
-    DocType.SOP: _WORKFLOW_FIELDS + [WORKFLOW_LOOPS, ALWAYS_INCLUDED, "Tags"],
+    DocType.SOP: _WORKFLOW_FIELDS
+    + [WORKFLOW_LOOPS, ALWAYS_INCLUDED, TASK_TAGS, "Tags"],
     **{dt: ["Tags"] for dt in DocType if dt != DocType.SOP},
 }
 

--- a/src/fx_alfred/rules/COR-1500-SOP-TDD-Development-Workflow.md
+++ b/src/fx_alfred/rules/COR-1500-SOP-TDD-Development-Workflow.md
@@ -4,6 +4,7 @@
 **Last updated:** 2026-03-15
 **Last reviewed:** 2026-03-15
 **Status:** Active
+**Task tags:** [implement, feature, tdd, code, code-change, fix]
 **Last executed:** —
 **Workflow input:** task:routed
 **Workflow output:** code:tested

--- a/src/fx_alfred/rules/COR-1602-SOP-Workflow-Multi-Model-Parallel-Review.md
+++ b/src/fx_alfred/rules/COR-1602-SOP-Workflow-Multi-Model-Parallel-Review.md
@@ -5,6 +5,7 @@
 **Last reviewed:** 2026-04-01
 **Status:** Active
 **Workflow loops:** [{id: review-retry, from: 7, to: 3, max_iterations: 3, condition: "iteration is on and not all reviewers approve"}]
+**Task tags:** [review, code-review, plan-review, multi-model, prp-review, implement]
 
 ---
 

--- a/src/fx_alfred/rules/COR-1608-SOP-PRP-Review-Scoring.md
+++ b/src/fx_alfred/rules/COR-1608-SOP-PRP-Review-Scoring.md
@@ -4,6 +4,7 @@
 **Last updated:** 2026-03-20
 **Last reviewed:** 2026-03-20
 **Status:** Active
+**Task tags:** [review, prp-review, prp, scoring]
 
 ---
 

--- a/src/fx_alfred/rules/COR-1609-SOP-CHG-Review-Scoring.md
+++ b/src/fx_alfred/rules/COR-1609-SOP-CHG-Review-Scoring.md
@@ -4,6 +4,7 @@
 **Last updated:** 2026-03-20
 **Last reviewed:** 2026-03-20
 **Status:** Active
+**Task tags:** [review, chg-review, scoring]
 
 ---
 

--- a/src/fx_alfred/rules/COR-1610-SOP-Code-Review-Scoring.md
+++ b/src/fx_alfred/rules/COR-1610-SOP-Code-Review-Scoring.md
@@ -4,6 +4,7 @@
 **Last updated:** 2026-03-20
 **Last reviewed:** 2026-03-20
 **Status:** Active
+**Task tags:** [review, code-review, scoring, implement]
 
 ---
 

--- a/src/fx_alfred/rules/COR-1611-SOP-Reviewer-Calibration-Guide.md
+++ b/src/fx_alfred/rules/COR-1611-SOP-Reviewer-Calibration-Guide.md
@@ -4,6 +4,7 @@
 **Last updated:** 2026-03-20
 **Last reviewed:** 2026-03-20
 **Status:** Active
+**Task tags:** [review, calibration]
 
 ---
 

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -838,3 +838,142 @@ class TestResolveSopsFromTaskBotP2Regression:
 
         assert exc_info.value.exit_code == 2
         assert "matched 0 tagged SOPs" in str(exc_info.value)
+
+
+class TestResolveSopsFromTaskAcidOnlyPositional:
+    """FXA-2205 PR4 — PR #46 bot P2 (2nd) regression.
+
+    Positional IDs passed to `resolve_sops_from_task` must accept ACID-only
+    identifiers (e.g. "1500") in addition to full PREFIX-ACID form, matching
+    the behavior of `af plan <id>` without --task, which routes through
+    `core.scanner.find_document`. Prior behavior rejected ACID-only with
+    "SOP '1500' not found".
+    """
+
+    def test_acid_only_positional_id_resolves(self):
+        """ACID-only positional ID ('1500') resolves to full PREFIX-ACID."""
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        doc = Document(
+            prefix="COR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD",
+            source="pkg",
+            directory="rules/COR-1500-SOP-TDD.md",
+        )
+        all_sops = [(doc, frozenset(["implement"]), False)]
+
+        ordered_ids, provenance = resolve_sops_from_task(
+            "implement xyz", all_sops, ["1500"]
+        )
+
+        assert "COR-1500" in ordered_ids
+        # Classified as explicit via positional (wins over auto).
+        assert "COR-1500" in provenance["explicit"]
+
+    def test_full_prefix_acid_still_works(self):
+        """Full PREFIX-ACID positional form still resolves (unchanged)."""
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        doc = Document(
+            prefix="COR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD",
+            source="pkg",
+            directory="rules/COR-1500-SOP-TDD.md",
+        )
+        all_sops = [(doc, frozenset(["implement"]), False)]
+
+        ordered_ids, provenance = resolve_sops_from_task(
+            "implement xyz", all_sops, ["COR-1500"]
+        )
+
+        assert "COR-1500" in ordered_ids
+        assert "COR-1500" in provenance["explicit"]
+
+    def test_bad_acid_only_still_raises(self):
+        """Non-existent ACID-only positional raises 'SOP 'X' not found'."""
+        import click
+
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        doc = Document(
+            prefix="COR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD",
+            source="pkg",
+            directory="rules/COR-1500-SOP-TDD.md",
+        )
+        all_sops = [(doc, frozenset(["implement"]), False)]
+
+        with pytest.raises(click.ClickException) as exc_info:
+            resolve_sops_from_task("implement", all_sops, ["99999"])
+
+        assert "99999" in str(exc_info.value)
+        assert "not found" in str(exc_info.value).lower()
+
+    def test_bad_full_id_still_raises(self):
+        """Non-existent full PREFIX-ACID raises 'SOP 'X' not found'."""
+        import click
+
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        doc = Document(
+            prefix="COR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD",
+            source="pkg",
+            directory="rules/COR-1500-SOP-TDD.md",
+        )
+        all_sops = [(doc, frozenset(["implement"]), False)]
+
+        with pytest.raises(click.ClickException) as exc_info:
+            resolve_sops_from_task("implement", all_sops, ["BAD-9999"])
+
+        assert "BAD-9999" in str(exc_info.value)
+        assert "not found" in str(exc_info.value).lower()
+
+    def test_ambiguous_acid_raises(self):
+        """Same ACID across two prefixes, ACID-only positional → ambiguity error."""
+        import click
+
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        doc_a = Document(
+            prefix="COR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD-A",
+            source="pkg",
+            directory="rules/COR-1500-SOP-TDD.md",
+        )
+        doc_b = Document(
+            prefix="USR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD-B",
+            source="usr",
+            directory="rules/USR-1500-SOP-TDD.md",
+        )
+        all_sops = [
+            (doc_a, frozenset(), False),
+            (doc_b, frozenset(), False),
+        ]
+
+        with pytest.raises(click.ClickException) as exc_info:
+            resolve_sops_from_task("implement", all_sops, ["1500"])
+
+        # The message comes from AmbiguousDocumentError.__str__
+        # Format: "Ambiguous ACID 1500. Multiple matches: COR-1500, USR-1500. ..."
+        msg = str(exc_info.value).lower()
+        assert "1500" in msg
+        assert "ambiguous" in msg or "multiple" in msg

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -770,3 +770,71 @@ class TestCoverageFills:
 
         assert "BAD-9999" in str(exc_info.value)
         assert "not found" in str(exc_info.value).lower()
+
+
+class TestResolveSopsFromTaskBotP2Regression:
+    """Regression tests for PR #46 bot-P2 fix (chatgpt-codex-connector).
+
+    The empty-match check must be based on tag_cands + positional_set only,
+    NOT on `candidates == always_set`. Otherwise, a SOP that is BOTH
+    always-included AND has a matching Task tag wrongly triggers exit 2.
+    """
+
+    def test_always_included_with_tag_match_does_not_trigger_empty_error(self):
+        """SOP that is BOTH Always included AND has matching tag → returns successfully."""
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        # Synthetic SOP that is both always-included AND has matching tag 'foo'.
+        always_and_tagged_doc = Document(
+            prefix="TST",
+            acid="9100",
+            type_code="SOP",
+            title="AlwaysAndTagged",
+            source="pkg",
+            directory="rules/TST-9100-SOP-AlwaysAndTagged.md",
+        )
+
+        # (doc, task_tags, always_included)
+        # Only one SOP in the corpus. It has tag 'foo' AND always_included=True.
+        all_sops = [
+            (always_and_tagged_doc, frozenset(["foo", "bar"]), True),
+        ]
+
+        # Task "foo bar" tokenizes to {foo, bar}; tag_cands = {TST-9100}.
+        # always_set also = {TST-9100}. Pre-fix: candidates == always_set → exit 2.
+        # Post-fix: tag_cands is non-empty → compose successfully.
+        ordered_ids, provenance = resolve_sops_from_task("foo bar", all_sops, [])
+
+        # No exception was raised; SOP is in the plan.
+        assert "TST-9100" in ordered_ids
+        # Always-included provenance wins the classification for dual-class SOPs.
+        assert "TST-9100" in provenance["always"]
+
+    def test_empty_match_still_raises_when_no_tags_and_no_positional(self):
+        """Empty tag match + no positional → ClickException exit 2 (fail-closed preserved)."""
+        import click
+
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        # SOP with no tags, not always-included.
+        untagged_doc = Document(
+            prefix="TST",
+            acid="9200",
+            type_code="SOP",
+            title="Untagged",
+            source="pkg",
+            directory="rules/TST-9200-SOP-Untagged.md",
+        )
+
+        all_sops = [
+            (untagged_doc, frozenset(), False),  # No tags, not always-included
+        ]
+
+        # "xyzzy unmatched" matches no tags; no positional → must fail-closed.
+        with pytest.raises(click.ClickException) as exc_info:
+            resolve_sops_from_task("xyzzy unmatched", all_sops, [])
+
+        assert exc_info.value.exit_code == 2
+        assert "matched 0 tagged SOPs" in str(exc_info.value)

--- a/tests/test_compose.py
+++ b/tests/test_compose.py
@@ -1,0 +1,772 @@
+"""Tests for core/compose.py (FXA-2205 PR4)."""
+
+import pytest
+
+
+class TestTokenize:
+    """Tests for tokenize() function."""
+
+    def test_tokenize_basic_lowercase(self):
+        """Tokenize converts to lowercase."""
+        from fx_alfred.core.compose import tokenize
+
+        result = tokenize("FXA-2117 PRP")
+        assert "fxa-2117" in result
+        assert "prp" in result
+
+    def test_tokenize_strips_punctuation(self):
+        """Tokenize strips string.punctuation from each token."""
+        from fx_alfred.core.compose import tokenize
+
+        # "FXA-2117!" → "fxa-2117" (exclamation stripped, hyphen kept as not in string.punctuation)
+        result = tokenize("FXA-2117! Please.")
+        assert "fxa-2117" in result
+        # "please" is in STOPWORDS, so it should be dropped
+        assert "please" not in result
+
+    def test_tokenize_drops_stopwords(self):
+        """Tokenize drops stopwords from the fixed set."""
+        from fx_alfred.core.compose import tokenize, STOPWORDS
+
+        # Test that stopwords are dropped
+        result = tokenize(
+            "the a an is are was were be been being to for of in on at by with from"
+        )
+        # All these are stopwords, should result in empty set
+        assert result == frozenset()
+
+        # Verify STOPWORDS contains expected words
+        assert "the" in STOPWORDS
+        assert "a" in STOPWORDS
+        assert "is" in STOPWORDS
+        assert "to" in STOPWORDS
+        assert "for" in STOPWORDS
+
+    def test_tokenize_drops_empty(self):
+        """Tokenize drops empty tokens after stripping."""
+        from fx_alfred.core.compose import tokenize
+
+        # "!!!" becomes empty after stripping punctuation
+        result = tokenize("!!! ??? ...")
+        assert result == frozenset()
+
+    def test_tokenize_returns_frozenset(self):
+        """Tokenize returns a frozenset (immutable, deduplicated)."""
+        from fx_alfred.core.compose import tokenize
+
+        result = tokenize("test test TEST")
+        assert isinstance(result, frozenset)
+        # Deduplicated
+        assert len(result) == 1
+        assert "test" in result
+
+    def test_tokenize_determinism(self):
+        """Same input → same output × 100 calls (determinism guarantee)."""
+        from fx_alfred.core.compose import tokenize
+
+        inputs = ["Implement FXA-2117 PRP, please."]
+        for inp in inputs:
+            results = [tokenize(inp) for _ in range(100)]
+            first = results[0]
+            for r in results[1:]:
+                assert r == first, f"Non-deterministic result for {inp!r}"
+
+
+class TestBigrams:
+    """Tests for bigrams() function."""
+
+    def test_bigrams_adjacent_pairs(self):
+        """Bigrams creates hyphen-joined pairs from adjacent tokens."""
+        from fx_alfred.core.compose import bigrams
+
+        # Input is a list of tokens in order
+        result = bigrams(["code", "change", "review"])
+        assert "code-change" in result
+        assert "change-review" in result
+        assert len(result) == 2
+
+    def test_bigrams_single_token_empty(self):
+        """Bigrams with single token returns empty set."""
+        from fx_alfred.core.compose import bigrams
+
+        result = bigrams(["single"])
+        assert result == frozenset()
+
+    def test_bigrams_empty_input(self):
+        """Bigrams with empty input returns empty set."""
+        from fx_alfred.core.compose import bigrams
+
+        result = bigrams([])
+        assert result == frozenset()
+
+    def test_bigrams_returns_frozenset(self):
+        """Bigrams returns a frozenset."""
+        from fx_alfred.core.compose import bigrams
+
+        result = bigrams(["a", "b", "c"])
+        assert isinstance(result, frozenset)
+
+
+class TestComposeOrder:
+    """Tests for compose_order() - Kahn's topological sort with tiebreak."""
+
+    def test_compose_order_single_sop(self):
+        """Single SOP returns list with just that SOP."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        doc = Document(
+            prefix="COR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD",
+            source="pkg",
+            directory="rules/COR-1500-SOP-TDD.md",
+        )
+        result = compose_order([doc])
+        assert len(result) == 1
+        assert result[0] == doc
+
+    def test_compose_order_independent_layer_tiebreak(self):
+        """Independent SOPs (no edges) → layer priority (PKG→USR→PRJ), then ASCII order."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        # Create three independent SOPs from different layers
+        pkg_doc = Document(
+            prefix="COR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD",
+            source="pkg",
+            directory="rules/COR-1500-SOP-TDD.md",
+        )
+        usr_doc = Document(
+            prefix="ALF",
+            acid="2207",
+            type_code="SOP",
+            title="Routing",
+            source="usr",
+            directory="~/.alfred/ALF-2207-SOP-Routing.md",
+        )
+        prj_doc = Document(
+            prefix="FXA",
+            acid="2125",
+            type_code="SOP",
+            title="Routing",
+            source="prj",
+            directory="rules/FXA-2125-SOP-Routing.md",
+        )
+
+        # Input order should not matter; output should be PKG → USR → PRJ
+        result = compose_order([prj_doc, usr_doc, pkg_doc])
+        assert result[0].source == "pkg"
+        assert result[1].source == "usr"
+        assert result[2].source == "prj"
+
+    def test_compose_order_ascii_tiebreak_same_layer(self):
+        """Same layer, no edges → ASCII order by SOP-ID."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        # Three PKG SOPs with different ACIDs
+        doc1 = Document(
+            prefix="COR",
+            acid="1602",
+            type_code="SOP",
+            title="Review",
+            source="pkg",
+            directory="rules/COR-1602-SOP-Review.md",
+        )
+        doc2 = Document(
+            prefix="COR",
+            acid="1500",
+            type_code="SOP",
+            title="TDD",
+            source="pkg",
+            directory="rules/COR-1500-SOP-TDD.md",
+        )
+        doc3 = Document(
+            prefix="COR",
+            acid="1600",
+            type_code="SOP",
+            title="General",
+            source="pkg",
+            directory="rules/COR-1600-SOP-General.md",
+        )
+
+        # ASCII order: COR-1500 < COR-1600 < COR-1602
+        result = compose_order([doc3, doc1, doc2])
+        assert result[0].acid == "1500"
+        assert result[1].acid == "1600"
+        assert result[2].acid == "1602"
+
+    def test_compose_order_typed_chain_a_to_b_to_c(self):
+        """Typed chain A→B→C via workflow_edges respects edge order even when ASCII would reverse."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        # Choose doc IDs whose ASCII order would be C < B < A, so edges must win.
+        doc_a = Document(
+            prefix="TST",
+            acid="9003",
+            type_code="SOP",
+            title="StepA",
+            source="pkg",
+            directory="rules/TST-9003-SOP-StepA.md",
+        )
+        doc_b = Document(
+            prefix="TST",
+            acid="9002",
+            type_code="SOP",
+            title="StepB",
+            source="pkg",
+            directory="rules/TST-9002-SOP-StepB.md",
+        )
+        doc_c = Document(
+            prefix="TST",
+            acid="9001",
+            type_code="SOP",
+            title="StepC",
+            source="pkg",
+            directory="rules/TST-9001-SOP-StepC.md",
+        )
+
+        # A.output="ax" → B.input="ax"; B.output="bx" → C.input="bx"
+        edges = {
+            "TST-9003": (None, "ax"),
+            "TST-9002": ("ax", "bx"),
+            "TST-9001": ("bx", None),
+        }
+
+        result = compose_order([doc_a, doc_b, doc_c], edges)
+        # Despite ASCII order 9001 < 9002 < 9003, typed edges force A→B→C.
+        assert [d.acid for d in result] == ["9003", "9002", "9001"]
+
+    def test_compose_order_edges_override_ascii_for_two_docs(self):
+        """Typed edge A.output → B.input forces [A, B] even when ASCII would return [B, A]."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        # ASCII: TST-7002 < TST-7009, so without edges result would be [7002, 7009].
+        doc_a = Document(
+            prefix="TST",
+            acid="7009",
+            type_code="SOP",
+            title="First",
+            source="pkg",
+            directory="rules/TST-7009-SOP-First.md",
+        )
+        doc_b = Document(
+            prefix="TST",
+            acid="7002",
+            type_code="SOP",
+            title="Second",
+            source="pkg",
+            directory="rules/TST-7002-SOP-Second.md",
+        )
+
+        edges = {
+            "TST-7009": (None, "draft"),
+            "TST-7002": ("draft", None),
+        }
+
+        result = compose_order([doc_a, doc_b], edges)
+        assert [d.acid for d in result] == ["7009", "7002"]
+
+        # Control: without edges, ASCII tiebreak restores [7002, 7009]
+        result_no_edges = compose_order([doc_a, doc_b])
+        assert [d.acid for d in result_no_edges] == ["7002", "7009"]
+
+    def test_compose_order_real_cycle_raises_click_exception(self):
+        """True cycle A→B→A in Workflow input/output edges raises ClickException."""
+        import click
+
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        doc_a = Document(
+            prefix="TST",
+            acid="8001",
+            type_code="SOP",
+            title="StepA",
+            source="pkg",
+            directory="rules/TST-8001-SOP-StepA.md",
+        )
+        doc_b = Document(
+            prefix="TST",
+            acid="8002",
+            type_code="SOP",
+            title="StepB",
+            source="pkg",
+            directory="rules/TST-8002-SOP-StepB.md",
+        )
+
+        # A.output=x → B.input=x AND B.output=y → A.input=y → cycle
+        edges = {
+            "TST-8001": ("y", "x"),
+            "TST-8002": ("x", "y"),
+        }
+
+        with pytest.raises(click.ClickException) as exc_info:
+            compose_order([doc_a, doc_b], edges)
+
+        msg = str(exc_info.value)
+        assert "cycle" in msg.lower() or "cyclic" in msg.lower() or "TST-8001" in msg
+
+    def test_compose_order_edge_doc_not_in_map_is_skipped(self):
+        """workflow_edges entries whose doc_id is absent from candidates are ignored."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        doc = Document(
+            prefix="TST",
+            acid="5001",
+            type_code="SOP",
+            title="Solo",
+            source="pkg",
+            directory="rules/TST-5001-SOP-Solo.md",
+        )
+
+        # Edge entries reference phantom docs not present in candidates
+        edges = {
+            "TST-5001": (None, "out1"),
+            "TST-9999": ("out1", None),  # phantom
+            "TST-8888": ("something", "out1"),  # phantom
+        }
+
+        result = compose_order([doc], edges)
+        assert len(result) == 1
+        assert result[0].acid == "5001"
+
+
+class TestResolveSopsFromTask:
+    """Tests for resolve_sops_from_task() - full C1 algorithm."""
+
+    def test_resolve_one_tag_match_returns_with_always_prepended(self):
+        """One tag match → returns it + always-included SOPs prepended."""
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        # Create mock SOPs with task tags and always-included status
+        tagged_doc = Document(
+            prefix="TST",
+            acid="1500",
+            type_code="SOP",
+            title="Tagged",
+            source="pkg",
+            directory="rules/TST-1500-SOP-Tagged.md",
+        )
+        always_doc = Document(
+            prefix="TST",
+            acid="1103",
+            type_code="SOP",
+            title="Always",
+            source="pkg",
+            directory="rules/TST-1103-SOP-Always.md",
+        )
+
+        all_sops = [
+            (tagged_doc, frozenset(["implement", "tdd"]), False),
+            (always_doc, frozenset(), True),
+        ]
+
+        # Task "implement" should match tagged_doc, plus always_doc
+        ordered_ids, provenance = resolve_sops_from_task(
+            "implement feature", all_sops, []
+        )
+
+        # Both should be included
+        assert "TST-1500" in ordered_ids
+        assert "TST-1103" in ordered_ids
+        # Always should be in always provenance
+        assert "TST-1103" in provenance["always"]
+        # Tagged should be in auto provenance
+        assert "TST-1500" in provenance["auto"]
+
+    def test_resolve_bigram_probe_matches_hyphenated_tag(self):
+        """Bigram probe 'code change' matches 'code-change' tag."""
+        from fx_alfred.core.compose import tokenize_ordered, bigrams
+
+        # Test the tokenization + bigram logic with original order preserved
+        tokens_list = tokenize_ordered("code change feature")
+        bg = bigrams(tokens_list)
+        assert "code-change" in bg
+        assert "change-feature" in bg
+
+    def test_resolve_empty_task_no_positional_raises_exit_2(self):
+        """Empty tag match + no positional → ClickException exit 2 with diagnostic."""
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+        import click
+
+        # Create only always-included SOP with no matching tags
+        always_doc = Document(
+            prefix="TST",
+            acid="1103",
+            type_code="SOP",
+            title="Always",
+            source="pkg",
+            directory="rules/TST-1103-SOP-Always.md",
+        )
+
+        all_sops = [(always_doc, frozenset(), True)]
+
+        # "xyzzy rare unmatched" should match nothing
+        with pytest.raises(click.ClickException) as exc_info:
+            resolve_sops_from_task("xyzzy rare unmatched", all_sops, [])
+
+        assert exc_info.value.exit_code == 2
+        assert "matched 0 tagged SOPs" in str(exc_info.value)
+
+    def test_resolve_positional_and_task_union_deduped(self):
+        """Positional IDs + tag matches → union, de-duplicated."""
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        # Create multiple SOPs
+        tagged_doc = Document(
+            prefix="TST",
+            acid="1500",
+            type_code="SOP",
+            title="Tagged",
+            source="pkg",
+            directory="rules/TST-1500-SOP-Tagged.md",
+        )
+        explicit_doc = Document(
+            prefix="TST",
+            acid="7001",
+            type_code="SOP",
+            title="Explicit",
+            source="pkg",
+            directory="rules/TST-7001-SOP-Explicit.md",
+        )
+        always_doc = Document(
+            prefix="TST",
+            acid="1103",
+            type_code="SOP",
+            title="Always",
+            source="pkg",
+            directory="rules/TST-1103-SOP-Always.md",
+        )
+
+        all_sops = [
+            (tagged_doc, frozenset(["implement"]), False),
+            (explicit_doc, frozenset(["other"]), False),
+            (always_doc, frozenset(), True),
+        ]
+
+        # Task "implement" matches tagged_doc, plus positional explicit_doc
+        ordered_ids, provenance = resolve_sops_from_task(
+            "implement", all_sops, ["TST-7001"]
+        )
+
+        # All three should be included, de-duplicated
+        assert len(ordered_ids) == len(set(ordered_ids))  # No duplicates
+        assert "TST-1500" in ordered_ids  # Tag matched
+        assert "TST-7001" in ordered_ids  # Explicit
+        assert "TST-1103" in ordered_ids  # Always
+        # Check provenance
+        assert "TST-1103" in provenance["always"]
+        assert "TST-7001" in provenance["explicit"]
+        assert "TST-1500" in provenance["auto"]
+
+    def test_resolve_always_included_prepended(self):
+        """Always-included SOPs are always prepended."""
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        # Create SOPs where always is PKG layer (should come first)
+        tagged_doc = Document(
+            prefix="TST",
+            acid="1500",
+            type_code="SOP",
+            title="Tagged",
+            source="prj",
+            directory="rules/TST-1500-SOP-Tagged.md",
+        )
+        always_doc = Document(
+            prefix="TST",
+            acid="1103",
+            type_code="SOP",
+            title="Always",
+            source="pkg",
+            directory="rules/TST-1103-SOP-Always.md",
+        )
+
+        all_sops = [
+            (tagged_doc, frozenset(["implement"]), False),
+            (always_doc, frozenset(), True),
+        ]
+
+        # Task "implement" matches tagged_doc, plus always_doc
+        ordered_ids, provenance = resolve_sops_from_task("implement", all_sops, [])
+
+        # Always should be first (PKG layer priority)
+        assert ordered_ids[0] == "TST-1103"
+        assert "TST-1103" in provenance["always"]
+        assert "TST-1500" in provenance["auto"]
+
+
+class TestStopwordsConstant:
+    """Tests for STOPWORDS constant."""
+
+    def test_stopwords_is_frozenset(self):
+        """STOPWORDS is a frozenset."""
+        from fx_alfred.core.compose import STOPWORDS
+
+        assert isinstance(STOPWORDS, frozenset)
+
+    def test_stopwords_contains_expected_words(self):
+        """STOPWORDS contains the verbatim set from the spec."""
+        from fx_alfred.core.compose import STOPWORDS
+
+        expected = {
+            "a",
+            "an",
+            "the",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "being",
+            "to",
+            "for",
+            "of",
+            "in",
+            "on",
+            "at",
+            "by",
+            "with",
+            "from",
+            "and",
+            "or",
+            "but",
+            "if",
+            "then",
+            "else",
+            "this",
+            "that",
+            "these",
+            "those",
+            "it",
+            "its",
+            "do",
+            "does",
+            "did",
+            "please",
+            "need",
+            "needs",
+            "needed",
+        }
+        assert STOPWORDS == expected
+
+
+class TestComposeOrderWithEdges:
+    """Tests for compose_order with typed workflow edges."""
+
+    def test_compose_order_two_node_chain(self):
+        """Two nodes with A.output == B.input → A before B."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        doc_a = Document(
+            prefix="TST",
+            acid="6001",
+            type_code="SOP",
+            title="StepA",
+            source="pkg",
+            directory="rules/TST-6001-SOP-StepA.md",
+        )
+        doc_b = Document(
+            prefix="TST",
+            acid="6002",
+            type_code="SOP",
+            title="StepB",
+            source="pkg",
+            directory="rules/TST-6002-SOP-StepB.md",
+        )
+
+        # A outputs "reviewed", B inputs "reviewed"
+        workflow_edges = {
+            "TST-6001": (None, "reviewed"),
+            "TST-6002": ("reviewed", None),
+        }
+
+        result = compose_order([doc_a, doc_b], workflow_edges)
+        # A should come before B because A.output == B.input
+        assert result[0].acid == "6001"
+        assert result[1].acid == "6002"
+
+    def test_compose_order_three_node_chain(self):
+        """Three nodes with A→B→C chain."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        doc_a = Document(
+            prefix="TST",
+            acid="6001",
+            type_code="SOP",
+            title="StepA",
+            source="pkg",
+            directory="rules/TST-6001-SOP-StepA.md",
+        )
+        doc_b = Document(
+            prefix="TST",
+            acid="6002",
+            type_code="SOP",
+            title="StepB",
+            source="pkg",
+            directory="rules/TST-6002-SOP-StepB.md",
+        )
+        doc_c = Document(
+            prefix="TST",
+            acid="6003",
+            type_code="SOP",
+            title="StepC",
+            source="pkg",
+            directory="rules/TST-6003-SOP-StepC.md",
+        )
+
+        # A→B→C chain: A.output == B.input, B.output == C.input
+        workflow_edges = {
+            "TST-6001": (None, "draft"),
+            "TST-6002": ("draft", "reviewed"),
+            "TST-6003": ("reviewed", None),
+        }
+
+        result = compose_order([doc_c, doc_a, doc_b], workflow_edges)
+        # Order should be A → B → C regardless of input order
+        assert result[0].acid == "6001"
+        assert result[1].acid == "6002"
+        assert result[2].acid == "6003"
+
+    def test_compose_order_cycle_raises_click_exception(self):
+        """True cycle A→B→A raises ClickException."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+        import click
+
+        doc_a = Document(
+            prefix="TST",
+            acid="6001",
+            type_code="SOP",
+            title="StepA",
+            source="pkg",
+            directory="rules/TST-6001-SOP-StepA.md",
+        )
+        doc_b = Document(
+            prefix="TST",
+            acid="6002",
+            type_code="SOP",
+            title="StepB",
+            source="pkg",
+            directory="rules/TST-6002-SOP-StepB.md",
+        )
+
+        # Cycle: A.output == B.input, B.output == A.input
+        workflow_edges = {
+            "TST-6001": ("done", "reviewed"),
+            "TST-6002": ("reviewed", "done"),
+        }
+
+        with pytest.raises(click.ClickException, match="Workflow cycle detected"):
+            compose_order([doc_a, doc_b], workflow_edges)
+
+    def test_compose_order_partial_edges(self):
+        """Some nodes with edges, others independent."""
+        from fx_alfred.core.compose import compose_order
+        from fx_alfred.core.document import Document
+
+        doc_a = Document(
+            prefix="TST",
+            acid="6001",
+            type_code="SOP",
+            title="StepA",
+            source="pkg",
+            directory="rules/TST-6001-SOP-StepA.md",
+        )
+        doc_b = Document(
+            prefix="TST",
+            acid="6002",
+            type_code="SOP",
+            title="StepB",
+            source="pkg",
+            directory="rules/TST-6002-SOP-StepB.md",
+        )
+        doc_c = Document(
+            prefix="TST",
+            acid="6003",
+            type_code="SOP",
+            title="StepC",
+            source="pkg",
+            directory="rules/TST-6003-SOP-StepC.md",
+        )
+
+        # A→B edge, C is independent
+        workflow_edges = {
+            "TST-6001": (None, "reviewed"),
+            "TST-6002": ("reviewed", None),
+            "TST-6003": (None, None),
+        }
+
+        result = compose_order([doc_c, doc_a, doc_b], workflow_edges)
+        # A should come before B, C can be anywhere (but ASCII tiebreak puts 6001, 6002, 6003)
+        # Actually, A→B edge means A must come before B, but C is independent
+        # So the order should respect the edge, with C positioned by ASCII tiebreak
+        # Since A has in_degree 0, and C has in_degree 0, they both start available
+        # Sorted by layer+ASCII: A (6001) < C (6003), so A first, then C or B
+        # A is processed first, then B's in_degree becomes 0
+        # Queue has [C (6003), B (6002)] - sorted: B < C
+        # So order is A, B, C
+        assert result[0].acid == "6001"  # A
+        assert result[1].acid == "6002"  # B
+        assert result[2].acid == "6003"  # C
+
+
+class TestCoverageFills:
+    """Extra targeted tests to exercise untested branches."""
+
+    def test_tokenize_ordered_skips_stopwords_and_empty(self):
+        """tokenize_ordered drops stopwords and empty-after-strip tokens."""
+        from fx_alfred.core.compose import tokenize_ordered
+
+        # "the" and "is" are stopwords; "!!!" strips to empty
+        result = tokenize_ordered("the implement !!! is fxa-2117")
+        assert "the" not in result
+        assert "is" not in result
+        assert "" not in result
+        assert "implement" in result
+        assert "fxa-2117" in result
+
+    def test_tokenize_ordered_dedupes_preserving_first_occurrence(self):
+        """Duplicate tokens are kept once, at their first position."""
+        from fx_alfred.core.compose import tokenize_ordered
+
+        result = tokenize_ordered("code change code change feature")
+        assert result == ["code", "change", "feature"]
+
+    def test_resolve_explicit_id_not_found_raises_clickexception(self):
+        """Unknown positional SOP ID in --task mode → ClickException 'SOP X not found'."""
+        import click
+
+        from fx_alfred.core.compose import resolve_sops_from_task
+        from fx_alfred.core.document import Document
+
+        doc = Document(
+            prefix="TST",
+            acid="1103",
+            type_code="SOP",
+            title="Always",
+            source="pkg",
+            directory="rules/TST-1103-SOP-Always.md",
+        )
+        all_sops = [(doc, frozenset(), True)]
+
+        with pytest.raises(click.ClickException) as exc_info:
+            resolve_sops_from_task("implement", all_sops, ["BAD-9999"])
+
+        assert "BAD-9999" in str(exc_info.value)
+        assert "not found" in str(exc_info.value).lower()

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -1264,3 +1264,241 @@ def test_malformed_loops_graph_mode(sample_project, monkeypatch):
     # Should still have mermaid block for the good SOP
     assert "```mermaid" in result.output
     assert "flowchart TD" in result.output
+
+
+# ── af plan --task auto-composition tests (FXA-2205 PR4) ────────────────────
+
+
+def _create_sop_with_task_tags(
+    rules_dir: Path,
+    prefix: str,
+    acid: str,
+    title: str,
+    task_tags: str,
+    always_included: bool = False,
+    workflow_input: str = "",
+    workflow_output: str = "",
+) -> Path:
+    """Helper to create an SOP with Task tags metadata.
+
+    Note: Uses non-COR prefix by default to avoid PKG-layer collision.
+    """
+    filename = f"{prefix}-{acid}-SOP-{title}.md"
+    always_line = "**Always included:** true\n" if always_included else ""
+    input_line = f"**Workflow input:** {workflow_input}\n" if workflow_input else ""
+    output_line = f"**Workflow output:** {workflow_output}\n" if workflow_output else ""
+    sop_content = f"""# {prefix}-{acid}: {title.replace("-", " ")}
+
+**Applies to:** Test
+**Status:** Active
+{always_line}{input_line}{output_line}**Task tags:** {task_tags}
+---
+## What Is It?
+A test SOP with task tags.
+## Steps
+1. First step for {acid}
+2. Second step for {acid}
+"""
+    filepath = rules_dir / filename
+    filepath.write_text(sop_content)
+    return filepath
+
+
+def test_task_flag_includes_tagged_sop(sample_project, monkeypatch):
+    """--task 'implement FXA-2117 PRP' includes TST-1500 (has 'implement' tag)."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(
+        rules_dir,
+        "TST",
+        "1500",
+        "TDD",
+        "[implement, feature, tdd, code, code-change, fix]",
+    )
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1103", "Routing", "[]", always_included=True
+    )
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "--task", "implement FXA-2117 PRP"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    # Should include TST-1500 (matched by 'implement' tag)
+    assert "TST-1500" in result.output
+    # Should include TST-1103 (always included)
+    assert "TST-1103" in result.output
+
+
+def test_task_no_match_raises_exit_2(sample_project, monkeypatch):
+    """--task 'rare unmatched xyzzy' → exit 2 with diagnostic message."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1103", "Routing", "[]", always_included=True
+    )
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "--task", "rare unmatched xyzzy"], catch_exceptions=False
+    )
+    # Exit code 2 for empty tag match
+    assert result.exit_code == 2
+    # Should have diagnostic message
+    assert "matched 0 tagged SOPs" in result.output or "Try:" in result.output
+
+
+def test_task_json_todo_graph_combo(sample_project, monkeypatch):
+    """--task ... --todo --graph --json → JSON has composed_from, todo, graph_mermaid."""
+    import json
+
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1500", "TDD", "[implement, feature, tdd]"
+    )
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1103", "Routing", "[]", always_included=True
+    )
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["plan", "--task", "implement feature", "--todo", "--graph", "--json"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    data = json.loads(result.output)
+    # Should have composed_from key
+    assert "composed_from" in data
+    assert "always" in data["composed_from"]
+    assert "auto" in data["composed_from"]
+    # Should have todo array
+    assert "todo" in data
+    # Should have graph_mermaid
+    assert "graph_mermaid" in data
+    # Schema version should be "2" or higher
+    assert data["schema_version"] in ("2", "3")
+
+
+def test_task_with_positional_union(sample_project, monkeypatch):
+    """--task ... TST-XXX → positional + tag matches, no duplicates."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1500", "TDD", "[implement, feature, tdd]"
+    )
+    _create_sop_with_task_tags(rules_dir, "TST", "7001", "Other", "[other, misc]")
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1103", "Routing", "[]", always_included=True
+    )
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "--task", "implement feature", "TST-7001"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    # Should include TST-7001 (positional)
+    assert "TST-7001" in result.output
+    # Should include TST-1500 (tag matched)
+    assert "TST-1500" in result.output
+    # Should include TST-1103 (always included)
+    assert "TST-1103" in result.output
+
+
+def test_default_plan_no_task_byte_identical(sample_project, monkeypatch):
+    """Default af plan COR-XXX (no --task) → byte-identical to pre-PR4 output."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(rules_dir, "TST", "7001", "First-SOP", "[test]")
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+
+    # Default output (no --task)
+    result = runner.invoke(cli, ["plan", "TST-7001"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    # Should have phased output headers and RULES
+    assert "## Phase" in result.output
+    assert "## RULES" in result.output
+    # Should NOT have Composed from header
+    assert "Composed from:" not in result.output
+
+
+def test_task_without_value_click_error(sample_project, monkeypatch):
+    """--task without value → Click error (non-zero exit)."""
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    # --task requires a value
+    result = runner.invoke(cli, ["plan", "--task"], catch_exceptions=False)
+    assert result.exit_code != 0
+
+
+def test_task_bigram_matches_hyphenated_tag(sample_project, monkeypatch):
+    """Bigram 'code change' matches 'code-change' tag."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1500", "TDD", "[code-change, implement]"
+    )
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "--task", "code change feature"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    # Should match via bigram "code-change"
+    assert "TST-1500" in result.output
+
+
+def test_task_header_shows_provenance(sample_project, monkeypatch):
+    """--task output header shows (always) / (auto) / (explicit) markers."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(rules_dir, "TST", "1500", "TDD", "[implement]")
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1103", "Routing", "[]", always_included=True
+    )
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "--task", "implement feature"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    # Should have Composed from header with markers
+    assert "Composed from:" in result.output
+    assert "(always)" in result.output
+    assert "(auto)" in result.output
+
+
+def test_task_json_composed_from_structure(sample_project, monkeypatch):
+    """--task --json composed_from has always/auto lists."""
+    import json
+
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(rules_dir, "TST", "1500", "TDD", "[implement]")
+    _create_sop_with_task_tags(
+        rules_dir, "TST", "1103", "Routing", "[]", always_included=True
+    )
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "--task", "implement", "--json"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+
+    data = json.loads(result.output)
+    assert "composed_from" in data
+    cf = data["composed_from"]
+    assert "always" in cf
+    assert "auto" in cf
+    assert "explicit" in cf
+    assert isinstance(cf["always"], list)
+    assert isinstance(cf["auto"], list)
+    assert isinstance(cf["explicit"], list)
+    # TST-1103 should be in always
+    assert "TST-1103" in cf["always"]
+    # TST-1500 should be in auto
+    assert "TST-1500" in cf["auto"]


### PR DESCRIPTION
## Summary

**Final of 4 rollout PRs** for approved PRP **FXA-2205**. Given a task description, Alfred auto-selects the correct set of SOPs via deterministic tag matching + always-included SOPs + Kahn's topological sort with typed workflow edges. Completes the FXA-2205 rollout.

Depends on PR #43 (PR 1, merged), PR #44 (PR 2, merged), and PR #45 (PR 3, OPEN — base will auto-update to main when #45 merges).

## What shipped

**New `core/compose.py`** (372 lines):
- `STOPWORDS` — verbatim from PRP §C1 Step 1.
- `tokenize()` — lowercase → strip `string.punctuation` → drop stopwords → drop empty. Returns `frozenset[str]`.
- `bigrams()` — adjacent token pairs joined with `-` (so `code change` also probes `code-change`).
- `compose_order()` — Kahn's topological sort with deterministic tiebreak (layer PKG→USR→PRJ, then SOP-ID ASCII). Fail-closed only on true cycles.
- `resolve_sops_from_task()` — full C1 algorithm:
  - Validates explicit positional IDs (raises `ClickException("SOP 'X' not found")` if missing).
  - Unions positional + tag-matched + always-included.
  - Parses each candidate's `Workflow input`/`Workflow output` to build edge map.
  - Returns topologically-ordered list.
  - Empty tag match → `ClickException`, exit 2.

**Schema**: registered `Task tags` as optional SOP metadata in `core/schema.py` + `core/normalize.py`.

**CLI** (`commands/plan_cmd.py`):
- `--task "<description>"` flag.
- Combines with all existing flags (`--todo`, `--graph`, `--json`).
- `Composed from: COR-XXX(always) → ... → COR-YYY(auto) → ... → COR-ZZZ(explicit)` header printed in all non-JSON modes (including `--human`).
- `--task` never fires implicitly; today's "Usage" error preserved when no SOP IDs and no `--task`.

**JSON**:
- `composed_from: {"always": [...], "auto": [...], "explicit": [...]}` (keys match PRP §Design Details verbatim).
- All existing keys preserved.

**Backfills** (PR 4 manifest):
| SOP | Task tags |
|-----|-----------|
| COR-1500 | `[implement, feature, tdd, code, code-change, fix]` |
| COR-1602 | `[review, code-review, plan-review, multi-model, prp-review, implement]` |
| COR-1608 | `[review, prp-review, prp, scoring]` |
| COR-1609 | `[review, chg-review, scoring]` |
| COR-1610 | `[review, code-review, scoring, implement]` |
| COR-1611 | `[review, calibration]` |
| FXA-2148 | `[evolve, sop, refactor-sop, improve-sop]` |

## Success Criterion demo

```
$ af plan --root . --task "implement FXA-2117 PRP" --todo --graph
# Composed from: COR-1103(always) → COR-1402(always) → COR-1500(auto) → COR-1602(auto) → COR-1608(auto) → COR-1610(auto)
...
```

✅ Covers routing + declare + TDD + review loop + scoring — exactly what PRP §Success Criteria required, with no manual SOP-ID enumeration.

## Review trail (COR-1602 + COR-1610, all real CLI)

Round 1 found 5+3 blockers; Round 2 fixed all + re-reviewed:

| Round | Gemini | Codex |
|---|---|---|
| R1 | 8.8 FIX (3 blockers) | 8.2 FIX (5 blockers, fresh session after prior session poisoned) |
| R2 | **9.4 PASS** ✅ | **9.4 PASS** ✅ (resumed fresh session, explicit live repros for all 7 blockers) |

**7 consolidated R1 blockers, all RESOLVED in commit `60c8921`:**

| # | Issue | Resolution |
|---|---|---|
| B1 | `resolve_sops_from_task` didn't pass `workflow_edges` to `compose_order` — Kahn's was dead code | Edges now built from `parse_workflow_signature`; live proof: `TST-7009/TST-7002` with typed edge `out=draft → in=draft` yields topological order, not ASCII |
| B2 | JSON key `positional` vs PRP spec `explicit` | Renamed public key + header marker |
| B3 | `Composed from:` header dropped in `--human` mode | `if not human` guard removed |
| B4 | Invalid positional SOP IDs silently dropped in `--task` mode | `click.ClickException("SOP 'X' not found")` raised before union |
| B5 | `test_compose.py` had 3 literal `pass` placeholders | Rewritten: 31 real assertion tests, 99% coverage |
| B6 | Success Criterion demo missed review loop + scoring | Backfilled tags on COR-1602/1608/1609/1610/1611 |
| B7 | `.gitignore` + `test_update_cmd.py` reformat drifted into PR 4 commit | Commit unwound + re-committed as `60c8921` with only PR 4 files |

## NOT-DO adherence (both reviewers verified)

- `core/workflow.py` unchanged. `core/mermaid.py` unchanged.
- `check_composition()` behavior unchanged.
- No new dependencies (still `click` + `pyyaml`).
- Default `af plan COR-XXX` byte-identical.
- No routing-doc fallback.

## Deferred (non-blocking advisories)

- Broad `except Exception` in edge parsing (compose.py:337-349) — intentional resilience for SOPs without workflow metadata; document in follow-up if it masks real bugs.
- Pre-existing `(no Steps section found)` for SOPs that don't use `## Steps` heading (COR-1103, COR-1500, COR-1608, COR-1610) — independent plan_cmd limitation, not a PR 4 regression.
- Kahn's queue re-sorts each pop; fine for <50 SOPs; `heapq` is a future micro-opt.

## Test plan

- [x] `.venv/bin/pytest -v` → **619 passed**
- [x] Coverage on `core/compose.py` → **99%** (2 defensive `continue` branches uncovered)
- [x] `.venv/bin/ruff check .` → clean
- [x] `af validate --root .` → **218 docs, 0 issues**
- [x] All 4 live-repro demos from reviewers: header in human / invalid-ID / empty-match / Success Criterion / typed edges override ASCII — all confirmed

## Protocol note

Round 1 Codex dispatch's resumed session was poisoned by the earlier PR 2 review context and produced no verdict; Round 1 retry used a FRESH Codex session (019d9e35-...) which produced a clean 8.2 FIX. Round 2 resumed that fresh session successfully. Gemini's Round 2 worker attestation is less strict than Codex's (no verbatim Gemini output quoted), but all live reproductions are verifiable in-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)