### PR TITLE
docs: mark FXA-2211 + FXA-2215 Completed (shipped in v1.6.2)

### DIFF
--- a/rules/FXA-2211-CHG-Close-three-edge-arm-coverage-gaps-with-tests.md
+++ b/rules/FXA-2211-CHG-Close-three-edge-arm-coverage-gaps-with-tests.md
@@ -3,7 +3,7 @@
 **Applies to:** FXA project
 **Last updated:** 2026-04-19
 **Last reviewed:** 2026-04-19
-**Status:** Proposed
+**Status:** Completed
 **Date:** 2026-04-19
 **Requested by:** Frank (FXA-2149 automated evolve-CLI run FXA-2209)
 **Priority:** Medium
@@ -103,3 +103,4 @@ PRP FXA-2210, CHG FXA-2211, run log FXA-2209.
 |------|--------|----|
 | 2026-04-19 | Initial version | — |
 | 2026-04-19 | Fill What / Why / Impact / Plan from approved PRP FXA-2210 (R3: Codex 9.9 / Gemini 10.0) | Frank + Claude |
+| 2026-04-19 | Shipped in v1.6.2 (PR #52 → PyPI 2026-04-19) | Frank + Claude |

--- a/rules/FXA-2215-CHG-Bundle-N2-N3-plan-cmd-parser-edge-tests.md
+++ b/rules/FXA-2215-CHG-Bundle-N2-N3-plan-cmd-parser-edge-tests.md
@@ -3,7 +3,7 @@
 **Applies to:** FXA project
 **Last updated:** 2026-04-19
 **Last reviewed:** 2026-04-19
-**Status:** Proposed
+**Status:** Completed
 **Date:** 2026-04-19
 **Requested by:** Frank (FXA-2149 automated evolve-CLI run FXA-2213)
 **Priority:** Medium
@@ -103,5 +103,6 @@ PRP FXA-2214, CHG FXA-2215, run log FXA-2213.
 
 | Date       | Change                                                                       | By             |
 |------------|------------------------------------------------------------------------------|----------------|
-| 2026-04-19 | Initial version                                                              | —              |
+| 2026-04-19 | Initial version | — |
 | 2026-04-19 | Fill What / Why / Impact / Plan from approved PRP FXA-2214 (R2 9.8/9.9 PASS) | Frank + Claude |
+| 2026-04-19 | Shipped in v1.6.2 (PR #55 → PyPI 2026-04-19) | Frank + Claude |


### PR DESCRIPTION
## Summary

Per FXA-2102 Step 6: mark both CHGs as Completed now that v1.6.2 is live on PyPI.

- **FXA-2211** (Status: Proposed → Completed) — shipped in PR #52 → v1.6.2
- **FXA-2215** (Status: Proposed → Completed) — shipped in PR #55 → v1.6.2

Change History rows added on each doc citing the PR + PyPI publish date.

## Verification

- PyPI: https://pypi.org/project/fx-alfred/1.6.2/ — live
- Release tag: https://github.com/frankyxhl/alfred/releases/tag/v1.6.2

## Test plan

- [x] `af validate` still passes (only metadata + Change History row changed)
- [x] No code / test / CI impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)