### PR TITLE
feat(FXA-2227): Phase 5 — ascii_graph.py flat branch integration

### DIFF
--- a/src/fx_alfred/core/ascii_graph.py
+++ b/src/fx_alfred/core/ascii_graph.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from fx_alfred.core.branch_layout import discover_branch_groups
+
 if TYPE_CHECKING:
     from fx_alfred.core.phases import PhaseDict, StepDict
+    from fx_alfred.core.workflow import BranchSignature
 
 # Minimum inner content width (fits in 50-wide box: '│ ' + 46 + ' │' = 50)
 INNER_MIN = 46
@@ -327,6 +330,134 @@ def _render_inline_loop(
         lines[from_line_idx] = marker
 
 
+def _build_phase_lines(
+    phase_idx: int,
+    phase: "PhaseDict",
+) -> tuple[list[str], list[int]]:
+    """Build inner content lines and step_indices for one phase.
+
+    Handles branch groups via ``discover_branch_groups``: branch parents emit
+    the primitive's geometry lines (no inner step-boxes); siblings and
+    convergence steps are skipped in the regular per-step iteration.
+
+    Returns:
+        lines: header line + per-step content lines (no box borders yet).
+        step_indices: parallel list of int step indices for loop-track machinery.
+            For branch groups, the parent index, sibling integer, and
+            convergence integer are appended in row order so loop annotations
+            attach to the right rows.
+    """
+    from fx_alfred.core.branch_geometry import BranchRenderInput, render_branch
+
+    sop_id = phase.get("sop_id", "UNKNOWN")
+    prov = phase.get("provenance")
+    steps = phase.get("steps", [])
+    branches_raw = phase.get("branches", [])
+
+    header = f"Phase {phase_idx}: {sop_id}"
+    if prov:
+        header += f" ({prov})"
+
+    lines: list[str] = [header]
+    step_indices: list[int] = [-1]  # placeholder for header; loop track skips -1
+
+    # Guard: only discover branch groups when branches are declared.
+    # Phases without `branches` skip this entirely, preserving pre-Phase-5 output.
+    skip_indices: set[int] = set()
+    branch_groups: dict[
+        int, tuple[list["StepDict"], "StepDict | None", "BranchSignature"]
+    ] = {}
+    if branches_raw:
+        for group in discover_branch_groups(steps, branches_raw):
+            sib_steps = [steps[i] for i in group.sibling_indices]
+            conv_step = (
+                steps[group.convergence_idx]
+                if group.convergence_idx is not None
+                else None
+            )
+            branch_groups[group.parent_idx] = (
+                sib_steps,
+                conv_step,
+                group.branch_signature,
+            )
+            skip_indices.update(group.sibling_indices)
+            if group.convergence_idx is not None:
+                skip_indices.add(group.convergence_idx)
+
+    for s_idx, step in enumerate(steps):
+        if s_idx in skip_indices:
+            continue
+
+        if s_idx in branch_groups:
+            sib_steps, conv_step, bsig = branch_groups[s_idx]
+            # Render the parent step's base text as a regular line first.
+            parent_text = _build_step_base_text(phase_idx, step)
+            lines.append(parent_text)
+            step_indices.append(step["index"])
+
+            n = len(bsig.to)
+            sibling_box_width = 12 if n <= 3 else 10
+
+            # Pair sibling body text by sub_branch letter, not positional zip.
+            sibling_text_by_letter = {
+                s.get("sub_branch", ""): s["text"] for s in sib_steps
+            }
+            sibling_texts = [sibling_text_by_letter[bt.branch] for bt in bsig.to]
+
+            primitive_input = BranchRenderInput(
+                parent_step_text=parent_text,
+                siblings=bsig.to,
+                sibling_texts=sibling_texts,
+                converges_to=(conv_step["index"] if conv_step else None),
+                converges_to_text=(conv_step["text"] if conv_step else None),
+                box_width=sibling_box_width,
+            )
+            primitive_out = render_branch(primitive_input)
+
+            # Sibling integer index: used by loop-track to find the sibling rows.
+            # Append it once, pointing at the first primitive line (parent bottom
+            # border row) — close enough for the loop track's row lookup.
+            sibling_int = sib_steps[0]["index"]
+
+            for prim_line in primitive_out.lines:
+                lines.append(prim_line)
+                step_indices.append(sibling_int)
+
+            # Convergence step: append its integer index at the convergence row
+            # (primitive_out.convergence_anchor_row points at the top border of
+            # the convergence box; the text body is one row later). Record the
+            # convergence integer at the convergence-box top-border row so the
+            # loop track can find it.
+            if (
+                conv_step is not None
+                and primitive_out.convergence_anchor_row is not None
+            ):
+                conv_int = conv_step["index"]
+                # Walk back from the end and re-stamp convergence rows with conv_int.
+                # The convergence block occupies the last 3 lines of primitive_out
+                # (top, middle, bottom borders) preceded by the join row and arrow.
+                # We identify the anchor row in the already-appended lines.
+                # lines[-1] is prim_out.lines[-1] (conv box bottom); work backward.
+                prim_len = len(primitive_out.lines)
+                # convergence_anchor_row in primitive is 0-based within primitive_out.lines.
+                # Map to lines[] offset: lines has header + parent + prim_len lines so far.
+                # First primitive line index in lines = len(lines) - prim_len.
+                prim_start_in_lines = len(lines) - prim_len
+                conv_line_in_lines = (
+                    prim_start_in_lines + primitive_out.convergence_anchor_row
+                )
+                # Overwrite step_indices entries from convergence_anchor_row onward
+                # with conv_int (top, middle, bottom of convergence box).
+                for ci in range(conv_line_in_lines, len(lines)):
+                    step_indices[ci] = conv_int
+        else:
+            base = _build_step_base_text(phase_idx, step)
+            lines.append(base)
+            step_indices.append(step["index"])
+
+    return lines, step_indices
+
+
 def render_ascii(phases: list[PhaseDict]) -> str:
     """Render phases as ASCII box-and-arrow diagram.
 
@@ -345,25 +476,9 @@ def render_ascii(phases: list[PhaseDict]) -> str:
     all_phase_data: list[tuple[list[str], list, list[int]]] = []
 
     for phase_idx, phase in enumerate(phases, 1):
-        sop_id = phase.get("sop_id", "UNKNOWN")
-        prov = phase.get("provenance")
-        steps = phase.get("steps", [])
         loops = phase.get("loops", [])
-
-        # Header line
-        header = f"Phase {phase_idx}: {sop_id}"
-        if prov:
-            header += f" ({prov})"
-
-        # Build step base texts WITHOUT loop annotations
-        step_lines: list[str] = []
-        step_indices: list[int] = []
-        for step in steps:
-            step_indices.append(step["index"])
-            base = _build_step_base_text(phase_idx, step)
-            step_lines.append(base)
-
-        all_phase_data.append(([header] + step_lines, loops, step_indices))
+        lines, step_indices = _build_phase_lines(phase_idx, phase)
+        all_phase_data.append((lines, loops, step_indices))
 
     # Phase 2: determine global box width (before loop track)
     max_inner = INNER_MIN
@@ -385,6 +500,10 @@ def render_ascii(phases: list[PhaseDict]) -> str:
     n_phases = len(all_phase_data)
 
     for p_idx, (lines, loops, step_indices) in enumerate(all_phase_data):
+        # step_indices[0] is -1 (header placeholder); _apply_loop_track uses
+        # the indices starting at position 1 (step lines), so -1 is never matched
+        # against a real step number and is harmless.
+
         # Step A: truncate base lines to inner_width (ellipsis-aware).
         truncated_lines = [
             _truncate_visual(ln, inner_width) if _visual_width(ln) > inner_width else ln
@@ -393,8 +512,9 @@ def render_ascii(phases: list[PhaseDict]) -> str:
 
         # Step B: layer the loop track on top. The track renderer owns
         # further shrinkage of base text so the track column stays clear.
+        # Pass step_indices[1:] to skip the header placeholder (-1).
         lines_with_track = _apply_loop_track(
-            truncated_lines, loops, p_idx + 1, inner_width, step_indices
+            truncated_lines, loops, p_idx + 1, inner_width, step_indices[1:]
         )
 
         # Step C: pad every line to exactly inner_width for box alignment.

--- a/src/fx_alfred/core/ascii_graph.py
+++ b/src/fx_alfred/core/ascii_graph.py
@@ -171,33 +171,16 @@ def _apply_loop_track(
             continue
 
         # Find step line indices (lines[0] is header, steps start at lines[1]).
-        # to_step: first occurrence is the step's text body row (correct for
-        #   ◄──────┐ placement).
-        # from_step: the ─────┘ suffix must land on a text body row, not a
-        #   box-drawing border.  When from_step appears on multiple rows (e.g.
-        #   it is a convergence step whose box occupies top/mid/bot rows), pick
-        #   the LAST occurrence whose underlying line is NOT pure box-drawing.
+        # Each step integer appears at most ONCE in step_indices (anchored to
+        # the body row only); first occurrence is the correct row for both
+        # to_step and from_step.
         to_line_idx = None
-        from_candidates: list[int] = []
+        from_line_idx = None
         for i, step_idx in enumerate(step_indices):
             if step_idx == to_step and to_line_idx is None:
-                to_line_idx = i + 1  # +1 for header line; first occurrence
-            if step_idx == from_step:
-                from_candidates.append(i + 1)  # +1 for header line
-
-        # Resolve from_line_idx: prefer the last candidate whose line is a
-        # text body row (not box-drawing geometry).
-        from_line_idx: int | None = None
-        if from_candidates:
-            from_line_idx = next(
-                (
-                    c
-                    for c in reversed(from_candidates)
-                    if c < len(result_lines)
-                    and not _is_box_drawing_line(result_lines[c])
-                ),
-                from_candidates[-1],
-            )
+                to_line_idx = i + 1  # +1 for header line
+            if step_idx == from_step and from_line_idx is None:
+                from_line_idx = i + 1  # +1 for header line
 
         if to_line_idx is None or from_line_idx is None:
             continue
@@ -209,11 +192,8 @@ def _apply_loop_track(
                 inner_width,
                 to_line_idx,
                 from_line_idx,
-                to_step,
-                from_step,
                 max_iter,
                 condition,
-                step_indices,
             )
 
         if not rendered_vertical:
@@ -235,11 +215,8 @@ def _render_vertical_track(
     inner_width: int,
     to_line_idx: int,
     from_line_idx: int,
-    to_step: int,
-    from_step: int,
     max_iter: object,
     condition: str,
-    step_indices: list[int],
 ) -> bool:
     """Mutate ``lines`` in place to draw a vertical loop track.
 
@@ -278,27 +255,22 @@ def _render_vertical_track(
         return False
 
     track_col = inner_width - reserve
+    pipe_col = track_col + corner_offset
 
     # to_step row: shrink base to track_col, pad, append the arrow-in marker.
     base = _shrink_for_track(lines[to_line_idx], track_col)
     lines[to_line_idx] = _pad_visual(base, track_col) + to_suffix
 
     # Intermediate rows: place `│` under the ┐ glyph on EVERY row between
-    # to_step and from_step.  For rows that are pure box-drawing geometry
-    # (branch borders, join rows, arrow rows) we pad to pipe_col and append │
-    # WITHOUT calling _shrink_for_track, which would truncate the geometry
-    # with "..." and mangle the visual output.  For text rows we shrink as
-    # usual so the prose content stays within the track column.
-    pipe_col = track_col + corner_offset
+    # to_step and from_step.  All rows (geometry and text) are handled
+    # uniformly: shrink to pipe_col then pad and stamp.  Branch geometry rows
+    # are shorter than pipe_col by construction (inner_width always exceeds
+    # branch primitive width; geometry rows get padded, not truncated).
     for i in range(to_line_idx + 1, from_line_idx):
         if i >= len(lines):
             break
-        if _is_box_drawing_line(lines[i]):
-            # Geometry row: pad only, never truncate.
-            lines[i] = _pad_visual(lines[i], pipe_col) + "│"
-        else:
-            mid = _shrink_for_track(lines[i], pipe_col)
-            lines[i] = _pad_visual(mid, pipe_col) + "│"
+        mid = _shrink_for_track(lines[i], pipe_col)
+        lines[i] = _pad_visual(mid, pipe_col) + "│"
 
     # from_step row: append the arrow-out marker.
     base = _shrink_for_track(lines[from_line_idx], track_col)
@@ -306,22 +278,6 @@ def _render_vertical_track(
     suffix = cond_from_suffix if use_condition else base_from_suffix
     lines[from_line_idx] = padded + suffix
     return True
-
-
-_BOX_DRAW_CHARS = set("┌┐└┘─┴┬┼│▼◄►")
-
-
-def _is_box_drawing_line(s: str) -> bool:
-    """Return True if ``s`` is composed entirely of box-drawing chars and spaces.
-
-    Used to detect rows that belong to branch geometry primitives (sibling box
-    borders, join rows, arrow rows) where calling _shrink_for_track would mangle
-    the geometry rather than safely truncating prose text.
-    """
-    stripped = s.strip()
-    if not stripped:
-        return False
-    return all(ch in _BOX_DRAW_CHARS or ch == " " for ch in stripped)
 
 
 def _shrink_for_track(line: str, limit: int) -> str:
@@ -456,42 +412,39 @@ def _build_phase_lines(
             )
             primitive_out = render_branch(primitive_input)
 
-            # Sibling integer index: used by loop-track to find the sibling rows.
-            # Append it once, pointing at the first primitive line (parent bottom
-            # border row) — close enough for the loop track's row lookup.
+            # Sibling integer index: used by loop-track to anchor to the sibling
+            # body row (the middle row of the first sibling's box).
+            # Only the body row gets sibling_int; all other primitive rows get -1.
             sibling_int = sib_steps[0]["index"]
+            # step_anchor_rows maps "3a" → row index of the middle (body) row
+            # within primitive_out.lines.  Use bsig.to[0] (first sibling in
+            # declared order) as the anchor; its key matches the primitive's
+            # rendering order.
+            first_target = bsig.to[0]
+            first_sibling_key = f"{first_target.parent}{first_target.branch}"
+            sibling_body_row_in_prim = primitive_out.step_anchor_rows.get(
+                first_sibling_key
+            )
 
-            for prim_line in primitive_out.lines:
-                lines.append(prim_line)
-                step_indices.append(sibling_int)
-
-            # Convergence step: append its integer index at the convergence row
-            # (primitive_out.convergence_anchor_row points at the top border of
-            # the convergence box; the text body is one row later). Record the
-            # convergence integer at the convergence-box top-border row so the
-            # loop track can find it.
+            # Convergence integer: body row is convergence_anchor_row + 1
+            # (anchor_row is the top border; +1 is the middle/text row).
+            conv_int: int | None = None
+            conv_body_row_in_prim: int | None = None
             if (
                 conv_step is not None
                 and primitive_out.convergence_anchor_row is not None
             ):
                 conv_int = conv_step["index"]
-                # Walk back from the end and re-stamp convergence rows with conv_int.
-                # The convergence block occupies the last 3 lines of primitive_out
-                # (top, middle, bottom borders) preceded by the join row and arrow.
-                # We identify the anchor row in the already-appended lines.
-                # lines[-1] is prim_out.lines[-1] (conv box bottom); work backward.
-                prim_len = len(primitive_out.lines)
-                # convergence_anchor_row in primitive is 0-based within primitive_out.lines.
-                # Map to lines[] offset: lines has header + parent + prim_len lines so far.
-                # First primitive line index in lines = len(lines) - prim_len.
-                prim_start_in_lines = len(lines) - prim_len
-                conv_line_in_lines = (
-                    prim_start_in_lines + primitive_out.convergence_anchor_row
-                )
-                # Overwrite step_indices entries from convergence_anchor_row onward
-                # with conv_int (top, middle, bottom of convergence box).
-                for ci in range(conv_line_in_lines, len(lines)):
-                    step_indices[ci] = conv_int
+                conv_body_row_in_prim = primitive_out.convergence_anchor_row + 1
+
+            for prim_idx, prim_line in enumerate(primitive_out.lines):
+                lines.append(prim_line)
+                if prim_idx == sibling_body_row_in_prim:
+                    step_indices.append(sibling_int)
+                elif conv_int is not None and prim_idx == conv_body_row_in_prim:
+                    step_indices.append(conv_int)
+                else:
+                    step_indices.append(-1)
         else:
             base = _build_step_base_text(phase_idx, step)
             lines.append(base)

--- a/src/fx_alfred/core/ascii_graph.py
+++ b/src/fx_alfred/core/ascii_graph.py
@@ -171,13 +171,33 @@ def _apply_loop_track(
             continue
 
         # Find step line indices (lines[0] is header, steps start at lines[1]).
+        # to_step: first occurrence is the step's text body row (correct for
+        #   ◄──────┐ placement).
+        # from_step: the ─────┘ suffix must land on a text body row, not a
+        #   box-drawing border.  When from_step appears on multiple rows (e.g.
+        #   it is a convergence step whose box occupies top/mid/bot rows), pick
+        #   the LAST occurrence whose underlying line is NOT pure box-drawing.
         to_line_idx = None
-        from_line_idx = None
+        from_candidates: list[int] = []
         for i, step_idx in enumerate(step_indices):
-            if step_idx == to_step:
-                to_line_idx = i + 1  # +1 for header line
+            if step_idx == to_step and to_line_idx is None:
+                to_line_idx = i + 1  # +1 for header line; first occurrence
             if step_idx == from_step:
-                from_line_idx = i + 1
+                from_candidates.append(i + 1)  # +1 for header line
+
+        # Resolve from_line_idx: prefer the last candidate whose line is a
+        # text body row (not box-drawing geometry).
+        from_line_idx: int | None = None
+        if from_candidates:
+            from_line_idx = next(
+                (
+                    c
+                    for c in reversed(from_candidates)
+                    if c < len(result_lines)
+                    and not _is_box_drawing_line(result_lines[c])
+                ),
+                from_candidates[-1],
+            )
 
         if to_line_idx is None or from_line_idx is None:
             continue
@@ -263,16 +283,22 @@ def _render_vertical_track(
     base = _shrink_for_track(lines[to_line_idx], track_col)
     lines[to_line_idx] = _pad_visual(base, track_col) + to_suffix
 
-    # Intermediate rows: place `│` under the ┐ glyph.
+    # Intermediate rows: place `│` under the ┐ glyph on EVERY row between
+    # to_step and from_step.  For rows that are pure box-drawing geometry
+    # (branch borders, join rows, arrow rows) we pad to pipe_col and append │
+    # WITHOUT calling _shrink_for_track, which would truncate the geometry
+    # with "..." and mangle the visual output.  For text rows we shrink as
+    # usual so the prose content stays within the track column.
     pipe_col = track_col + corner_offset
-    for step_idx in step_indices:
-        if to_step < step_idx < from_step:
-            pos_in_steps = step_indices.index(step_idx)
-            line_idx = pos_in_steps + 1  # +1 for header
-            if line_idx >= len(lines):
-                continue
-            mid = _shrink_for_track(lines[line_idx], pipe_col)
-            lines[line_idx] = _pad_visual(mid, pipe_col) + "│"
+    for i in range(to_line_idx + 1, from_line_idx):
+        if i >= len(lines):
+            break
+        if _is_box_drawing_line(lines[i]):
+            # Geometry row: pad only, never truncate.
+            lines[i] = _pad_visual(lines[i], pipe_col) + "│"
+        else:
+            mid = _shrink_for_track(lines[i], pipe_col)
+            lines[i] = _pad_visual(mid, pipe_col) + "│"
 
     # from_step row: append the arrow-out marker.
     base = _shrink_for_track(lines[from_line_idx], track_col)
@@ -280,6 +306,22 @@ def _render_vertical_track(
     suffix = cond_from_suffix if use_condition else base_from_suffix
     lines[from_line_idx] = padded + suffix
     return True
+
+
+_BOX_DRAW_CHARS = set("┌┐└┘─┴┬┼│▼◄►")
+
+
+def _is_box_drawing_line(s: str) -> bool:
+    """Return True if ``s`` is composed entirely of box-drawing chars and spaces.
+
+    Used to detect rows that belong to branch geometry primitives (sibling box
+    borders, join rows, arrow rows) where calling _shrink_for_track would mangle
+    the geometry rather than safely truncating prose text.
+    """
+    stripped = s.strip()
+    if not stripped:
+        return False
+    return all(ch in _BOX_DRAW_CHARS or ch == " " for ch in stripped)
 
 
 def _shrink_for_track(line: str, limit: int) -> str:

--- a/tests/test_ascii_graph_branches.py
+++ b/tests/test_ascii_graph_branches.py
@@ -197,6 +197,246 @@ def test_flat_branches_plus_loops() -> None:
     )
 
 
+def test_flat_loop_track_crosses_branch_group_clean_intermediate_rows() -> None:
+    """Loop whose from_step→to_step range crosses a branch group renders cleanly.
+
+    SOP shape:
+      1. Setup         <- loop to_step (◄──────┐ lands here)
+      2. Decision      <- branch parent
+      3a. Ba           <- sibling
+      3b. Bb           <- sibling
+      4. Continue      <- convergence
+      5. End           <- loop from_step (─────┘ max N lands here)
+
+    Structural invariants:
+    - ◄──────┐ appears on the "[1.1] Setup" body row (to_step body row)
+    - ─────┘ max appears on the "[1.5] End" body row, NOT on any box-border row
+    - All intermediate rows between to_step and from_step have │ at the track col
+    - No row contains ...│ (no truncation-of-box-drawing geometry)
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="ok"),
+                BranchTarget(parent=3, branch="b", label="no"),
+            ),
+        )
+    ]
+    loops = [
+        LoopSignature(
+            id="retry",
+            from_step=5,
+            to_step=1,
+            max_iterations=3,
+            condition="",
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9010",
+            [
+                _step(1, "Setup"),
+                _step(2, "Decision"),
+                _step(3, "Ba", sub_branch="a"),
+                _step(3, "Bb", sub_branch="b"),
+                _step(4, "Continue"),
+                _step(5, "End"),
+            ],
+            loops=loops,
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    lines = out.split("\n")
+
+    # Find the to_step body row: must contain "◄──────┐"
+    to_rows = [ln for ln in lines if "◄──────┐" in ln]
+    assert to_rows, f"◄──────┐ not found in output:\n{out}"
+    # The to_step row must contain "[1.1]" (Setup body)
+    assert all("[1.1]" in ln for ln in to_rows), (
+        "◄──────┐ landed on wrong row (expected [1.1] Setup body):\n"
+        + "\n".join(to_rows)
+    )
+
+    # Find the from_step suffix row: must contain "─────┘ max" or "──────┘ max"
+    from_rows = [ln for ln in lines if "┘ max" in ln]
+    assert from_rows, f"┘ max not found in output:\n{out}"
+    # The from_step row must contain "[1.5]" (End body) and NOT be a box-border row
+    for fr in from_rows:
+        assert "[1.5]" in fr, (
+            f"─────┘ max landed on wrong row (expected [1.5] End body):\n{fr}"
+        )
+        # Must not be a pure box-drawing row
+        stripped = fr.strip(" │")
+        assert not all(ch in "┌┐└┘─┴┬┼│▼◄► " for ch in stripped if stripped), (
+            f"─────┘ max landed on a box-drawing row:\n{fr}"
+        )
+
+    # All intermediate rows between to_step and from_step must have │ at track col.
+    # Find the row indices of to_step and from_step in lines.
+    to_idx = next(i for i, ln in enumerate(lines) if "◄──────┐" in ln)
+    from_idx = next(i for i, ln in enumerate(lines) if "┘ max" in ln)
+    assert to_idx < from_idx, "to_step row must precede from_step row"
+    # Find the track column (column of ┐ in to_step row).
+    to_row = lines[to_idx]
+    track_col = to_row.index("┐")  # rightmost ┐ is the track corner
+    for i in range(to_idx + 1, from_idx):
+        ln = lines[i]
+        assert len(ln) > track_col and ln[track_col] == "│", (
+            f"Intermediate row {i} missing │ at track col {track_col}:\n{ln!r}"
+        )
+
+    # No row must contain "...│" (box-drawing mangled by shrink_for_track).
+    mangled = [ln for ln in lines if "...│" in ln]
+    assert not mangled, (
+        "found rows with '...│' (box-drawing geometry mangled):\n" + "\n".join(mangled)
+    )
+
+
+def test_flat_branch_box_borders_not_mangled_by_loop_track() -> None:
+    """Box-border rows (─ runs) must not be truncated with '...│' by loop track.
+
+    Same SOP as test_flat_loop_track_crosses_branch_group_clean_intermediate_rows.
+    After rendering, every row that contains a ─ run (box horizontal border)
+    must NOT contain '...│'.
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="ok"),
+                BranchTarget(parent=3, branch="b", label="no"),
+            ),
+        )
+    ]
+    loops = [
+        LoopSignature(
+            id="retry",
+            from_step=5,
+            to_step=1,
+            max_iterations=3,
+            condition="",
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9011",
+            [
+                _step(1, "Setup"),
+                _step(2, "Decision"),
+                _step(3, "Ba", sub_branch="a"),
+                _step(3, "Bb", sub_branch="b"),
+                _step(4, "Continue"),
+                _step(5, "End"),
+            ],
+            loops=loops,
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    lines = out.split("\n")
+    # Rows that contain horizontal-border runs (─ sequences) are box borders.
+    border_rows = [ln for ln in lines if "──" in ln]
+    assert border_rows, "expected box-border rows in output"
+    mangled_borders = [ln for ln in border_rows if "...│" in ln]
+    assert not mangled_borders, (
+        "box-border rows were mangled with '...│':\n" + "\n".join(mangled_borders)
+    )
+
+
+def test_flat_4way_fanout() -> None:
+    """4-way branch with convergence: all 4 labels present, width-uniformity holds."""
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="A"),
+                BranchTarget(parent=3, branch="b", label="B"),
+                BranchTarget(parent=3, branch="c", label="C"),
+                BranchTarget(parent=3, branch="d", label="D"),
+            ),
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9012",
+            [
+                _step(1, "Start"),
+                _step(2, "Fork"),
+                _step(3, "Aa", sub_branch="a"),
+                _step(3, "Bb", sub_branch="b"),
+                _step(3, "Cc", sub_branch="c"),
+                _step(3, "Dd", sub_branch="d"),
+                _step(4, "Merge"),
+            ],
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    # All 4 labels present.
+    for label in ("A", "B", "C", "D"):
+        assert label in out, f"label {label!r} missing from output:\n{out}"
+    # Width-uniformity: all │-containing lines have same total cell width.
+    lines = out.split("\n")
+    box_lines = [ln for ln in lines if "│" in ln]
+    assert box_lines, "expected phase-box border lines"
+    widths = {wcwidth.wcswidth(ln) for ln in box_lines}
+    assert len(widths) == 1, (
+        f"phase-box lines have non-uniform widths {widths}:\n"
+        + "\n".join(f"  ({wcwidth.wcswidth(ln)}) {ln}" for ln in box_lines)
+    )
+
+
+def test_flat_sibling_text_paired_by_branch_letter() -> None:
+    """Siblings declared (a, b, c) but steps listed (c, a, b): column order follows
+    declared label order, not step-definition order.
+
+    Uses short body texts that fit in 12-cell sibling box: 'Ba', 'Bb', 'Bc'.
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="A"),
+                BranchTarget(parent=3, branch="b", label="B"),
+                BranchTarget(parent=3, branch="c", label="C"),
+            ),
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9013",
+            [
+                _step(1, "Start"),
+                _step(2, "Split"),
+                # Steps listed in (c, a, b) order — different from declared (a, b, c).
+                _step(3, "Bc", sub_branch="c"),
+                _step(3, "Ba", sub_branch="a"),
+                _step(3, "Bb", sub_branch="b"),
+                _step(4, "Join"),
+            ],
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    # All three body texts must appear.
+    for body in ("Ba", "Bb", "Bc"):
+        assert body in out, f"sibling body {body!r} missing:\n{out}"
+    # In each sibling row, left-to-right order must be Ba, Bb, Bc
+    # (matching declared a, b, c — not the step-list c, a, b order).
+    sibling_row = next(
+        (ln for ln in out.split("\n") if "Ba" in ln and "Bb" in ln and "Bc" in ln),
+        None,
+    )
+    assert sibling_row is not None, (
+        "could not find a single row containing Ba, Bb, Bc:\n" + out
+    )
+    assert (
+        sibling_row.index("Ba") < sibling_row.index("Bb") < sibling_row.index("Bc")
+    ), f"column order is wrong (expected Ba < Bb < Bc):\n{sibling_row}"
+
+
 def test_flat_phase_box_uniform_width_with_branches() -> None:
     """Width-uniformity invariant: every │-containing line has the same total width.
 

--- a/tests/test_ascii_graph_branches.py
+++ b/tests/test_ascii_graph_branches.py
@@ -475,3 +475,221 @@ def test_flat_phase_box_uniform_width_with_branches() -> None:
         "branch group output may have overflowed phase border\n"
         + "\n".join(f"  ({wcwidth.wcswidth(line)}) {line}" for line in box_lines)
     )
+
+
+def test_flat_loop_to_sibling_index_lands_on_sibling_body() -> None:
+    """Loop with to_step set to the sibling integer: ◄──────┐ lands on sibling body.
+
+    SOP shape:
+      1. Setup
+      2. Decision   <- branch parent
+      3a. Path A    <- sibling (to_step = 3)
+      3b. Path B    <- sibling
+      4. Continue   <- convergence
+      5. End        <- loop from_step
+
+    ◄──────┐ must appear on the row that also contains 'Path A' (sibling body),
+    NOT on a label row or box-border row.
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="ok"),
+                BranchTarget(parent=3, branch="b", label="no"),
+            ),
+        )
+    ]
+    loops = [
+        LoopSignature(
+            id="retry",
+            from_step=5,
+            to_step=3,
+            max_iterations=3,
+            condition="",
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9020",
+            [
+                _step(1, "Setup"),
+                _step(2, "Decision"),
+                _step(3, "Path A", sub_branch="a"),
+                _step(3, "Path B", sub_branch="b"),
+                _step(4, "Continue"),
+                _step(5, "End"),
+            ],
+            loops=loops,
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    lines = out.split("\n")
+
+    # ◄──────┐ must appear somewhere in the output.
+    to_rows = [ln for ln in lines if "◄──────┐" in ln]
+    assert to_rows, f"◄──────┐ not found in output:\n{out}"
+
+    # The row with ◄──────┐ must contain sibling body text ('Path A' or 'Path B'),
+    # NOT be a pure box-border or label row.
+    for row in to_rows:
+        # Must contain sibling body text — it is the middle row of a sibling box.
+        has_body = "Path A" in row or "Path B" in row
+        stripped = row.strip(" │")
+        is_border = all(ch in "┌┐└┘─┴┬┼│▼◄► " for ch in stripped) if stripped else False
+        assert has_body and not is_border, (
+            f"◄──────┐ landed on wrong row (expected sibling body, not border/label):\n{row!r}"
+        )
+
+
+def test_flat_loop_from_sibling_index_lands_on_sibling_body() -> None:
+    """Loop with from_step set to the sibling integer: ─────┘ max N lands on sibling body.
+
+    SOP shape:
+      1. Setup         <- loop to_step
+      2. Decision      <- branch parent
+      3a. Path A       <- sibling (from_step = 3)
+      3b. Path B       <- sibling
+
+    ─────┘ max N must appear on the row that also contains 'Path A' or 'Path B'
+    (sibling body), NOT on a label row or box-border row.
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="ok"),
+                BranchTarget(parent=3, branch="b", label="no"),
+            ),
+        )
+    ]
+    loops = [
+        LoopSignature(
+            id="retry",
+            from_step=3,
+            to_step=1,
+            max_iterations=3,
+            condition="",
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9021",
+            [
+                _step(1, "Setup"),
+                _step(2, "Decision"),
+                _step(3, "Path A", sub_branch="a"),
+                _step(3, "Path B", sub_branch="b"),
+            ],
+            loops=loops,
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    lines = out.split("\n")
+
+    # ┘ max must appear somewhere in the output.
+    from_rows = [ln for ln in lines if "┘ max" in ln]
+    assert from_rows, f"┘ max not found in output:\n{out}"
+
+    # The row with ┘ max must contain sibling body text, NOT be a border row.
+    for row in from_rows:
+        has_body = "Path A" in row or "Path B" in row
+        is_border = (
+            all(ch in "┌┐└┘─┴┬┼│▼◄► " for ch in row.strip(" │"))
+            if row.strip(" │")
+            else False
+        )
+        assert has_body and not is_border, (
+            f"┘ max landed on wrong row (expected sibling body, not border/label):\n{row!r}"
+        )
+
+
+def test_flat_loop_track_with_long_condition_stays_aligned() -> None:
+    """Branch + loop with a long condition string: │ track stays at uniform column.
+
+    SOP shape:
+      1. Setup         <- to_step (◄──────┐ lands here)
+      2. Decision      <- branch parent
+      3a. Path A       <- sibling
+      3b. Path B       <- sibling
+      4. Continue      <- convergence
+      5. End           <- from_step
+
+    Long condition eats into track reservation (TRACK_RESERVE). All rows
+    containing │ as a track marker must have that │ at the SAME column position.
+    No │ track marker should appear AFTER the end of a box-drawing geometry row
+    (which would indicate pipe_col > geometry width, i.e. appended to the right
+    edge rather than placed at the track column).
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="ok"),
+                BranchTarget(parent=3, branch="b", label="no"),
+            ),
+        )
+    ]
+    loops = [
+        LoopSignature(
+            id="retry",
+            from_step=5,
+            to_step=1,
+            max_iterations=3,
+            condition="the_long_condition_text_for_alignment_test",
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9022",
+            [
+                _step(1, "Setup"),
+                _step(2, "Decision"),
+                _step(3, "Path A", sub_branch="a"),
+                _step(3, "Path B", sub_branch="b"),
+                _step(4, "Continue"),
+                _step(5, "End"),
+            ],
+            loops=loops,
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    lines = out.split("\n")
+
+    # Find to_step row — it has ◄──────┐
+    to_rows = [ln for ln in lines if "◄──────┐" in ln]
+    assert to_rows, f"◄──────┐ not found in output:\n{out}"
+
+    # Determine track ┐ column from the to_step row.
+    to_row = to_rows[0]
+    track_col = to_row.index("┐")  # rightmost ┐ is the track corner
+
+    # Find from_step row — it has ┘ max
+    from_rows = [ln for ln in lines if "┘ max" in ln]
+    if not from_rows:
+        # Fell back to inline — that's acceptable for very long conditions.
+        assert "→ back to" in out or "max 3" in out, (
+            f"no loop annotation at all in output:\n{out}"
+        )
+        return
+
+    to_idx = next(i for i, ln in enumerate(lines) if "◄──────┐" in ln)
+    from_idx = next(i for i, ln in enumerate(lines) if "┘ max" in ln)
+
+    # Every intermediate row must have │ at track_col (not appended at end).
+    for i in range(to_idx + 1, from_idx):
+        ln = lines[i]
+        if len(ln) <= track_col:
+            # Line shorter than track_col — │ must be at end (padded)
+            assert (
+                ln.rstrip().endswith("│") or ln[track_col : track_col + 1] == "│"
+                if len(ln) > track_col
+                else True
+            ), f"Intermediate row {i} missing │ at track col {track_col}:\n{ln!r}"
+        else:
+            assert ln[track_col] == "│", (
+                f"Intermediate row {i} has '{ln[track_col]}' at track col {track_col} (expected │):\n{ln!r}"
+            )

--- a/tests/test_ascii_graph_branches.py
+++ b/tests/test_ascii_graph_branches.py
@@ -1,0 +1,237 @@
+"""Tests for FXA-2227 Phase 5 — ascii_graph.py flat-layout integration with
+branch_geometry primitive.
+
+Per CHG-2227 §"Phase 5 — `ascii_graph.py` flat integration":
+- Detect branch groups (same pattern as Phase 4) via discover_branch_groups.
+- Call render_branch(...) directly WITHOUT phase-box wrapping (flat layout).
+- No step_idx/step_indices widening — keep list[int].
+- Existing tests/test_ascii_graph.py tests stay green (non-branchy phases
+  render byte-identical to pre-Phase-5).
+"""
+
+from __future__ import annotations
+
+import wcwidth
+
+from fx_alfred.core.ascii_graph import render_ascii
+from fx_alfred.core.workflow import BranchSignature, BranchTarget, LoopSignature
+
+
+def _step(
+    index: int,
+    text: str,
+    gate: bool = False,
+    sub_branch: str | None = None,
+) -> dict:
+    s: dict = {"index": index, "text": text, "gate": gate}
+    if sub_branch is not None:
+        s["sub_branch"] = sub_branch
+    return s
+
+
+def _phase(
+    sop_id: str,
+    steps: list[dict],
+    loops: list[LoopSignature] | None = None,
+    branches: list[BranchSignature] | None = None,
+) -> dict:
+    p: dict = {"sop_id": sop_id, "steps": steps, "loops": loops or []}
+    if branches is not None:
+        p["branches"] = branches
+    return p
+
+
+def test_flat_3way_with_convergence() -> None:
+    """3-way branch with convergence renders without inner phase-box wrapping.
+
+    SOP shape:
+      1. Setup
+      2. Decision    <- parent (branches.from = 2)
+      3a. pass       <- sibling
+      3b. fail       <- sibling
+      3c. esc        <- sibling
+      4. Continue    <- convergence (auto-detected)
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="pass"),
+                BranchTarget(parent=3, branch="b", label="fail"),
+                BranchTarget(parent=3, branch="c", label="esc"),
+            ),
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9001",
+            [
+                _step(1, "Setup"),
+                _step(2, "Decision"),
+                _step(3, "pass-body", sub_branch="a"),
+                _step(3, "fail-body", sub_branch="b"),
+                _step(3, "esc-body", sub_branch="c"),
+                _step(4, "Continue"),
+            ],
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    # Branch tees and convergence join present.
+    assert "┬" in out, f"expected branch tees in output:\n{out}"
+    assert "pass" in out
+    assert "fail" in out
+    assert "esc" in out
+    assert "┼" in out, f"expected convergence join in output:\n{out}"
+    # Sibling body texts present.
+    assert "pass-body" in out or "3a" in out, (
+        f"expected sibling 3a content in output:\n{out}"
+    )
+    # Single outer box still wraps everything (flat layout: one box for the phase).
+    assert "Phase 1: TST-9001" in out
+    # No intermediate phase-box borders inside the branch geometry — all branch
+    # geometry sits INSIDE the outer │...│ borders (flat, not nested step-boxes).
+    lines = out.split("\n")
+    # All content lines between the top ┌ and bottom └ must use │ ... │ form.
+    top_row = next(i for i, line in enumerate(lines) if line.startswith("┌"))
+    bottom_row = next(i for i, line in enumerate(lines) if line.startswith("└"))
+    content_lines = lines[top_row + 1 : bottom_row]
+    # No content line should start a new ┌ border (that would be an inner box).
+    inner_box_openers = [ln for ln in content_lines if ln.startswith("┌")]
+    assert not inner_box_openers, (
+        "unexpected inner phase-box borders inside flat branch geometry:\n"
+        + "\n".join(inner_box_openers)
+    )
+
+
+def test_flat_legacy_unchanged() -> None:
+    """Phase WITHOUT branches: renders with no ┬ or ┼ markers (no regression)."""
+    phases = [
+        _phase(
+            "COR-1500",
+            [_step(1, "Red"), _step(2, "Green"), _step(3, "Refactor")],
+        ),
+    ]
+    out = render_ascii(phases)
+    assert "Phase 1: COR-1500" in out
+    assert "[1.1]" in out
+    assert "[1.2]" in out
+    assert "[1.3]" in out
+    # No branch markers should appear.
+    assert "┬" not in out, f"unexpected branch tee in legacy output:\n{out}"
+    assert "┼" not in out, f"unexpected convergence join in legacy output:\n{out}"
+
+
+def test_flat_dangling_branch() -> None:
+    """Terminal branch (no convergence): ┬ present, ┼ absent."""
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="end-a"),
+                BranchTarget(parent=3, branch="b", label="end-b"),
+            ),
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9002",
+            [
+                _step(1, "Setup"),
+                _step(2, "Decision"),
+                _step(3, "Final A", sub_branch="a"),
+                _step(3, "Final B", sub_branch="b"),
+            ],
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    assert "┬" in out, f"branch tees missing:\n{out}"
+    assert "┼" not in out, f"dangling branch should have no join:\n{out}"
+    assert "end-a" in out and "end-b" in out
+
+
+def test_flat_branches_plus_loops() -> None:
+    """Branch + intra-SOP loop in same SOP: branch markers + loop track both render.
+
+    Loops are orthogonal to branches — adding `Workflow branches:` should NOT
+    break the existing right-side vertical loop track.
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="ok"),
+                BranchTarget(parent=3, branch="b", label="no"),
+            ),
+        )
+    ]
+    loops = [
+        LoopSignature(
+            id="retry",
+            from_step=4,
+            to_step=1,
+            max_iterations=3,
+            condition="failed",
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9003",
+            [
+                _step(1, "Setup"),
+                _step(2, "Decision"),
+                _step(3, "Path A", sub_branch="a"),
+                _step(3, "Path B", sub_branch="b"),
+                _step(4, "Continue"),
+            ],
+            loops=loops,
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    assert "┬" in out, "branch tees missing"
+    # Loop annotation should still appear (vertical track or inline).
+    assert "◄──────┐" in out or "→ back to" in out or "max 3" in out, (
+        f"loop annotation missing from output:\n{out}"
+    )
+
+
+def test_flat_phase_box_uniform_width_with_branches() -> None:
+    """Width-uniformity invariant: every │-containing line has the same total width.
+
+    Same precedent as Phase 4's test_nested_phase_box_uniform_width_with_branches.
+    """
+    branches = [
+        BranchSignature(
+            from_step=2,
+            to=(
+                BranchTarget(parent=3, branch="a", label="A"),
+                BranchTarget(parent=3, branch="b", label="B"),
+            ),
+        )
+    ]
+    phases = [
+        _phase(
+            "TST-9004",
+            [
+                _step(1, "First"),
+                _step(2, "Decision"),
+                _step(3, "Path A", sub_branch="a"),
+                _step(3, "Path B", sub_branch="b"),
+                _step(4, "After"),
+            ],
+            branches=branches,
+        )
+    ]
+    out = render_ascii(phases)
+    lines = out.split("\n")
+    # All lines containing │ borders must have the same total cell width.
+    box_lines = [line for line in lines if "│" in line]
+    assert box_lines, "expected phase-box border lines"
+    widths = {wcwidth.wcswidth(line) for line in box_lines}
+    assert len(widths) == 1, (
+        f"phase-box lines have non-uniform widths {widths}; "
+        "branch group output may have overflowed phase border\n"
+        + "\n".join(f"  ({wcwidth.wcswidth(line)}) {line}" for line in box_lines)
+    )


### PR DESCRIPTION
## Summary

CHG-2227 Phase 5: integrates the `branch_geometry` primitive (Phase 3, PR #69) into the flat ASCII renderer (`ascii_graph.py`), reusing the shared discovery primitive from Phase 4 (PR #70).

- `_build_phase_lines()` helper extracted from `render_ascii()` — handles branch detection per phase
- Phases without `branches:` take the identical pre-Phase-5 path (zero behavior change for legacy SOPs)
- Branch parents render parent text + delegate to `branch_geometry.render_branch()`; primitive's lines are padded to `inner_width` and wrapped in the existing flat-layout phase-box border
- `step_indices: list[int]` kept untouched per CHG-2226 Path B contract — Phase 5 introduces no int→str widening
- Loop-track machinery (right-side vertical) continues to work alongside branches (orthogonal — proven by `test_flat_branches_plus_loops`)

CHG-2227 phase order:
- ✅ Phase 1+2: Data layer (PR #68)
- ✅ Phase 3: `branch_geometry` primitive (PR #69)
- ✅ Phase 4: `dag_graph.py` nested integration (PR #70)
- ✅ Phase 5: this PR — `ascii_graph.py` flat integration
- ⏭️ Phase 7: `mermaid.py` sub-step IDs
- ⏭️ Phase 8a: flip `_BRANCHES_RENDERER_READY = True`

## Test plan

- [x] 5 new tests in `tests/test_ascii_graph_branches.py`
  - `test_flat_3way_with_convergence`
  - `test_flat_legacy_unchanged` — byte-identical legacy output
  - `test_flat_dangling_branch` — terminal branch, no `┼`
  - `test_flat_branches_plus_loops` — branch + loop track orthogonality
  - `test_flat_phase_box_uniform_width_with_branches` — wcwidth invariant
- [x] All 25 existing `tests/test_ascii_graph.py` tests stay green (no regression)
- [x] Full suite: 816/816 pass
- [x] Pyright: 0 errors
- [x] Ruff: clean