### PR TITLE
docs: mark FXA-2218 Completed (shipped in v1.7.0)

### DIFF
--- a/rules/FXA-2218-CHG-ASCII-DAG-nested-graph-layout-implementation.md
+++ b/rules/FXA-2218-CHG-ASCII-DAG-nested-graph-layout-implementation.md
@@ -3,7 +3,7 @@
 **Applies to:** FXA project
 **Last updated:** 2026-04-19
 **Last reviewed:** 2026-04-19
-**Status:** Proposed
+**Status:** Completed
 **Date:** 2026-04-19
 **Requested by:** Frank (manually-driven PRP after FXA-2213 Evolve-CLI cold-discarded FXA-2212 at 6.05)
 **Priority:** Medium
@@ -176,5 +176,6 @@ referencing #58, monitor CI + automated reviewers up to 3 iterations.
 
 | Date       | Change                                                 | By             |
 |------------|--------------------------------------------------------|----------------|
-| 2026-04-19 | Initial version                                        | —              |
+| 2026-04-19 | Initial version | — |
 | 2026-04-19 | Fill from approved PRP FXA-2217 (R3 9.30 / 10.0 PASS) | Frank + Claude |
+| 2026-04-19 | Shipped in v1.7.0 (PR #59 → PR #60 release → PyPI 2026-04-19) | Frank + Claude |


### PR DESCRIPTION
Per FXA-2102 Step 6: bump CHG FXA-2218 Status from Proposed to Completed now that v1.7.0 is live on PyPI.

## Verification

- PyPI: https://pypi.org/project/fx-alfred/1.7.0/ — live
- Release tag: https://github.com/frankyxhl/alfred/releases/tag/v1.7.0
- Feature PR: #59 (merged)
- Release PR: #60 (merged)

## Test plan

- [x] Only metadata + Change History row changed
- [x] No code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)