### PR TITLE
feat(FXA-2226): implement Data Layer (Phases 1, 2, 3)

### DIFF
--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -25,7 +25,9 @@ from fx_alfred.core.schema import TASK_TAGS
 from fx_alfred.core.workflow import (
     LoopSignature,
     WorkflowSignature,
+    _BRANCHES_RENDERER_READY,
     check_composition,
+    parse_workflow_branches,
     parse_workflow_loops,
     parse_workflow_signature,
     validate_workflow_signature,
@@ -124,10 +126,12 @@ def _parse_numbered_items(section_text: str) -> list[str]:
     items: list[str] = []
     for line in section_text.split("\n"):
         stripped = line.strip()
-        # Match "### 1. text" or "1. text"
-        m = re.match(r"^(?:###\s+)?(\d+)\.\s+(.+)", stripped)
+        # Match "### 1. text", "1. text", "3a. text" (FXA-2226 Path B sub-step)
+        m = re.match(r"^(?:###\s+)?(\d+)([a-z])?\.\s+(.+)", stripped)
         if m:
-            items.append(f"{m.group(1)}. {m.group(2)}")
+            number = m.group(1)
+            sub_branch = m.group(2) or ""
+            items.append(f"{number}{sub_branch}. {m.group(3)}")
     return items
 
 
@@ -582,6 +586,21 @@ def plan_cmd(
             parsed = parse_metadata(content)
             sig = parse_workflow_signature(parsed)
             loops = parse_workflow_loops(parsed)
+            # FXA-2226 Path B: enforce renderer-readiness gate at plan time too
+            # (per Gemini PR #68 review F2). Until CHG-2227 Phase 8a flips
+            # `_BRANCHES_RENDERER_READY` to True, any SOP authoring
+            # `Workflow branches:` is rejected here so `af plan` never emits
+            # sub-stepped surface (`"1.3a"` indices, ASCII collisions, etc.)
+            # before the renderer ships.
+            if not _BRANCHES_RENDERER_READY:
+                branches = parse_workflow_branches(parsed)
+                if branches:
+                    raise click.ClickException(
+                        f"{doc.prefix}-{doc.acid}: Workflow branches: schema "
+                        "is parsed but renderer support is not yet shipped "
+                        "(CHG-2227 pending). Production SOPs MUST NOT author "
+                        "this field until CHG-2227 lands."
+                    )
         except MalformedDocumentError as e:
             if not output_json:
                 click.echo(

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -27,7 +27,7 @@ from fx_alfred.core.workflow import (
     WorkflowSignature,
     _BRANCHES_RENDERER_READY,
     check_composition,
-    parse_workflow_branches,
+    has_workflow_branches_field,
     parse_workflow_loops,
     parse_workflow_signature,
     validate_workflow_signature,
@@ -592,15 +592,17 @@ def plan_cmd(
             # `Workflow branches:` is rejected here so `af plan` never emits
             # sub-stepped surface (`"1.3a"` indices, ASCII collisions, etc.)
             # before the renderer ships.
-            if not _BRANCHES_RENDERER_READY:
-                branches = parse_workflow_branches(parsed)
-                if branches:
-                    raise click.ClickException(
-                        f"{doc.prefix}-{doc.acid}: Workflow branches: schema "
-                        "is parsed but renderer support is not yet shipped "
-                        "(CHG-2227 pending). Production SOPs MUST NOT author "
-                        "this field until CHG-2227 lands."
-                    )
+            # Per Codex PR #68 R2 review: gate on FIELD PRESENCE (including
+            # `Workflow branches: []` / `null`), not on parsed-list non-emptiness.
+            # The spec is "MUST NOT author this field" — authoring empty still
+            # authors the field.
+            if not _BRANCHES_RENDERER_READY and has_workflow_branches_field(parsed):
+                raise click.ClickException(
+                    f"{doc.prefix}-{doc.acid}: Workflow branches: schema "
+                    "is parsed but renderer support is not yet shipped "
+                    "(CHG-2227 pending). Production SOPs MUST NOT author "
+                    "this field until CHG-2227 lands."
+                )
         except MalformedDocumentError as e:
             if not output_json:
                 click.echo(

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -283,7 +283,9 @@ def _build_todo_items(
         step_idx = step["index"]
         text = step["text"]
         gate = step["gate"]
-        dotted = f"{phase_num}.{step_idx}"
+        # FXA-2226 Path B: append optional sub_branch suffix for sibling
+        # sub-steps so dotted index goes from "1.3" → "1.3a".
+        dotted = f"{phase_num}.{step_idx}{step.get('sub_branch', '')}"
 
         # Classify step (gate and loop markers are independent)
         is_gate, loop_to_sig, loop_from_sig = _classify_step(
@@ -349,7 +351,8 @@ def _build_todo_json(
         step_idx = step["index"]
         text = step["text"]
         gate = step["gate"]
-        dotted = f"{phase_num}.{step_idx}"
+        # FXA-2226 Path B: append optional sub_branch suffix.
+        dotted = f"{phase_num}.{step_idx}{step.get('sub_branch', '')}"
 
         # Classify step (gate and loop markers are independent)
         is_gate, loop_to_sig, loop_from_sig = _classify_step(

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -603,12 +603,16 @@ def plan_cmd(
             if not _BRANCHES_RENDERER_READY:
                 _gate_trip = has_workflow_branches_field(parsed)
                 if not _gate_trip:
+                    # Per Codex PR #68 R4 inline review: use a flush-left,
+                    # fence-aware scan (mirrors validate_branches discipline).
+                    # `_parse_steps_for_json` strips indentation and skips
+                    # fence tracking, so it would falsely trip the gate on
+                    # indented or fenced `3a.` lines.
+                    from fx_alfred.core.steps import has_top_level_substep_lines
+
                     _steps_section = _extract_steps_section(parsed.body)
                     if _steps_section is not None:
-                        _gate_trip = any(
-                            "sub_branch" in s
-                            for s in _parse_steps_for_json(_steps_section)
-                        )
+                        _gate_trip = has_top_level_substep_lines(_steps_section)
                 if _gate_trip:
                     raise click.ClickException(
                         f"{doc.prefix}-{doc.acid}: Workflow branches: schema "

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -594,15 +594,29 @@ def plan_cmd(
             # before the renderer ships.
             # Per Codex PR #68 R2 review: gate on FIELD PRESENCE (including
             # `Workflow branches: []` / `null`), not on parsed-list non-emptiness.
-            # The spec is "MUST NOT author this field" — authoring empty still
-            # authors the field.
-            if not _BRANCHES_RENDERER_READY and has_workflow_branches_field(parsed):
-                raise click.ClickException(
-                    f"{doc.prefix}-{doc.acid}: Workflow branches: schema "
-                    "is parsed but renderer support is not yet shipped "
-                    "(CHG-2227 pending). Production SOPs MUST NOT author "
-                    "this field until CHG-2227 lands."
-                )
+            # Per Codex PR #68 R3 review: also gate on undeclared sub-step lines
+            # (`3a./3b.` written directly in `## Steps` without the metadata
+            # field). The Phase 1 parser surfaces those into StepDict.sub_branch
+            # and Phase 3's `dotted` format emits `"1.3a"` — so even without
+            # the metadata field, an author can produce Path B surface.
+            # Detection: any parsed step has a `sub_branch` key set.
+            if not _BRANCHES_RENDERER_READY:
+                _gate_trip = has_workflow_branches_field(parsed)
+                if not _gate_trip:
+                    _steps_section = _extract_steps_section(parsed.body)
+                    if _steps_section is not None:
+                        _gate_trip = any(
+                            "sub_branch" in s
+                            for s in _parse_steps_for_json(_steps_section)
+                        )
+                if _gate_trip:
+                    raise click.ClickException(
+                        f"{doc.prefix}-{doc.acid}: Workflow branches: schema "
+                        "(or sub-step lines like `3a./3b.`) parsed but renderer "
+                        "support is not yet shipped (CHG-2227 pending). "
+                        "Production SOPs MUST NOT author this field or use "
+                        "sub-step syntax until CHG-2227 lands."
+                    )
         except MalformedDocumentError as e:
             if not output_json:
                 click.echo(

--- a/src/fx_alfred/commands/validate_cmd.py
+++ b/src/fx_alfred/commands/validate_cmd.py
@@ -28,8 +28,10 @@ from fx_alfred.core.steps import (
     parse_top_level_step_indices,
 )
 from fx_alfred.core.workflow import (
+    parse_workflow_branches,
     parse_workflow_loops,
     parse_workflow_signature,
+    validate_branches,
     validate_workflow_signature,
 )
 
@@ -278,6 +280,17 @@ def validate_cmd(ctx: click.Context, output_json: bool):
                 if sig is not None:
                     wf_errors = validate_workflow_signature(sig)
                     issues.extend(wf_errors)
+
+                # Check 8b: Workflow branches (FXA-2226 Path B). Parse + validate.
+                # Until CHG-2227 Phase 8a flips the renderer-readiness gate,
+                # any production SOP authoring this field is rejected.
+                try:
+                    branches = parse_workflow_branches(parsed)
+                except MalformedDocumentError as exc:
+                    issues.append(str(exc))
+                    branches = []
+                for berr in validate_branches(parsed, branches):
+                    issues.append(berr.msg)
 
                 # Check 8: Cross-SOP workflow loop references (FXA-2218 D2/D3)
                 # For each Workflow loops entry whose `to` is a cross-SOP ref,

--- a/src/fx_alfred/commands/validate_cmd.py
+++ b/src/fx_alfred/commands/validate_cmd.py
@@ -264,7 +264,13 @@ def validate_cmd(ctx: click.Context, output_json: bool):
                 next_heading = steps_section.find("\n## ")
                 if next_heading > 0:
                     steps_section = steps_section[:next_heading]
-                step_count = len(re.findall(r"^\d+\.", steps_section, re.MULTILINE))
+                # FXA-2226 Path B: count both plain steps (`3.`) and sub-steps
+                # (`3a.`) toward the > 5 → require ## Examples heuristic. The
+                # legacy regex `^\d+\.` undercounted branchy SOPs; per PR #68
+                # multi-model code review F4 (Codex 9.1, Gemini 9.6).
+                step_count = len(
+                    re.findall(r"^\d+[a-z]?\.", steps_section, re.MULTILINE)
+                )
 
                 if (has_prerequisites or step_count > 5) and not re.search(
                     r"^## Examples\s*$", body_text, re.MULTILINE

--- a/src/fx_alfred/core/phases.py
+++ b/src/fx_alfred/core/phases.py
@@ -11,18 +11,30 @@ if TYPE_CHECKING:
     from fx_alfred.core.workflow import LoopSignature
 
 
-class StepDict(TypedDict):
-    """A single step within a phase.
-
-    Attributes:
-        index: 1-based within-SOP step index.
-        text: Step text (already gate-markers-cleaned per PR 2).
-        gate: True if this step is a gate (⚠️).
-    """
+class _StepRequired(TypedDict):
+    """Required keys for StepDict — always present."""
 
     index: int
     text: str
     gate: bool
+
+
+class StepDict(_StepRequired, total=False):
+    """A single step within a phase.
+
+    Attributes:
+        index: 1-based within-SOP step index. For sub-stepped siblings
+            (e.g. `3a`, `3b`), all siblings share the parent integer (3).
+        text: Step text (already gate-markers-cleaned per PR 2).
+        gate: True if this step is a gate (⚠️).
+        sub_branch: Optional single letter (`"a"`, `"b"`, ...) for branch
+            siblings under FXA-2226 ``Workflow branches:`` schema. The key
+            is OMITTED for plain steps (Path B convention; never set to
+            ``None`` or any sentinel). Use ``step.get("sub_branch", "")`` for
+            deterministic format string concatenation.
+    """
+
+    sub_branch: str
 
 
 class LoopDict(TypedDict):

--- a/src/fx_alfred/core/schema.py
+++ b/src/fx_alfred/core/schema.py
@@ -55,6 +55,9 @@ WORKFLOW_PROVIDES = "Workflow provides"
 # FXA-2205: Loop metadata key — SOP-only, optional.
 WORKFLOW_LOOPS = "Workflow loops"
 
+# FXA-2226 Path B: Branch metadata key — SOP-only, optional.
+WORKFLOW_BRANCHES = "Workflow branches"
+
 # FXA-2205: Always-included flag — SOP-only, optional.
 ALWAYS_INCLUDED = "Always included"
 
@@ -70,7 +73,7 @@ _WORKFLOW_FIELDS = [
 
 OPTIONAL_METADATA: dict[DocType, list[str]] = {
     DocType.SOP: _WORKFLOW_FIELDS
-    + [WORKFLOW_LOOPS, ALWAYS_INCLUDED, TASK_TAGS, "Tags"],
+    + [WORKFLOW_LOOPS, WORKFLOW_BRANCHES, ALWAYS_INCLUDED, TASK_TAGS, "Tags"],
     **{dt: ["Tags"] for dt in DocType if dt != DocType.SOP},
 }
 

--- a/src/fx_alfred/core/steps.py
+++ b/src/fx_alfred/core/steps.py
@@ -126,3 +126,44 @@ def parse_top_level_step_indices(section_text: str) -> frozenset[int]:
         if m:
             indices.add(int(m.group(1)))
     return frozenset(indices)
+
+
+# Flush-left top-level sub-step matcher — same shape as `_TOP_LEVEL_STEP_RE`
+# but requires the trailing letter, so it matches ONLY sub-step lines like
+# `3a.` (not plain `3.`). Used by `has_top_level_substep_lines` for the
+# FXA-2226 Path B renderer-readiness gate.
+_TOP_LEVEL_SUBSTEP_RE = re.compile(r"^(?:###\s+)?(\d+)([a-z])\.\s+")
+
+
+def has_top_level_substep_lines(section_text: str) -> bool:
+    """Return True if the Steps section contains any flush-left top-level
+    sub-step line (e.g. ``3a.``) outside of fenced code blocks.
+
+    Used by the FXA-2226 Path B plan-time gate to detect undeclared sub-step
+    surface (sub-step lines authored directly in ``## Steps`` without the
+    ``Workflow branches:`` metadata field). Mirrors the flush-left + fence
+    tracking discipline of :func:`parse_top_level_step_indices` so the gate
+    cannot be falsely tripped by indented or fenced ``3a.`` lines (Codex
+    PR #68 R4 inline review).
+    """
+    fence_char: str | None = None
+    fence_len = 0
+    for line in section_text.split("\n"):
+        stripped = line.lstrip()
+        if fence_char is not None:
+            if stripped and stripped[0] == fence_char:
+                run = _fence_run_length(stripped, fence_char)
+                if run >= fence_len:
+                    fence_char = None
+                    fence_len = 0
+            continue
+        if stripped and stripped[0] in ("`", "~"):
+            ch = stripped[0]
+            run = _fence_run_length(stripped, ch)
+            if run >= 3:
+                fence_char = ch
+                fence_len = run
+                continue
+        if _TOP_LEVEL_SUBSTEP_RE.match(line):
+            return True
+    return False

--- a/src/fx_alfred/core/steps.py
+++ b/src/fx_alfred/core/steps.py
@@ -36,18 +36,27 @@ def extract_steps_section(body: str) -> str | None:
 def _parse_steps_for_json(section_text: str) -> list[StepDict]:
     """Extract steps as structured data for JSON output.
 
-    Returns list of {"index": int, "text": str, "gate": bool}.
-    Gate is true if step ends with "✓" or contains "[GATE]".
+    Returns list of StepDict shapes. Plain steps have keys
+    ``{"index", "text", "gate"}``; sub-stepped siblings (FXA-2226 Path B)
+    additionally carry ``"sub_branch"`` set to the suffix letter (``"a"``,
+    ``"b"``, ...). Gate is true if step ends with "✓" or contains "[GATE]".
+
+    Path B convention: plain steps OMIT the ``sub_branch`` key entirely;
+    it is never set to ``None`` or any sentinel.
     """
     steps: list[StepDict] = []
     for line in section_text.split("\n"):
         stripped = line.strip()
-        m = re.match(r"^(?:###\s+)?(\d+)\.\s+(.+)", stripped)
+        m = re.match(r"^(?:###\s+)?(\d+)([a-z])?\.\s+(.+)", stripped)
         if m:
             index = int(m.group(1))
-            text = m.group(2)
+            sub_branch = m.group(2)  # None for plain; "a"/"b"/... for sub-steps
+            text = m.group(3)
             gate = text.endswith("✓") or "[GATE]" in text
-            steps.append({"index": index, "text": text, "gate": gate})
+            step: StepDict = {"index": index, "text": text, "gate": gate}
+            if sub_branch is not None:
+                step["sub_branch"] = sub_branch
+            steps.append(step)
     return steps
 
 
@@ -56,7 +65,11 @@ def _parse_steps_for_json(section_text: str) -> list[StepDict]:
 # lines inside indented code fences are **not** counted, keeping this
 # consistent with `workflow._parse_step_indices`. Shared via this module so
 # validate_cmd can use the same definition of "top-level step" (PR #59 P1).
-_TOP_LEVEL_STEP_RE = re.compile(r"^(?:###\s+)?(\d+)\.\s+")
+# FXA-2226 Path B: regex extended to also match sub-step lines like ``3a.`` so
+# ``parse_top_level_step_indices`` injects the parent integer (3) from each
+# sibling. The optional ``[a-z]?`` is OUTSIDE the int-capturing group, so the
+# captured group always yields a pure integer for ``int()`` casting.
+_TOP_LEVEL_STEP_RE = re.compile(r"^(?:###\s+)?(\d+)[a-z]?\.\s+")
 
 
 def _fence_run_length(stripped: str, ch: str) -> int:

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -266,6 +266,23 @@ class BranchSignature:
     to: tuple[BranchTarget, ...]
 
 
+@dataclass(frozen=True)
+class BranchError:
+    """Validation error for a Workflow branches: entry (or a file-level issue)."""
+
+    msg: str
+    branch_idx: int | None = None
+
+
+# CHG-2226 Path B intermediate-state guardrail. The parser+schema land in
+# this CHG (Phase 1) but the renderer support arrives in CHG-2227. Until
+# CHG-2227 Phase 8a flips this flag to ``True`` as a separately-reviewable
+# commit, ``af validate`` rejects any SOP authoring ``Workflow branches:``
+# so production SOPs cannot land branchy declarations that misrender in
+# nested/flat/Mermaid output.
+_BRANCHES_RENDERER_READY = False
+
+
 def parse_workflow_branches(parsed: ParsedDocument) -> list[BranchSignature]:
     """Parse the optional ``Workflow branches:`` metadata into BranchSignatures.
 
@@ -349,6 +366,229 @@ def parse_workflow_branches(parsed: ParsedDocument) -> list[BranchSignature]:
             BranchSignature(from_step=int(from_step_raw), to=tuple(targets))
         )
     return branches
+
+
+def validate_branches(
+    parsed: ParsedDocument,
+    branches: list[BranchSignature],
+    *,
+    _gate_open_for_test: bool = False,
+) -> list[BranchError]:
+    """Validate ``Workflow branches:`` declarations against the SOP body.
+
+    Returns a list of :class:`BranchError`.  Empty list means valid.
+
+    Validation rules:
+
+    1. **Renderer-readiness gate** — if ``_BRANCHES_RENDERER_READY`` is False
+       (the default in CHG-2226 until CHG-2227 Phase 8a flips it), the
+       presence of *any* branch declaration is a hard error directing
+       authors to wait for CHG-2227. ``_gate_open_for_test`` bypasses this
+       gate for tests that need to exercise the structural rules below.
+    2. **`from` exists** — must reference an existing integer step in
+       ``## Steps``.
+    3. **`to.parent == from + 1`** — every sibling's parent integer must
+       equal ``from + 1`` (the convention is that branches fork from step
+       N to siblings ``(N+1)a``, ``(N+1)b``, ...).
+    4. **Sub-step exists** — every ``to.id`` (e.g. ``3a``) must appear in
+       ``## Steps`` as an actual sub-step line.
+    5. **Siblings contiguous** — sibling lines must appear consecutively in
+       ``## Steps`` (no integer step interleaved between them).
+    6. **No orphan sub-steps** — every sub-step letter present in ``## Steps``
+       must appear in some ``branches.to`` declaration.
+    """
+    errors: list[BranchError] = []
+
+    # Rule 1: gate
+    if branches and not (_BRANCHES_RENDERER_READY or _gate_open_for_test):
+        errors.append(
+            BranchError(
+                msg=(
+                    "Workflow branches: schema is parsed but renderer support is "
+                    "not yet shipped (CHG-2227 pending). Production SOPs MUST NOT "
+                    "author this field until CHG-2227 lands."
+                ),
+            )
+        )
+        # Continue running structural checks too — useful for early authors.
+
+    # Pull the actual ## Steps lines (in document order) for sub-step
+    # presence and contiguity checks.
+    from fx_alfred.core.parser import extract_section as _extract_section
+
+    section = _extract_section(parsed.body, "Steps") if parsed.body else None
+    step_indices = _parse_step_indices(parsed) or frozenset()
+    sub_steps_in_order: list[tuple[int, str]] = []  # [(parent, branch), ...]
+    plain_step_positions: dict[int, int] = {}  # int_index -> first occurrence
+    if section is not None:
+        position = 0  # logical position counting ALL parsed step lines
+        fence_char: str | None = None
+        fence_len = 0
+        for raw in section.split("\n"):
+            stripped = raw.lstrip()
+            # Skip fenced code blocks (mirrors parse_top_level_step_indices).
+            if fence_char is not None:
+                if stripped and stripped[0] == fence_char:
+                    run = 0
+                    while run < len(stripped) and stripped[run] == fence_char:
+                        run += 1
+                    if run >= fence_len:
+                        fence_char = None
+                        fence_len = 0
+                continue
+            if stripped and stripped[0] in ("`", "~"):
+                ch = stripped[0]
+                run = 0
+                while run < len(stripped) and stripped[run] == ch:
+                    run += 1
+                if run >= 3:
+                    fence_char = ch
+                    fence_len = run
+                    continue
+            # Match either "3." (plain) or "3a." (sub-step).
+            m = re.match(r"^(?:###\s+)?(\d+)([a-z])?\.\s+", raw)
+            if not m:
+                continue
+            parent = int(m.group(1))
+            sub = m.group(2)
+            if sub is None:
+                if parent not in plain_step_positions:
+                    plain_step_positions[parent] = position
+            else:
+                sub_steps_in_order.append((parent, sub))
+            position += 1
+
+    # Build a lookup set of (parent, branch) pairs that exist in ## Steps.
+    sub_steps_set = set(sub_steps_in_order)
+    # Build a lookup set of (parent, branch) pairs DECLARED across all branches.
+    declared: set[tuple[int, str]] = set()
+    for sig in branches:
+        for tgt in sig.to:
+            declared.add((tgt.parent, tgt.branch))
+
+    for i, sig in enumerate(branches):
+        # Rule 2: from references existing integer step
+        if sig.from_step not in step_indices:
+            errors.append(
+                BranchError(
+                    msg=(
+                        f"Workflow branches[{i}]: from = {sig.from_step} does "
+                        f"not reference an existing step in ## Steps"
+                    ),
+                    branch_idx=i,
+                )
+            )
+        for j, tgt in enumerate(sig.to):
+            # Rule 3: parent must equal from + 1
+            if tgt.parent != sig.from_step + 1:
+                errors.append(
+                    BranchError(
+                        msg=(
+                            f"Workflow branches[{i}].to[{j}]: id "
+                            f"{tgt.parent}{tgt.branch!r} parent must be "
+                            f"{sig.from_step + 1} (from + 1), got {tgt.parent}"
+                        ),
+                        branch_idx=i,
+                    )
+                )
+            # Rule 4: sub-step exists
+            if (tgt.parent, tgt.branch) not in sub_steps_set:
+                errors.append(
+                    BranchError(
+                        msg=(
+                            f"Workflow branches[{i}].to[{j}]: id "
+                            f"{tgt.parent}{tgt.branch} does not reference "
+                            f"an existing sub-step in ## Steps"
+                        ),
+                        branch_idx=i,
+                    )
+                )
+
+        # Rule 5: siblings contiguous in ## Steps. Find positions of declared
+        # siblings; assert they are consecutive (allowing only sub-step lines
+        # between them).
+        sibling_positions = [
+            idx
+            for idx, (parent, branch) in enumerate(sub_steps_in_order)
+            if (parent, branch) in {(t.parent, t.branch) for t in sig.to}
+        ]
+        if sibling_positions:
+            expected_parent = sig.from_step + 1
+            interleaved_plain = False
+            # Build a unified ordered list of (kind, parent, branch_or_None)
+            # and verify no plain integer step appears between the first and
+            # last declared sibling.
+            unified: list[tuple[str, int, str | None]] = []
+            if section is not None:
+                fence_char = None
+                fence_len = 0
+                for raw in section.split("\n"):
+                    stripped = raw.lstrip()
+                    if fence_char is not None:
+                        if stripped and stripped[0] == fence_char:
+                            run = 0
+                            while run < len(stripped) and stripped[run] == fence_char:
+                                run += 1
+                            if run >= fence_len:
+                                fence_char = None
+                                fence_len = 0
+                        continue
+                    if stripped and stripped[0] in ("`", "~"):
+                        ch = stripped[0]
+                        run = 0
+                        while run < len(stripped) and stripped[run] == ch:
+                            run += 1
+                        if run >= 3:
+                            fence_char = ch
+                            fence_len = run
+                            continue
+                    m = re.match(r"^(?:###\s+)?(\d+)([a-z])?\.\s+", raw)
+                    if not m:
+                        continue
+                    p = int(m.group(1))
+                    s = m.group(2)
+                    unified.append(("sub" if s else "plain", p, s))
+            sibling_set = {(t.parent, t.branch) for t in sig.to}
+            sib_unified_positions = [
+                u_idx
+                for u_idx, (kind, p, s) in enumerate(unified)
+                if kind == "sub" and (p, s) in sibling_set
+            ]
+            if sib_unified_positions and len(sib_unified_positions) >= 2:
+                lo = min(sib_unified_positions)
+                hi = max(sib_unified_positions)
+                for u_idx in range(lo + 1, hi):
+                    kind, p, s = unified[u_idx]
+                    if kind == "plain":
+                        interleaved_plain = True
+                        break
+            if interleaved_plain:
+                errors.append(
+                    BranchError(
+                        msg=(
+                            f"Workflow branches[{i}]: siblings must be "
+                            f"contiguous in ## Steps (parent {expected_parent}); "
+                            f"found a plain integer step interleaved between "
+                            f"sub-step siblings"
+                        ),
+                        branch_idx=i,
+                    )
+                )
+
+    # Rule 6: no orphan sub-steps (sub-steps in ## Steps not declared).
+    for parent, branch in sub_steps_in_order:
+        if (parent, branch) not in declared:
+            errors.append(
+                BranchError(
+                    msg=(
+                        f"sub-step {parent}{branch} appears in ## Steps but "
+                        f"is an orphan — not declared in any "
+                        f"Workflow branches.to entry"
+                    ),
+                )
+            )
+
+    return errors
 
 
 @dataclass(frozen=True)

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -728,25 +728,23 @@ def _parse_step_indices(parsed: ParsedDocument) -> frozenset[int] | None:
 
     Returns ``None`` if no ``Steps`` heading is present; otherwise a frozenset
     of the step indices parsed from top-level numbered Markdown lines (e.g.
-    ``1. First``) and ``### 1. First``-style headings.
+    ``1. First``, ``### 1. First``, or ``3a. Sub-step``).
 
-    The regex is applied to the *raw* line (not stripped), so indented
-    sub-items (e.g. ``    1. Sub-item``) and numbered lines inside fenced
-    code blocks are **not** counted as top-level steps — top-level Markdown
-    numbered items are flush-left by convention.
+    Delegates to :func:`fx_alfred.core.steps.parse_top_level_step_indices`,
+    which is fence-aware: numbered lines inside ```` ``` ```` / ``~~~``
+    fenced code blocks are skipped. Fence-awareness is critical for FXA-2226
+    Path B because the widened regex (``\\d+[a-z]?``) matches sub-step
+    lines too, and a fenced ``3a. example`` line would otherwise inject
+    parent step 3 into existence checks for `Workflow loops.from/to: 3`
+    (Codex PR #68 R3 inline review).
     """
     from fx_alfred.core.parser import extract_section
+    from fx_alfred.core.steps import parse_top_level_step_indices
 
     section = extract_section(parsed.body, "Steps")
     if section is None:
         return None
-
-    indices: set[int] = set()
-    for line in section.split("\n"):
-        m = _STEP_INDEX_RE.match(line)
-        if m:
-            indices.add(int(m.group(1)))
-    return frozenset(indices)
+    return parse_top_level_step_indices(section)
 
 
 def validate_loops(

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -417,7 +417,6 @@ def validate_branches(
     from fx_alfred.core.parser import extract_section as _extract_section
 
     section = _extract_section(parsed.body, "Steps") if parsed.body else None
-    step_indices = _parse_step_indices(parsed) or frozenset()
     sub_steps_in_order: list[tuple[int, str]] = []  # [(parent, branch), ...]
     plain_step_positions: dict[int, int] = {}  # int_index -> first occurrence
     if section is not None:
@@ -466,9 +465,18 @@ def validate_branches(
         for tgt in sig.to:
             declared.add((tgt.parent, tgt.branch))
 
+    # Plain-step ints only (excluding parent ints injected from sub-step
+    # lines) — used by Rule 2 below per PR #68 Codex F1 finding. The
+    # spec says `from` must reference an EXISTING INTEGER step in
+    # `## Steps`; sub-stepped-only parents (no bare `2.` line) should
+    # NOT satisfy `from: 2`.
+    plain_only_ints = frozenset(plain_step_positions.keys())
+
     for i, sig in enumerate(branches):
-        # Rule 2: from references existing integer step
-        if sig.from_step not in step_indices:
+        # Rule 2: from references existing INTEGER step (must be a bare
+        # plain step line — not satisfied solely by parent-int injection
+        # from sub-step siblings).
+        if sig.from_step not in plain_only_ints:
             errors.append(
                 BranchError(
                     msg=(

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from typing import NamedTuple
 
 import yaml
 
@@ -19,6 +20,7 @@ from fx_alfred.core.schema import (
     WORKFLOW_PROVIDES,
     WORKFLOW_REQUIRES,
     WORKFLOW_LOOPS,
+    WORKFLOW_BRANCHES,
 )
 
 # Token format per the CHG-2204 contract.
@@ -177,8 +179,11 @@ def check_composition(
 # FXA-2205: Loop metadata parsing and validation
 # ---------------------------------------------------------------------------
 
-# Regex to match numbered steps: "1. text" or "### 1. text"
-_STEP_INDEX_RE = re.compile(r"^(?:###\s+)?(\d+)\.\s+")
+# Regex to match numbered steps. FXA-2226 Path B: extended to also match
+# sub-step lines like ``3a.`` so ``_parse_step_indices`` injects the parent
+# integer (3) from each sibling. The optional ``[a-z]?`` is OUTSIDE the
+# int-capturing group, so ``int(m.group(1))`` always yields a clean int.
+_STEP_INDEX_RE = re.compile(r"^(?:###\s+)?(\d+)[a-z]?\.\s+")
 # Required keys in a loop declaration
 _LOOP_REQUIRED_KEYS = ("id", "from", "to", "max_iterations", "condition")
 # Cross-SOP loop reference — authored as "PREFIX-ACID.step" (FXA-2218 Commit 2).
@@ -218,6 +223,132 @@ class LoopSignature:
                 f"{self.to_step!r} does not match CROSS_SOP_REF"
             )
         return m.group("prefix"), m.group("acid"), int(m.group("step"))
+
+
+# ---------------------------------------------------------------------------
+# FXA-2226 Path B: Branch metadata parsing.
+#
+# `Workflow branches:` declares forward branches with edge labels. Schema:
+#
+#     Workflow branches:
+#       - from: 2
+#         to:
+#           - {id: 3a, label: pass}
+#           - {id: 3b, label: fail}
+#
+# Sub-step `id` values are split into ``parent`` (int — leading digits) and
+# ``branch`` (str — single trailing letter). Path B keeps types int-stable;
+# the branch suffix is exposed via a separate field.
+# ---------------------------------------------------------------------------
+
+# Sub-step ID format: one or more digits followed by a single letter.
+_BRANCH_TO_ID_RE = re.compile(r"^(?P<parent>\d+)(?P<branch>[a-z])$")
+
+
+class BranchTarget(NamedTuple):
+    """A single sibling of a forward branch.
+
+    ``parent`` is the integer step (e.g. ``3`` for ``3a``); ``branch`` is the
+    suffix letter (``"a"``); ``label`` is the edge label printed above the
+    branch arrow.
+    """
+
+    parent: int
+    branch: str
+    label: str
+
+
+@dataclass(frozen=True)
+class BranchSignature:
+    """Forward-branch declaration extracted from ``Workflow branches:`` metadata."""
+
+    from_step: int
+    to: tuple[BranchTarget, ...]
+
+
+def parse_workflow_branches(parsed: ParsedDocument) -> list[BranchSignature]:
+    """Parse the optional ``Workflow branches:`` metadata into BranchSignatures.
+
+    Returns ``[]`` when the field is absent or its value is empty.
+
+    Raises :class:`MalformedDocumentError` if the YAML is not a list, if any
+    entry is not a dict, if a required key is missing, or if any sub-step
+    ``id`` does not match ``\\d+[a-z]``.
+    """
+    field_map = {mf.key: mf.value for mf in parsed.metadata_fields}
+    raw = field_map.get(WORKFLOW_BRANCHES)
+    if raw is None or not raw.strip():
+        return []
+
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise MalformedDocumentError(
+            f"Workflow branches: invalid YAML — {exc}"
+        ) from exc
+
+    if data is None:
+        return []
+    if not isinstance(data, list):
+        raise MalformedDocumentError(
+            "Workflow branches: expected a YAML list of branch objects"
+        )
+
+    branches: list[BranchSignature] = []
+    for i, entry in enumerate(data):
+        if not isinstance(entry, dict):
+            raise MalformedDocumentError(
+                f"Workflow branches[{i}]: expected a YAML mapping, got {type(entry).__name__}"
+            )
+        if "from" not in entry or "to" not in entry:
+            raise MalformedDocumentError(
+                f"Workflow branches[{i}]: missing required key 'from' or 'to'"
+            )
+        from_step_raw = entry["from"]
+        if isinstance(from_step_raw, bool) or not isinstance(from_step_raw, int):
+            raise MalformedDocumentError(
+                f"Workflow branches[{i}]: 'from' must be an integer step index"
+            )
+        to_raw = entry["to"]
+        if not isinstance(to_raw, list) or not to_raw:
+            raise MalformedDocumentError(
+                f"Workflow branches[{i}]: 'to' must be a non-empty list of "
+                f"{{id, label}} entries"
+            )
+        targets: list[BranchTarget] = []
+        for j, target_raw in enumerate(to_raw):
+            if not isinstance(target_raw, dict):
+                raise MalformedDocumentError(
+                    f"Workflow branches[{i}].to[{j}]: expected a mapping"
+                )
+            target_id = target_raw.get("id")
+            if not isinstance(target_id, str):
+                raise MalformedDocumentError(
+                    f"Workflow branches[{i}].to[{j}]: 'id' must be a string "
+                    f"matching '\\d+[a-z]'"
+                )
+            m = _BRANCH_TO_ID_RE.match(target_id)
+            if m is None:
+                raise MalformedDocumentError(
+                    f"Workflow branches[{i}].to[{j}]: 'id' {target_id!r} "
+                    f"does not match '\\d+[a-z]'"
+                )
+            label = target_raw.get("label", "")
+            if not isinstance(label, str):
+                raise MalformedDocumentError(
+                    f"Workflow branches[{i}].to[{j}]: 'label' must be a string"
+                )
+            targets.append(
+                BranchTarget(
+                    parent=int(m.group("parent")),
+                    branch=m.group("branch"),
+                    label=label,
+                )
+            )
+        branches.append(
+            BranchSignature(from_step=int(from_step_raw), to=tuple(targets))
+        )
+    return branches
 
 
 @dataclass(frozen=True)

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -283,6 +283,17 @@ class BranchError:
 _BRANCHES_RENDERER_READY = False
 
 
+def has_workflow_branches_field(parsed: ParsedDocument) -> bool:
+    """Return True if the SOP authors the ``Workflow branches:`` field at all.
+
+    True even for empty values (``Workflow branches: []`` or ``null``). Used by
+    the renderer-readiness gate to enforce the spec rule "MUST NOT author this
+    field until CHG-2227 lands" — authoring an empty list still counts as
+    authoring the field (per Codex PR #68 R2 review).
+    """
+    return any(mf.key == WORKFLOW_BRANCHES for mf in parsed.metadata_fields)
+
+
 def parse_workflow_branches(parsed: ParsedDocument) -> list[BranchSignature]:
     """Parse the optional ``Workflow branches:`` metadata into BranchSignatures.
 
@@ -399,8 +410,12 @@ def validate_branches(
     """
     errors: list[BranchError] = []
 
-    # Rule 1: gate
-    if branches and not (_BRANCHES_RENDERER_READY or _gate_open_for_test):
+    # Rule 1: gate. Per Codex PR #68 R2 review, fire on FIELD PRESENCE
+    # (including `Workflow branches: []` / `null`), not on parsed-list
+    # non-emptiness. The spec is "MUST NOT author this field until
+    # CHG-2227 lands" — authoring an empty list still authors the field.
+    field_present = has_workflow_branches_field(parsed)
+    if field_present and not (_BRANCHES_RENDERER_READY or _gate_open_for_test):
         errors.append(
             BranchError(
                 msg=(

--- a/tests/test_phases.py
+++ b/tests/test_phases.py
@@ -1,0 +1,44 @@
+"""Tests for core/phases.py — including FXA-2226 StepDict refactor.
+
+StepDict moves from a single TypedDict(total=True) to the
+`_StepRequired + total=False` subclass pattern matching the
+existing `_PhaseRequired + PhaseDict(total=False)` precedent at
+`phases.py:47-75`. New optional `sub_branch: str` lives on the
+total=False subclass.
+"""
+
+from __future__ import annotations
+
+from fx_alfred.core.phases import StepDict
+
+
+def test_stepdict_required_keys_only() -> None:
+    """A plain StepDict with only required keys type-checks and is valid at runtime."""
+    s: StepDict = {"index": 1, "text": "First", "gate": False}
+    assert s["index"] == 1
+    assert s["text"] == "First"
+    assert s["gate"] is False
+    # sub_branch is OPTIONAL — must NOT be present on plain steps.
+    assert "sub_branch" not in s
+
+
+def test_stepdict_with_sub_branch() -> None:
+    """A sub-stepped StepDict carries the optional sub_branch field."""
+    s: StepDict = {
+        "index": 3,
+        "text": "Branch A",
+        "gate": False,
+        "sub_branch": "a",
+    }
+    assert s.get("sub_branch") == "a"
+
+
+def test_stepdict_get_returns_none_for_absent_sub_branch() -> None:
+    """Plain steps' sub_branch is genuinely absent (not None) — .get() returns None default."""
+    s: StepDict = {"index": 1, "text": "Plain", "gate": False}
+    # `.get("sub_branch")` returns None because the key is absent.
+    assert s.get("sub_branch") is None
+    # But the key itself must NOT be present (Path B convention).
+    assert "sub_branch" not in s
+    # `step.get("sub_branch", "")` returns "" for plain steps (used by plan_cmd format).
+    assert s.get("sub_branch", "") == ""

--- a/tests/test_plan_cmd_substeps.py
+++ b/tests/test_plan_cmd_substeps.py
@@ -179,6 +179,44 @@ A test SOP authoring an empty Workflow branches: list.
     assert "CHG-2227" in result.output
 
 
+def test_plan_gate_fires_on_undeclared_substep_lines(sample_project, monkeypatch):
+    """Per Codex PR #68 R3 inline review: gate must also fire when an author
+    writes `3a./3b.` lines directly in ## Steps WITHOUT the Workflow branches:
+    metadata field.
+
+    Pre-fix, the gate fired only on metadata field presence. An author could
+    bypass it by writing sub-step lines in the body — Phase 1's
+    `_parse_steps_for_json` would extract `sub_branch="a"` from `3a.`, and
+    Phase 3's `dotted` format would emit `"1.3a"` in `todo[].index`,
+    leaking Path B surface before the renderer ships.
+    """
+    rules_dir = sample_project / "rules"
+    filename = "TST-9004-SOP-UndeclaredSubsteps.md"
+    content = """# TST-9004: Undeclared Substeps
+
+**Applies to:** Test
+**Status:** Active
+---
+## What Is It?
+A test SOP with sub-step lines in body but no Workflow branches: metadata.
+## Steps
+1. Setup
+2. Decision
+3a. Bypass-attempt branch a
+3b. Bypass-attempt branch b
+4. After
+"""
+    (rules_dir / filename).write_text(content)
+    monkeypatch.chdir(sample_project)
+    # NO monkeypatch of the flag — exercise default-closed gate.
+    result = CliRunner().invoke(cli, ["plan", "TST-9004", "--todo", "--json"])
+    assert result.exit_code != 0, (
+        f"Expected af plan to reject undeclared sub-step lines; "
+        f"got exit 0:\n{result.output}"
+    )
+    assert "CHG-2227" in result.output
+
+
 def test_plan_human_branchy_renders_substeps(sample_project, monkeypatch):
     """Per PR #68 Gemini F3: `af plan --human` must NOT silently drop 3a/3b.
 

--- a/tests/test_plan_cmd_substeps.py
+++ b/tests/test_plan_cmd_substeps.py
@@ -64,10 +64,15 @@ A test SOP without branches.
 
 
 def test_todo_index_substep_format_in_json(sample_project, monkeypatch):
-    """Sub-stepped plan emits todo[].index = '<phase>.3a' for sub-steps."""
+    """Sub-stepped plan emits todo[].index = '<phase>.3a' for sub-steps.
+
+    Bypasses the renderer-readiness gate (Path B intermediate-state guardrail)
+    because this test verifies the format extension that ships in CHG-2227.
+    """
     rules_dir = sample_project / "rules"
     _create_sop_with_branches(rules_dir)
     monkeypatch.chdir(sample_project)
+    monkeypatch.setattr("fx_alfred.commands.plan_cmd._BRANCHES_RENDERER_READY", True)
     result = CliRunner().invoke(cli, ["plan", "TST-9001", "--todo", "--json"])
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
@@ -107,6 +112,7 @@ def test_phases_steps_index_int_unchanged(sample_project, monkeypatch):
     rules_dir = sample_project / "rules"
     _create_sop_with_branches(rules_dir)
     monkeypatch.chdir(sample_project)
+    monkeypatch.setattr("fx_alfred.commands.plan_cmd._BRANCHES_RENDERER_READY", True)
     result = CliRunner().invoke(cli, ["plan", "TST-9001", "--todo", "--json"])
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
@@ -119,11 +125,53 @@ def test_phases_steps_index_int_unchanged(sample_project, monkeypatch):
             )
 
 
+def test_plan_blocked_by_gate_when_branches_present(sample_project, monkeypatch):
+    """Per PR #68 Gemini F2: `af plan` must reject branchy SOPs while gate is closed.
+
+    Otherwise the renderer-readiness gate is `af validate`-only and `af plan`
+    silently emits sub-stepped surface (`"index": "1.3a"`, ASCII collisions)
+    before CHG-2227 ships. The test fixture's `_BRANCHES_RENDERER_READY` is
+    False at module level (Path B default), so this should fail with a
+    ClickException directing the author to wait for CHG-2227.
+    """
+    rules_dir = sample_project / "rules"
+    _create_sop_with_branches(rules_dir)
+    monkeypatch.chdir(sample_project)
+    # NO monkeypatch of the flag — exercise the default-closed gate.
+    result = CliRunner().invoke(cli, ["plan", "TST-9001", "--todo", "--json"])
+    assert result.exit_code != 0, (
+        "Expected af plan to reject Workflow branches: while gate closed; "
+        f"got exit 0 with output:\n{result.output}"
+    )
+    assert "CHG-2227" in result.output
+
+
+def test_plan_human_branchy_renders_substeps(sample_project, monkeypatch):
+    """Per PR #68 Gemini F3: `af plan --human` must NOT silently drop 3a/3b.
+
+    Pre-fix, `_parse_numbered_items` regex was `^(?:###\\s+)?(\\d+)\\.\\s+`
+    which only matched plain `3.` lines, dropping `3a/3b`. Test asserts the
+    human output for a branchy SOP includes both sub-step entries.
+    """
+    rules_dir = sample_project / "rules"
+    _create_sop_with_branches(rules_dir)
+    monkeypatch.chdir(sample_project)
+    monkeypatch.setattr("fx_alfred.commands.plan_cmd._BRANCHES_RENDERER_READY", True)
+    result = CliRunner().invoke(cli, ["plan", "TST-9001", "--human"])
+    assert result.exit_code == 0, result.output
+    # Sub-step lines must appear in the human checklist (preceded by "3a." / "3b.").
+    assert "3a." in result.output, (
+        f"--human output silently dropped sub-step 3a:\n{result.output}"
+    )
+    assert "3b." in result.output
+
+
 def test_phases_steps_sub_branch_emitted(sample_project, monkeypatch):
     """phases[].steps[].sub_branch is emitted ONLY for sub-stepped entries."""
     rules_dir = sample_project / "rules"
     _create_sop_with_branches(rules_dir)
     monkeypatch.chdir(sample_project)
+    monkeypatch.setattr("fx_alfred.commands.plan_cmd._BRANCHES_RENDERER_READY", True)
     result = CliRunner().invoke(cli, ["plan", "TST-9001", "--todo", "--json"])
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)

--- a/tests/test_plan_cmd_substeps.py
+++ b/tests/test_plan_cmd_substeps.py
@@ -1,0 +1,145 @@
+"""Tests for FXA-2226 Phase 3 — plan_cmd.py todo[].index format extension.
+
+Phase 3 extends the dotted ``todo[].index`` format from
+``"phase.step"`` (e.g. ``"1.1"``) to ``"phase.stepLetter"`` (e.g.
+``"2.3a"``) for sub-stepped plans. The change is at
+``plan_cmd.py:286`` and ``:352``: the format string adds
+``step.get('sub_branch', '')`` so plain steps emit unchanged and
+sub-steps emit with the suffix appended.
+
+Plain plans must remain byte-identical to v1.7.1 for the
+``todo[].index`` field (legacy compatibility).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from fx_alfred.cli import cli
+
+
+def _create_sop_with_branches(rules_dir: Path) -> Path:
+    """Create a SOP that uses Workflow branches: schema (sub-stepped)."""
+    filename = "TST-9001-SOP-Branchy.md"
+    content = """# TST-9001: Branchy
+
+**Applies to:** Test
+**Status:** Active
+**Workflow branches:** [{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}]}]
+---
+## What Is It?
+A test SOP exercising Workflow branches.
+## Steps
+1. Setup
+2. Decision
+3a. Pass branch
+3b. Fail branch
+4. Continue
+"""
+    filepath = rules_dir / filename
+    filepath.write_text(content)
+    return filepath
+
+
+def _create_sop_legacy(rules_dir: Path) -> Path:
+    filename = "TST-9002-SOP-Legacy.md"
+    content = """# TST-9002: Legacy
+
+**Applies to:** Test
+**Status:** Active
+---
+## What Is It?
+A test SOP without branches.
+## Steps
+1. Alpha
+2. Bravo
+3. Charlie
+"""
+    filepath = rules_dir / filename
+    filepath.write_text(content)
+    return filepath
+
+
+def test_todo_index_substep_format_in_json(sample_project, monkeypatch):
+    """Sub-stepped plan emits todo[].index = '<phase>.3a' for sub-steps."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_branches(rules_dir)
+    monkeypatch.chdir(sample_project)
+    result = CliRunner().invoke(cli, ["plan", "TST-9001", "--todo", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    todo = data.get("todo", [])
+    indices = [item.get("index") for item in todo]
+    # Plain steps share `phase.N` form; sub-steps share `phase.Na` form.
+    assert any(idx.endswith(".3a") for idx in indices), (
+        f"expected at least one '*.3a' index, got {indices}"
+    )
+    assert any(idx.endswith(".3b") for idx in indices)
+    # All indices remain strings (Path B contract).
+    assert all(isinstance(idx, str) for idx in indices)
+
+
+def test_todo_index_legacy_unchanged_in_json(sample_project, monkeypatch):
+    """All-integer SOP emits todo[].index identical to pre-CHG format."""
+    rules_dir = sample_project / "rules"
+    _create_sop_legacy(rules_dir)
+    monkeypatch.chdir(sample_project)
+    result = CliRunner().invoke(cli, ["plan", "TST-9002", "--todo", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    todo = data.get("todo", [])
+    indices = [item.get("index") for item in todo]
+    # Legacy SOPs: every index matches `^\d+\.\d+$` exactly (no suffix).
+    import re
+
+    legacy_pattern = re.compile(r"^\d+\.\d+$")
+    for idx in indices:
+        assert legacy_pattern.match(idx), (
+            f"legacy plan emitted non-legacy index {idx!r} — Path B byte-identity violated"
+        )
+
+
+def test_phases_steps_index_int_unchanged(sample_project, monkeypatch):
+    """phases[].steps[].index remains int (Path B contract)."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_branches(rules_dir)
+    monkeypatch.chdir(sample_project)
+    result = CliRunner().invoke(cli, ["plan", "TST-9001", "--todo", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    phases = data.get("phases", [])
+    assert phases
+    for ph in phases:
+        for step in ph.get("steps", []):
+            assert isinstance(step["index"], int), (
+                f"Path B violated: phases[].steps[].index must stay int, got {type(step['index']).__name__}"
+            )
+
+
+def test_phases_steps_sub_branch_emitted(sample_project, monkeypatch):
+    """phases[].steps[].sub_branch is emitted ONLY for sub-stepped entries."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_branches(rules_dir)
+    monkeypatch.chdir(sample_project)
+    result = CliRunner().invoke(cli, ["plan", "TST-9001", "--todo", "--json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    phases = data.get("phases", [])
+    assert phases
+    seen_sub_branches: list[str] = []
+    seen_plain_steps_with_no_sub_branch = 0
+    for ph in phases:
+        for step in ph.get("steps", []):
+            if "sub_branch" in step:
+                seen_sub_branches.append(step["sub_branch"])
+            else:
+                seen_plain_steps_with_no_sub_branch += 1
+    # Branchy SOP: should have at least 'a' and 'b' sub_branch entries.
+    assert sorted(seen_sub_branches) == ["a", "b"], (
+        f"expected sub_branches ['a','b'], got {seen_sub_branches}"
+    )
+    # Plain steps must NOT carry sub_branch key (Path B convention).
+    assert seen_plain_steps_with_no_sub_branch >= 1

--- a/tests/test_plan_cmd_substeps.py
+++ b/tests/test_plan_cmd_substeps.py
@@ -217,6 +217,74 @@ A test SOP with sub-step lines in body but no Workflow branches: metadata.
     assert "CHG-2227" in result.output
 
 
+def test_plan_gate_does_not_trip_on_indented_substep_line(sample_project, monkeypatch):
+    """Per Codex PR #68 R4 inline review: indented `3a.` lines (sub-items
+    nested under another step) MUST NOT trip the gate.
+
+    `has_top_level_substep_lines` scans flush-left only; sub-items at any
+    indent level are ignored. This SOP has no real sub-step surface, so
+    `af plan` should succeed despite the `3a.` text.
+    """
+    rules_dir = sample_project / "rules"
+    filename = "TST-9005-SOP-IndentedSubstep.md"
+    content = """# TST-9005: Indented Substep
+
+**Applies to:** Test
+**Status:** Active
+---
+## What Is It?
+A test SOP with `3a.` text appearing only as an indented sub-item.
+## Steps
+1. Setup
+2. Decision
+3. Discuss the format. Maybe label paths:
+    3a. like this (indented sub-item, not a top-level step)
+    3b. or this
+4. Continue
+"""
+    (rules_dir / filename).write_text(content)
+    monkeypatch.chdir(sample_project)
+    # Default-closed gate; should NOT fire because the only `3a./3b.` lines
+    # are indented (sub-items, not top-level).
+    result = CliRunner().invoke(cli, ["plan", "TST-9005", "--todo", "--json"])
+    assert result.exit_code == 0, (
+        f"Indented sub-item lines should NOT trip the gate; got exit "
+        f"{result.exit_code}:\n{result.output}"
+    )
+
+
+def test_plan_gate_does_not_trip_on_fenced_substep_line(sample_project, monkeypatch):
+    """Per Codex PR #68 R4 inline review: `3a.` lines inside fenced code
+    blocks MUST NOT trip the gate (they're examples, not authored steps).
+    """
+    rules_dir = sample_project / "rules"
+    filename = "TST-9006-SOP-FencedSubstep.md"
+    content = """# TST-9006: Fenced Substep
+
+**Applies to:** Test
+**Status:** Active
+---
+## What Is It?
+A test SOP demonstrating substep syntax inside a code fence (example only).
+## Steps
+1. Setup
+2. Decision
+3. Show what FXA-2226 substep syntax looks like:
+```
+3a. Pass branch
+3b. Fail branch
+```
+4. Continue
+"""
+    (rules_dir / filename).write_text(content)
+    monkeypatch.chdir(sample_project)
+    result = CliRunner().invoke(cli, ["plan", "TST-9006", "--todo", "--json"])
+    assert result.exit_code == 0, (
+        f"Fenced sub-step example should NOT trip the gate; got exit "
+        f"{result.exit_code}:\n{result.output}"
+    )
+
+
 def test_plan_human_branchy_renders_substeps(sample_project, monkeypatch):
     """Per PR #68 Gemini F3: `af plan --human` must NOT silently drop 3a/3b.
 

--- a/tests/test_plan_cmd_substeps.py
+++ b/tests/test_plan_cmd_substeps.py
@@ -146,6 +146,39 @@ def test_plan_blocked_by_gate_when_branches_present(sample_project, monkeypatch)
     assert "CHG-2227" in result.output
 
 
+def test_plan_gate_fires_on_empty_workflow_branches_field(sample_project, monkeypatch):
+    """Per Codex PR #68 R2 review: ``Workflow branches: []`` triggers the
+    plan-time gate too.
+
+    Pre-fix, the plan_cmd.py gate only fired when `parse_workflow_branches`
+    returned a non-empty list — an SOP authoring `Workflow branches: []`
+    would sneak past. Spec: MUST NOT author the field at all.
+    """
+    rules_dir = sample_project / "rules"
+    filename = "TST-9003-SOP-EmptyBranches.md"
+    content = """# TST-9003: Empty Branches
+
+**Applies to:** Test
+**Status:** Active
+**Workflow branches:** []
+---
+## What Is It?
+A test SOP authoring an empty Workflow branches: list.
+## Steps
+1. Setup
+2. Done
+"""
+    (rules_dir / filename).write_text(content)
+    monkeypatch.chdir(sample_project)
+    # NO monkeypatch of the flag — exercise default-closed gate.
+    result = CliRunner().invoke(cli, ["plan", "TST-9003", "--todo", "--json"])
+    assert result.exit_code != 0, (
+        f"Expected af plan to reject empty Workflow branches: field; "
+        f"got exit 0:\n{result.output}"
+    )
+    assert "CHG-2227" in result.output
+
+
 def test_plan_human_branchy_renders_substeps(sample_project, monkeypatch):
     """Per PR #68 Gemini F3: `af plan --human` must NOT silently drop 3a/3b.
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1,0 +1,81 @@
+"""Tests for core/steps.py — including FXA-2226 sub-step parsing (Path B).
+
+Sub-steps are authored as `3a.`, `3b.`, etc. and parse to StepDict
+with int `index` (the parent integer, e.g. 3) plus optional `sub_branch`
+key holding the suffix letter.
+
+Path B convention: plain steps OMIT the `sub_branch` key entirely
+(it is never set to None or any sentinel).
+"""
+
+from __future__ import annotations
+
+from fx_alfred.core.steps import (
+    _parse_steps_for_json,
+    parse_top_level_step_indices,
+)
+
+
+def test_extract_step_substep_format() -> None:
+    """`3a. Foo` parses to StepDict(index=3, sub_branch="a", text="Foo")."""
+    section = "1. First\n2. Second\n3a. Branch A\n3b. Branch B\n4. After\n"
+    steps = _parse_steps_for_json(section)
+    indices_branches = [(s["index"], s.get("sub_branch")) for s in steps]
+    assert indices_branches == [
+        (1, None),
+        (2, None),
+        (3, "a"),
+        (3, "b"),
+        (4, None),
+    ]
+    # Plain steps must OMIT sub_branch entirely (not None) — Path B convention.
+    plain = steps[0]
+    assert "sub_branch" not in plain
+    # Sub-stepped entries DO carry sub_branch.
+    assert "sub_branch" in steps[2]
+    assert steps[2]["sub_branch"] == "a"
+
+
+def test_legacy_int_steps_unchanged() -> None:
+    """Existing all-integer fixtures parse identically (no sub_branch keys)."""
+    section = "1. Alpha\n2. Bravo\n3. Charlie\n"
+    steps = _parse_steps_for_json(section)
+    for s in steps:
+        assert "sub_branch" not in s, f"plain step has unexpected sub_branch: {s}"
+    assert [s["index"] for s in steps] == [1, 2, 3]
+
+
+def test_substep_with_gate() -> None:
+    """`3a. Foo [GATE]` detects gate AND preserves sub_branch."""
+    section = "1. Plain\n3a. With gate [GATE]\n3b. Without\n"
+    steps = _parse_steps_for_json(section)
+    assert steps[0] == {"index": 1, "text": "Plain", "gate": False}
+    assert steps[1]["index"] == 3
+    assert steps[1]["sub_branch"] == "a"
+    assert steps[1]["gate"] is True
+    assert steps[2]["sub_branch"] == "b"
+    assert steps[2]["gate"] is False
+
+
+def test_parse_top_level_step_indices_with_bare_parent() -> None:
+    """SOP `1, 2, 3, 3a, 3b, 4` (with bare parent) → {1, 2, 3, 4}."""
+    section = "1. A\n2. B\n3. Decision\n3a. Branch a\n3b. Branch b\n4. Continue\n"
+    indices = parse_top_level_step_indices(section)
+    assert indices == frozenset({1, 2, 3, 4})
+
+
+def test_parse_top_level_step_indices_substeps_only() -> None:
+    """SOP `1, 2, 3a, 3b, 4` (no bare parent) ALSO → {1, 2, 3, 4}.
+
+    The parser injects parent integer 3 from each sub-step line.
+    """
+    section = "1. A\n2. B\n3a. Branch a\n3b. Branch b\n4. Continue\n"
+    indices = parse_top_level_step_indices(section)
+    assert indices == frozenset({1, 2, 3, 4})
+
+
+def test_parse_top_level_step_indices_legacy_unchanged() -> None:
+    """All-integer fixture returns plain frozenset[int] unchanged from v1.7.1."""
+    section = "1. A\n2. B\n3. C\n"
+    indices = parse_top_level_step_indices(section)
+    assert indices == frozenset({1, 2, 3})

--- a/tests/test_validate_cmd.py
+++ b/tests/test_validate_cmd.py
@@ -868,6 +868,49 @@ Do not use when not needed.
     assert "SOP missing required section: '## Examples'" in result.output
 
 
+def test_validate_sop_with_substeps_counted_for_examples_rule(tmp_path):
+    """Per PR #68 R2 review F4: sub-step lines (`3a.`, `3b.`) must count
+    toward the > 5 → require ## Examples heuristic.
+
+    Pre-fix, the regex `^\\d+\\.` undercounted branchy SOPs: a 3-plain +
+    3-substep SOP (6 step-equivalents) was counted as 3 and silently
+    bypassed the rule.
+    """
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    body = """## What Is It?
+
+A SOP with branches.
+
+## Why
+
+Branches need testing.
+
+## When to Use
+
+When deciding.
+
+## When NOT to Use
+
+Never.
+
+## Steps
+
+1. Setup
+2. Decision
+3a. Pass branch
+3b. Fail branch
+3c. Escalate branch
+4. After"""
+    _write_sop_with_body(rules_dir / "SOP-1000-SOP-Substep-Count.md", "1000", body)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", "--root", str(tmp_path)])
+    # 6 numbered lines (1, 2, 3a, 3b, 3c, 4) — exceeds threshold of 5.
+    # Should require ## Examples.
+    assert result.exit_code == 1
+    assert "SOP missing required section: '## Examples'" in result.output
+
+
 def test_validate_sop_few_steps_no_examples_no_issue(tmp_path):
     """SOP with 5 or fewer steps and no Examples should pass."""
     rules_dir = tmp_path / "rules"

--- a/tests/test_workflow_branches.py
+++ b/tests/test_workflow_branches.py
@@ -25,8 +25,6 @@ from __future__ import annotations
 
 import textwrap
 
-import pytest
-
 from fx_alfred.core.parser import parse_metadata
 from fx_alfred.core.workflow import (
     BranchSignature,

--- a/tests/test_workflow_branches.py
+++ b/tests/test_workflow_branches.py
@@ -1,0 +1,152 @@
+"""Tests for FXA-2226 Workflow branches: schema parser.
+
+Schema:
+
+    Workflow branches:
+      - from: 2
+        to:
+          - {id: 3a, label: pass}
+          - {id: 3b, label: fail}
+          - {id: 3c, label: escalate}
+
+Parsed to:
+
+    [BranchSignature(
+        from_step=2,
+        to=[
+            BranchTarget(parent=3, branch="a", label="pass"),
+            BranchTarget(parent=3, branch="b", label="fail"),
+            BranchTarget(parent=3, branch="c", label="escalate"),
+        ],
+    )]
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from fx_alfred.core.parser import parse_metadata
+from fx_alfred.core.workflow import (
+    BranchSignature,
+    BranchTarget,
+    parse_workflow_branches,
+    parse_workflow_loops,
+)
+
+
+def _doc(yaml_branches: str) -> str:
+    """Build a minimal SOP-shaped document with the given Workflow branches: value."""
+    return textwrap.dedent(
+        f"""\
+        # SOP-9999: Test
+
+        **Status:** Active
+        **Workflow branches:** {yaml_branches}
+
+        ---
+
+        ## Steps
+
+        1. Decision setup
+        2. Audit Ledger Gate
+        3a. Pass branch
+        3b. Fail branch
+        3c. Escalate branch
+        4. After
+
+        ## Change History
+
+        | Date | Change | By |
+        |------|--------|----|
+        | 2026-04-27 | Initial | Test |
+        """
+    )
+
+
+def test_parse_simple_3way() -> None:
+    """3-way branch parses to expected BranchSignature/BranchTarget shape."""
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}, {id: 3c, label: escalate}]}]"
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    assert branches == [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="pass"),
+                BranchTarget(parent=3, branch="b", label="fail"),
+                BranchTarget(parent=3, branch="c", label="escalate"),
+            ),
+        )
+    ]
+
+
+def test_parse_2way() -> None:
+    """2-way branch."""
+    body = _doc("[{from: 5, to: [{id: 6a, label: 'no'}, {id: 6b, label: 'yes'}]}]")
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    assert len(branches) == 1
+    sig = branches[0]
+    assert sig.from_step == 5
+    assert sig.to == (
+        BranchTarget(parent=6, branch="a", label="no"),
+        BranchTarget(parent=6, branch="b", label="yes"),
+    )
+
+
+def test_parse_branches_absent() -> None:
+    """SOP without `Workflow branches:` returns []."""
+    body = textwrap.dedent(
+        """\
+        # SOP-9999: Test
+
+        **Status:** Active
+
+        ---
+
+        ## Steps
+
+        1. First
+        2. Second
+        """
+    )
+    parsed = parse_metadata(body)
+    assert parse_workflow_branches(parsed) == []
+
+
+def test_branches_legacy_loops_unchanged() -> None:
+    """SOPs without `Workflow branches:` parse loops byte-identically."""
+    body = textwrap.dedent(
+        """\
+        # SOP-9999: Test
+
+        **Status:** Active
+        **Workflow loops:** [{id: retry, from: 3, to: 1, max_iterations: 3, condition: failed}]
+
+        ---
+
+        ## Steps
+
+        1. Setup
+        2. Validate
+        3. Decision
+
+        ## Change History
+
+        | Date | Change | By |
+        |------|--------|----|
+        | 2026-04-27 | Initial | Test |
+        """
+    )
+    parsed = parse_metadata(body)
+    loops = parse_workflow_loops(parsed)
+    assert len(loops) == 1
+    assert loops[0].id == "retry"
+    assert loops[0].from_step == 3
+    assert loops[0].to_step == 1
+    # Branches absent → empty.
+    assert parse_workflow_branches(parsed) == []

--- a/tests/test_workflow_branches_validate.py
+++ b/tests/test_workflow_branches_validate.py
@@ -170,6 +170,24 @@ def test_branches_valid_3way_passes_when_gate_open() -> None:
     assert errors == []
 
 
+def test_gate_fires_on_empty_field_authored() -> None:
+    """Per Codex PR #68 R2 review: ``Workflow branches: []`` (or ``null``)
+    must trigger the gate too.
+
+    Spec is "MUST NOT author this field until CHG-2227 lands" — authoring an
+    empty list still authors the field. Pre-fix, the gate only fired when
+    `parse_workflow_branches()` returned a non-empty list, so an SOP could
+    sneak past the gate by writing `Workflow branches: []`.
+    """
+    body = _doc("[]", "1. A\n2. B\n3. C\n")
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    assert branches == []  # parsed-empty
+    # Gate should still fire on field presence even though branches=[].
+    errors = validate_branches(parsed, branches)
+    assert any("renderer support is not yet shipped" in e.msg for e in errors)
+
+
 def test_branches_legacy_loops_unaffected() -> None:
     """SOPs without Workflow branches: produce no branch errors regardless of gate."""
     body = textwrap.dedent(

--- a/tests/test_workflow_branches_validate.py
+++ b/tests/test_workflow_branches_validate.py
@@ -1,0 +1,176 @@
+"""Tests for FXA-2226 Phase 2 — validate_branches + renderer-readiness gate.
+
+The gate (`_BRANCHES_RENDERER_READY = False`) blocks production SOPs from
+authoring `Workflow branches:` until CHG-2227 ships the renderer. CHG-2227
+Phase 8a flips the flag to `True` as a separately-reviewable commit.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from fx_alfred.core.parser import MalformedDocumentError, parse_metadata
+from fx_alfred.core.workflow import (
+    parse_workflow_branches,
+    validate_branches,
+    _BRANCHES_RENDERER_READY,
+)
+
+
+def _doc(yaml_branches: str, steps_section: str) -> str:
+    # Build without textwrap.dedent — interpolating multiline `steps_section`
+    # defeats common-prefix detection.
+    return (
+        "# SOP-9999: Test\n"
+        "\n"
+        "**Status:** Active\n"
+        f"**Workflow branches:** {yaml_branches}\n"
+        "\n"
+        "---\n"
+        "\n"
+        "## Steps\n"
+        "\n"
+        f"{steps_section}\n"
+        "## Change History\n"
+        "\n"
+        "| Date | Change | By |\n"
+        "|------|--------|----|\n"
+        "| 2026-04-27 | Initial | Test |\n"
+    )
+
+
+def test_renderer_readiness_gate_default_blocks() -> None:
+    """Default `_BRANCHES_RENDERER_READY = False` makes ANY Workflow branches:
+    SOP fail validation with a clear message instructing authors to wait for
+    CHG-2227.
+    """
+    assert _BRANCHES_RENDERER_READY is False, (
+        "CHG-2226 ships with the gate CLOSED; CHG-2227 Phase 8a flips it open"
+    )
+
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}]}]",
+        "1. Setup\n2. Decision\n3a. A path\n3b. B path\n4. After\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches)
+    assert len(errors) >= 1
+    assert any("renderer support is not yet shipped" in e.msg for e in errors)
+    assert any("CHG-2227" in e.msg for e in errors)
+
+
+def test_branches_from_must_exist() -> None:
+    """`from` referencing a nonexistent step rejected."""
+    body = _doc(
+        "[{from: 99, to: [{id: 100a, label: x}, {id: 100b, label: y}]}]",
+        "1. A\n2. B\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    assert any("from" in e.msg and "99" in e.msg for e in errors)
+
+
+def test_branches_to_must_exist() -> None:
+    """`to.id` referencing a non-existent sub-step rejected."""
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: pass}, {id: 3z, label: fail}]}]",
+        "1. A\n2. B\n3a. Has it\n4. After\n",  # no 3z
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    assert any("3z" in e.msg for e in errors)
+
+
+def test_branches_to_parent_must_match_from_plus_one() -> None:
+    """`from: 2` requires `to` siblings to use parent 3, not 4."""
+    body = _doc(
+        "[{from: 2, to: [{id: 4a, label: x}, {id: 4b, label: y}]}]",
+        "1. A\n2. B\n4a. wrong parent\n4b. wrong parent\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    assert any("from + 1" in e.msg or "must be 3" in e.msg for e in errors)
+
+
+def test_branches_substep_id_malformed_raises_at_parse() -> None:
+    """`3aa` rejected at PARSE time (regex \\d+[a-z], not \\d+[a-z]+)."""
+    body = _doc(
+        "[{from: 2, to: [{id: 3aa, label: x}, {id: 3b, label: y}]}]",
+        "1. A\n2. B\n",
+    )
+    parsed = parse_metadata(body)
+    with pytest.raises(MalformedDocumentError, match=r"3aa"):
+        parse_workflow_branches(parsed)
+
+
+def test_branches_orphan_substep_rejected() -> None:
+    """A sub-step in ## Steps not declared in any branches.to is an orphan."""
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: x}]}]",
+        "1. A\n2. B\n3a. Declared\n3b. ORPHAN — not in branches.to\n4. After\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    assert any("3b" in e.msg and "orphan" in e.msg.lower() for e in errors)
+
+
+def test_branches_siblings_must_be_contiguous() -> None:
+    """`3a, 4, 3b` (integer step interleaved between siblings) rejected."""
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: x}, {id: 3b, label: y}]}]",
+        "1. A\n2. B\n3a. First\n4. WRONG — interleaved\n3b. Second\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    assert any("contiguous" in e.msg.lower() for e in errors)
+
+
+def test_branches_valid_3way_passes_when_gate_open() -> None:
+    """Well-formed 3-way branches pass validation when gate is open."""
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}, {id: 3c, label: escalate}]}]",
+        "1. Setup\n2. Decision\n3a. Pass\n3b. Fail\n3c. Escalate\n4. Continue\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    assert errors == []
+
+
+def test_branches_legacy_loops_unaffected() -> None:
+    """SOPs without Workflow branches: produce no branch errors regardless of gate."""
+    body = textwrap.dedent(
+        """\
+        # SOP-9999: Test
+
+        **Status:** Active
+        **Workflow loops:** [{id: retry, from: 3, to: 1, max_iterations: 3, condition: failed}]
+
+        ---
+
+        ## Steps
+
+        1. A
+        2. B
+        3. C
+
+        ## Change History
+
+        | Date | Change | By |
+        |------|--------|----|
+        | 2026-04-27 | Initial | Test |
+        """
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    assert branches == []
+    errors = validate_branches(parsed, branches)
+    assert errors == []

--- a/tests/test_workflow_branches_validate.py
+++ b/tests/test_workflow_branches_validate.py
@@ -62,6 +62,31 @@ def test_renderer_readiness_gate_default_blocks() -> None:
     assert any("CHG-2227" in e.msg for e in errors)
 
 
+def test_branches_from_must_be_plain_int_not_substep_only() -> None:
+    """Per PR #68 Codex F1: `from: 2` requires a BARE `2.` line in ## Steps.
+
+    A SOP with `2a.`/`2b.` lines but no plain `2.` line should NOT satisfy
+    `from: 2` — even though `_parse_step_indices` injects parent integer 2
+    from the sub-step lines (Phase 1 design). Path B keeps step_indices
+    int-stable, but the `from` validator must only accept *plain* integer
+    parents.
+
+    Note: this fixture is somewhat artificial because in practice any
+    branchy SOP authored as `Workflow branches: from: 2` would have a
+    bare `2.` decision step. The defensive check guards against the
+    silent false-negative class.
+    """
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}]}]",
+        "1. Setup\n2a. ORPHAN-as-from\n2b. ORPHAN\n3a. Pass\n3b. Fail\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    # Should reject `from: 2` because there's no bare `2.` line — only `2a/2b`.
+    assert any("from = 2" in e.msg for e in errors)
+
+
 def test_branches_from_must_exist() -> None:
     """`from` referencing a nonexistent step rejected."""
     body = _doc(


### PR DESCRIPTION
## Summary

Implements CHG-2226 (Branching ASCII — Data Layer) per Path B (two-field architecture) across 3 phases. Behavior-neutral: no user-visible change ships in this PR. The renderer-readiness gate (\`_BRANCHES_RENDERER_READY = False\`) blocks production SOPs from authoring \`Workflow branches:\` until CHG-2227 Phase 8a flips the flag.

## Commits

| Phase | Commit | What landed |
|---|---|---|
| **1** | \`d2b8d15\` | Sub-step parser regex \`(\d+)([a-z])?\.\s+\` in \`core/steps.py\`. \`StepDict\` refactored to \`_StepRequired + total=False\` (matches \`phases.py:47-75\` precedent; no \`typing_extensions\` dep). New \`BranchSignature\`/\`BranchTarget\` + \`parse_workflow_branches\` in \`core/workflow.py\` with full YAML validation. \`WORKFLOW_BRANCHES\` schema constant registered. \`_parse_step_indices\` regex extended so sub-step lines contribute parent ints. |
| **2** | \`30b0b6f\` | New \`BranchError\` dataclass. \`_BRANCHES_RENDERER_READY = False\` flag. \`validate_branches()\` with 6 rules (gate, from-exists, parent==from+1, to-exists, contiguity, no orphans). Wired into \`commands/validate_cmd.py\`. |
| **3** | \`b706c65\` | \`plan_cmd.py:286, :352\` — \`dotted\` format extended from \`"{phase_num}.{step_idx}"\` to \`"{phase_num}.{step_idx}{step.get('sub_branch', '')}"\`. Plain steps emit byte-identical (\`"1.1"\`); sub-steps emit \`"1.3a"\`. \`phases[].steps[].index\` remains \`int\`. |

## Test plan

- [x] 720 → 746 tests (+26 new). Full suite green.
- [x] \`ruff check\` clean
- [x] \`ruff format --check\` clean
- [x] \`pyright src/\` 0 errors
- [x] Self-audit grep tabulation (per CHG-2226 Phase 1 REFACTOR mandate): 68 hits across \`src/fx_alfred/\`, all \`int-only-read-safe\` except 2 intentional sites in \`phases.py\`/\`steps.py\` — Path B's additivity verified empirically
- [ ] Multi-model code review (COR-1602 + COR-1610) to be dispatched after this PR opens

## Path B verification

Per CHG-2226 §"Why this architecture (path B)":

| Property | After | Verified |
|---|---|---|
| \`StepDict.index\` type | \`int\` (unchanged) | ✅ \`test_phases_steps_index_int_unchanged\` |
| \`step_indices\` return type | \`frozenset[int]\` (unchanged) | ✅ \`test_parse_top_level_step_indices_*\` |
| \`LoopSignature.from_step / to_step\` | \`int\` (unchanged) | ✅ \`test_branches_legacy_loops_unaffected\` |
| \`CROSS_SOP_REF\` regex | \`\d+\` (unchanged) | ✅ |
| \`phases[].steps[].index\` JSON type | \`int\` (unchanged) | ✅ \`test_phases_steps_index_int_unchanged\` |
| \`todo[].index\` legacy format | \`"phase.step"\` byte-identical | ✅ \`test_todo_index_legacy_unchanged_in_json\` |
| Renderer call sites at \`dag_graph.py\`, \`mermaid.py\`, \`ascii_graph.py\` | untouched | ✅ self-audit grep |
| New \`StepDict.sub_branch\` | optional via \`total=False\` | ✅ \`test_stepdict_*\` |

## After merge

CHG-2227 Phase 3+ branches off main; lands branch geometry primitive + nested/flat/Mermaid integration + v1.8.0 release. CHG-2227 Phase 8a flips the renderer-readiness flag from \`False\` to \`True\` as a separately-reviewable commit at the end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)