### PR TITLE
release: v1.7.0 — ASCII DAG graph layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ baseline (e.g., COR-1103 routing), and topologically orders the result via
 terminal-friendly) and a fenced Mermaid block (pasteable into GitHub / Obsidian).
 Use `--graph-format={ascii,mermaid,both}` to pick one.
 
+**`--graph-layout={nested,flat}`** (v1.7.0+, ASCII-only) chooses the DAG shape.
+The default **`nested`** layout draws each SOP as an outer phase-box containing
+inner step-boxes with `▼` connectors. Intra-SOP loops render as a `🔁 → N.M max K`
+annotation line inside the phase box. Cross-SOP loops — declared via
+`Workflow loops: [{from: N, to: "PREFIX-ACID.step", ...}]` metadata — render as a
+right-side vertical track (`◄───┐ ... ───┘ max N`) that spans phase boundaries.
+**`flat`** restores the v1.6.x layout (one phase-box per SOP, steps listed inside,
+intra-SOP loops only) for downstream tooling pinned on the legacy shape.
+
 See [COR-1202 (Compose Session Plan)](src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md)
 for the canonical usage procedure.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.6.2"
+version = "1.7.0"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## Unreleased
+## v1.7.0 (2026-04-19)
+
+Feature release: ASCII DAG nested graph layout becomes the new default for `af plan --graph`, with cross-SOP loop metadata expressible for the first time. Full design trail in PRP FXA-2217 and CHG FXA-2218; 720 tests passing including 46+ new ones covering the widening surface and every edge caught during PR #59 review (12 rounds of GitHub bot feedback, all fixed with regression tests).
 
 ### New
 


### PR DESCRIPTION
Feature release for FXA-2212 / FXA-2217 / FXA-2218 (shipped to main via PR #59).

## What's in v1.7.0

New default ASCII layout for `af plan --graph`:
- Step-boxes inside phase-boxes
- Intra-SOP loops as `🔁 → N.M max K` annotation lines
- Cross-SOP loops as right-side vertical tracks (`◄───┐ / ───┘ max N`)
- `--graph-layout=flat` preserves v1.6.x layout

New metadata surface: `Workflow loops.to` accepts `int` (intra-SOP, unchanged) or `"PREFIX-ACID.step"` (cross-SOP, new).

New `af validate` cross-SOP pass (D2 + D3): first cross-corpus check — rejects dangling SOP refs and out-of-range step indices.

New `af plan` runtime checks (D4): rejects cross-SOP loops whose target isn't composed or whose direction isn't a back-edge.

## Prereqs (FXA-2102)

- [x] `pytest`: 720/720 pass
- [x] `ruff check`: clean
- [x] `ruff format --check`: 69 files clean
- [x] `pyright src/`: 0 errors / 0 warnings / 0 informations
- [x] `af validate`: 233/233 valid
- [x] README updated with `--graph-layout` docs (per FXA-2136)
- [x] `pyproject.toml` bumped 1.6.2 → 1.7.0
- [x] `CHANGELOG.md` Unreleased section retitled to v1.7.0 (2026-04-19)

## Stats

| | v1.6.2 | v1.7.0 | Δ |
|---|---:|---:|---:|
| Tests | 665 | 720 | +55 |
| New modules | — | `core/dag_graph.py`, `core/steps.py` | +2 |
| Breaking changes | — | ASCII `af plan --graph` default shape differs; `--graph-layout=flat` restores legacy | 0 (with escape hatch) |

## Review trail (summary)

- PRP FXA-2217: R1 → R2 → R3 (Codex 9.3 / Gemini 10.0 PASS)
- CHG FXA-2218 code: R1 → R2 → R3 (Codex 9.4 / Gemini 9.55 PASS)
- PR #59: 12 rounds of GitHub @chatgpt-codex-connector bot feedback, every one a real edge-case bug, every one with a regression test. All closed.

## Post-merge

1. `gh release create v1.7.0` with CHANGELOG-derived release notes
2. GitHub Actions publishes to PyPI via Trusted Publisher
3. `pipx upgrade fx-alfred && af --version` (should print 1.7.0)
4. Mark CHG FXA-2218 Status = Completed

## Test plan

- [x] Tests, ruff, format, pyright, af validate all green
- [x] `af --version` reports 1.7.0
- [x] `af plan --help` shows `--graph-layout`
- [ ] CI green on release PR
- [ ] Post-merge: release + publish + PyPI verify succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)