### PR TITLE
chore: bump version to 1.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.7.0"
+version = "1.7.1"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## v1.7.1 (2026-04-26)
+
+Patch release: housekeeping migration to resolve a duplicate-ACID block and consolidate the PRJ document namespace. No CLI behavior changes.
+
+### Changed
+
+- **PKG `COR-0002` (Document Format Contract)** — added Section Rule 4 clarifying that author-project ID attributions in `## Change History` rows (e.g. `per FXA-2223`) are PRJ-layer provenance from the document's authoring project and are not bundled in the package. Informational, not a broken reference. (FXA-2219 CHG)
+- **PKG `COR-*` Change-History attribution rewrites** — 29 historical attribution rows that previously cited `ALF-2210` / `ALF-2208` / `ALF-2206` (renamed PRJ docs in the `fx-alfred` repo) now cite `FXA-2223` / `FXA-2221` / `FXA-2220`. Same opacity to downstream users as before — these were always PRJ-only references — but consistent with the migration. (FXA-2219 CHG)
+
+### Internal (not in PyPI but part of the same release branch)
+
+- Migrated 6 ALF-prefixed PRJ docs in `fx_alfred/rules/` to the `FXA` prefix (PR #63). Resolves a duplicate-ACID error between USR `~/.alfred/ALF-2206` and PRJ `ALF-2206` that was blocking `af guide` / `af plan` / `af read`. PRJ now uses `FXA` exclusively; USR retains the `ALF` namespace.
+- Multi-model review (COR-1602): Codex 9.2 PASS, Gemini 9.9 PASS.
+
 ## v1.7.0 (2026-04-19)
 
 Feature release: ASCII DAG nested graph layout becomes the new default for `af plan --graph`, with cross-SOP loop metadata expressible for the first time. Full design trail in PRP FXA-2217 and CHG FXA-2218; 720 tests passing including 46+ new ones covering the widening surface and every edge caught during PR #59 review (12 rounds of GitHub bot feedback, all fixed with regression tests).


### PR DESCRIPTION
## Summary

Patch release shipping the FXA-2219 housekeeping migration to PyPI.

- `pyproject.toml`: 1.7.0 → 1.7.1
- `CHANGELOG.md`: 1.7.1 entry added

No CLI behavior changes. PKG content updates only:
- `COR-0002` — added Section Rule 4 clarifying author-project ID attribution in Change History (PRJ-layer provenance, not bundled)
- `COR-*` — 29 historical Change-History attribution rows rewritten from `ALF-2210` / `ALF-2208` / `ALF-2206` to `FXA-2223` / `FXA-2221` / `FXA-2220` (consistent with the rename in #63)

## Test plan

- [x] `pytest`: 720 passed
- [x] `af validate --root .`: 238 documents, 0 issues
- [ ] GitHub Actions PyPI publish on tag (post-merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)