### PR TITLE
release: v1.6.2 — test-only (evolve-CLI coverage)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.6.1"
+version = "1.6.2"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## v1.6.2 (2026-04-19)
+
+Test-only release: two automated evolve-CLI runs (FXA-2149) closed 7 coverage gaps by adding 5 narrow tests. Zero runtime behaviour changes, zero new dependencies, zero public CLI surface changes. Users should see no observable difference.
+
+### Tests
+
+- **FXA-2211 (PR #52)**: three tests pin edge behaviour at `list --json` empty-result `[]` contract (`list_cmd.py:66`), `atomic_write` double-failure invariant (`_helpers.py:86–87`), and `af validate` malformed Change-History early-return arms (`validate_cmd.py:60, 70`).
+- **FXA-2215 (PR #55)**: two tests pin edge behaviour at `af plan --todo` raw-section-text fallback (`plan_cmd.py:276`) and `parse_metadata` "heading-but-no-table" early return (`parser.py:194`).
+
+Both runs went through PRP → dual-reviewer scoring (Codex + Gemini on COR-1602 strict) → TDD Red (source mutation) → code review → PR. PRP FXA-2210 needed three rounds (R1 misquote, R2 pass, R3 self-caught Gap 2 scope error). PRP FXA-2214 needed two rounds (R1 caught a broken `str(area)` fix, R2 dropped C4 cleanly). Full review trail in the linked run logs.
+
+### Deferred
+
+- **FXA-2212 (PR #53)**: REF-only seed for a future opt-in `af plan --graph-layout=dag` ASCII DAG renderer. Evaluator discarded at 6.05 on first cold pass (SR=5, Nec=3). Per REF policy: stays as REF, try again next run, promote to PRP on second discard.
+
+### Stats
+
+- 0 runtime changes
+- 660 → 665 tests (+5)
+- 0 new dependencies
+- Coverage: 90 → 83 missed lines (-7)
+- 0 breaking changes
+
+### Install / Upgrade
+
+```bash
+pip install fx-alfred==1.6.2       # install specific version
+pipx install fx-alfred              # first install
+pipx upgrade fx-alfred              # upgrade existing
+```
+
 ## v1.6.1 (2026-04-18)
 
 Patch release: v1.6.0's publish-to-PyPI GitHub Actions workflow failed at the `pyright src/` step with 16 type errors. The errors were static-only — all 660 tests passed — but blocked PyPI publish, so v1.6.0 exists as a GitHub tag only. v1.6.1 ships the identical feature set with the type annotations corrected.


### PR DESCRIPTION
## Summary

Test-only patch release: two automated evolve-CLI runs (FXA-2149) closed 7 coverage gaps via 5 new narrow tests. Zero runtime changes, zero new deps, zero public CLI surface changes.

## What's in v1.6.2

Already merged since v1.6.1:
- **PR #52 (FXA-2211)** — 3 tests pinning edge behaviour at `list --json` empty-result, `atomic_write` double-failure invariant, `af validate` malformed Change-History arms
- **PR #53 (FXA-2212)** — REF-only evolve seed for a future opt-in `af plan --graph-layout=dag` renderer
- **PR #55 (FXA-2215)** — 2 tests pinning `af plan --todo` raw-section fallback, `parse_metadata` "heading-but-no-table" early return

## Prereqs (FXA-2102)

- [x] `pytest`: 665/665 pass
- [x] `ruff check`: clean
- [x] `ruff format --check`: 66 files clean
- [x] `pyright src/`: 0 errors / 0 warnings / 0 informations
- [x] README up-to-date (per FXA-2136 "When NOT to Use": patch releases with no user-facing changes do not require README update)
- [x] Version bumped in `pyproject.toml`: 1.6.1 → 1.6.2
- [x] CHANGELOG.md v1.6.2 entry added

## Stats

| | v1.6.1 | v1.6.2 | Δ |
|---|---:|---:|---:|
| Tests | 660 | 665 | +5 |
| Missed coverage lines | 90 | 83 | −7 |
| Runtime code changes | — | — | 0 |
| Breaking changes | — | — | 0 |

## Post-merge plan

Per FXA-2102 SOP:
1. `gh release create v1.6.2 --title "v1.6.2" --notes ...`
2. GitHub Actions builds + publishes to PyPI via Trusted Publisher
3. `pipx upgrade fx-alfred && af --version` to verify

## Test plan

- [x] Tests pass locally (665/665)
- [x] Ruff / format / pyright all clean
- [x] `af --version` reports 1.6.2
- [ ] CI green on PR
- [ ] Post-merge: `gh release create` + CI auto-publish succeeds
- [ ] PyPI shows 1.6.2 within ~5 min of release

🤖 Generated with [Claude Code](https://claude.com/claude-code)