### PR TITLE
feat(FXA-2227): flip _BRANCHES_RENDERER_READY = True

### DIFF
--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -23,11 +23,13 @@ from fx_alfred.core.mermaid import render_mermaid
 from fx_alfred.core.phases import PhaseDict
 from fx_alfred.core.schema import TASK_TAGS
 from fx_alfred.core.workflow import (
+    BranchSignature,
     LoopSignature,
     WorkflowSignature,
     _BRANCHES_RENDERER_READY,
     check_composition,
     has_workflow_branches_field,
+    parse_workflow_branches,
     parse_workflow_loops,
     parse_workflow_signature,
     validate_workflow_signature,
@@ -397,6 +399,9 @@ def _build_mermaid_phases(
     Each entry is ``{"sop_id": str, "steps": list[dict], "loops": list}``.
     When ``provenance_map`` is provided, each entry also gets
     ``"provenance"`` set to the matching marker ("always" / "auto" / "explicit").
+    When the SOP declares ``Workflow branches:``, each entry also gets
+    ``"branches"`` set to the parsed list of :class:`BranchSignature` objects.
+    Legacy SOPs without the field do not get the key (optional-field discipline).
     """
     mermaid_phases: list[PhaseDict] = []
     for sop_id, doc, parsed, sig, loops in phase_info:
@@ -413,6 +418,9 @@ def _build_mermaid_phases(
             prov = provenance_map.get(doc_id)
             if prov:
                 entry["provenance"] = prov
+        branches: list[BranchSignature] = parse_workflow_branches(parsed)
+        if branches:
+            entry["branches"] = branches
         mermaid_phases.append(entry)
     return mermaid_phases
 

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -418,7 +418,10 @@ def _build_mermaid_phases(
             prov = provenance_map.get(doc_id)
             if prov:
                 entry["provenance"] = prov
-        branches: list[BranchSignature] = parse_workflow_branches(parsed)
+        try:
+            branches: list[BranchSignature] = parse_workflow_branches(parsed)
+        except MalformedDocumentError as e:
+            raise click.ClickException(f"{doc_id}: malformed Workflow branches: {e}")
         if branches:
             entry["branches"] = branches
         mermaid_phases.append(entry)

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -280,7 +280,7 @@ class BranchError:
 # commit, ``af validate`` rejects any SOP authoring ``Workflow branches:``
 # so production SOPs cannot land branchy declarations that misrender in
 # nested/flat/Mermaid output.
-_BRANCHES_RENDERER_READY = False
+_BRANCHES_RENDERER_READY = True
 
 
 def has_workflow_branches_field(parsed: ParsedDocument) -> bool:

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -2193,3 +2193,68 @@ Test.
     assert "branches" not in phases[0], (
         "PhaseDict must NOT have 'branches' key for legacy SOP (optional-field discipline)"
     )
+
+
+def test_plan_handles_malformed_branches_gracefully():
+    """_build_mermaid_phases raises ClickException (not MalformedDocumentError) for invalid Workflow branches: YAML.
+
+    Mirrors the loop-parsing guard: a single bad SOP must not propagate a bare
+    MalformedDocumentError to the caller.  The ClickException message must
+    include the document's prefix-ACID so the user knows which SOP failed.
+    """
+    content = """\
+# TST-9902: Malformed Branches SOP
+
+**Applies to:** Test
+**Last updated:** 2026-04-28
+**Last reviewed:** 2026-04-28
+**Status:** Active
+**Workflow branches:** [{from: not-an-int, to: [{id: 3a, label: pass}]}]
+
+---
+
+## What Is It?
+
+A test SOP with malformed branches.
+
+## Why
+
+Test.
+
+## When to Use
+
+Test.
+
+## When NOT to Use
+
+Test.
+
+## Steps
+
+1. Step one
+2. Step two
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-04-28 | Initial | — |
+"""
+    parsed = parse_metadata(content)
+    doc = Document(
+        prefix="TST",
+        acid="9902",
+        type_code="SOP",
+        title="Malformed Branches SOP",
+        directory="rules",
+        source="prj",
+    )
+    sig = WorkflowSignature(input="", output="")
+    phase_info = [("TST-9902", doc, parsed, sig, [])]
+
+    with pytest.raises(click.ClickException) as exc_info:
+        _build_mermaid_phases(phase_info)
+
+    assert "TST-9902" in str(exc_info.value.format_message())

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -7,9 +7,13 @@ import pytest
 from click.testing import CliRunner
 from fx_alfred.cli import cli
 from fx_alfred.commands.plan_cmd import (
+    _build_mermaid_phases,
     _format_phase,
     _parse_steps_for_json,
 )
+from fx_alfred.core.document import Document
+from fx_alfred.core.parser import parse_metadata
+from fx_alfred.core.workflow import BranchSignature, WorkflowSignature
 
 
 def _create_sop_with_steps(rules_dir: Path, prefix: str, acid: str, title: str) -> Path:
@@ -2032,3 +2036,160 @@ def test_graph_layout_without_graph_errors(sample_project, monkeypatch):
     )
     assert result.exit_code != 0
     assert "--graph-layout requires --graph" in result.output
+
+
+# ── FXA-2227 Phase 8a: _build_mermaid_phases branch propagation ─────────────
+
+
+def _make_branchy_phase_info(prefix: str = "TST", acid: str = "9900"):
+    """Build a minimal phase_info tuple for a 3-way fan-out SOP fixture."""
+    content = """\
+# TST-9900: Branchy SOP
+
+**Applies to:** Test
+**Last updated:** 2026-04-28
+**Last reviewed:** 2026-04-28
+**Status:** Active
+**Workflow branches:** [{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}, {id: 3c, label: esc}]}]
+---
+
+## What Is It?
+
+A test SOP with 3-way branch.
+
+## Why
+
+Test.
+
+## When to Use
+
+Test.
+
+## When NOT to Use
+
+Test.
+
+## Steps
+
+1. Setup
+2. Decision
+3a. Pass path
+3b. Fail path
+3c. Escalate path
+4. Continue
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-04-28 | Initial | — |
+"""
+    parsed = parse_metadata(content)
+    doc = Document(
+        prefix=prefix,
+        acid=acid,
+        type_code="SOP",
+        title="Branchy SOP",
+        directory="rules",
+        source="prj",
+    )
+    sig = WorkflowSignature(input="", output="")
+    loops = []
+    return [(f"{prefix}-{acid}", doc, parsed, sig, loops)]
+
+
+def test_plan_propagates_branches_to_phase_payload():
+    """_build_mermaid_phases sets 'branches' key when SOP has Workflow branches:.
+
+    Asserts:
+    - The PhaseDict has a 'branches' key.
+    - branches is a list with one BranchSignature entry.
+    - branches[0].from_step == 2.
+    - branches[0].to has 3 BranchTarget entries with labels pass/fail/esc.
+    """
+    phase_info = _make_branchy_phase_info()
+    phases = _build_mermaid_phases(phase_info)
+
+    assert len(phases) == 1
+    phase = phases[0]
+    assert "branches" in phase, "PhaseDict missing 'branches' key for branchy SOP"
+
+    branches = phase["branches"]
+    assert isinstance(branches, list)
+    assert len(branches) == 1
+
+    sig = branches[0]
+    assert isinstance(sig, BranchSignature)
+    assert sig.from_step == 2
+
+    targets = sig.to
+    assert len(targets) == 3
+    labels = {t.label for t in targets}
+    assert labels == {"pass", "fail", "esc"}
+
+
+def test_plan_no_branches_key_for_legacy_sop():
+    """_build_mermaid_phases does NOT set 'branches' key for a legacy SOP.
+
+    Preserves the optional-field discipline: PhaseDict shape stays minimal
+    for SOPs that have no Workflow branches: field.
+    """
+    content = """\
+# TST-9901: Legacy SOP
+
+**Applies to:** Test
+**Last updated:** 2026-04-28
+**Last reviewed:** 2026-04-28
+**Status:** Active
+
+---
+
+## What Is It?
+
+A legacy SOP with no branches.
+
+## Why
+
+Test.
+
+## When to Use
+
+Test.
+
+## When NOT to Use
+
+Test.
+
+## Steps
+
+1. Step one
+2. Step two
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-04-28 | Initial | — |
+"""
+    parsed = parse_metadata(content)
+    doc = Document(
+        prefix="TST",
+        acid="9901",
+        type_code="SOP",
+        title="Legacy SOP",
+        directory="rules",
+        source="prj",
+    )
+    sig = WorkflowSignature(input="", output="")
+    phase_info = [("TST-9901", doc, parsed, sig, [])]
+
+    phases = _build_mermaid_phases(phase_info)
+
+    assert len(phases) == 1
+    assert "branches" not in phases[0], (
+        "PhaseDict must NOT have 'branches' key for legacy SOP (optional-field discipline)"
+    )

--- a/tests/test_plan_cmd_substeps.py
+++ b/tests/test_plan_cmd_substeps.py
@@ -128,16 +128,13 @@ def test_phases_steps_index_int_unchanged(sample_project, monkeypatch):
 def test_plan_blocked_by_gate_when_branches_present(sample_project, monkeypatch):
     """Per PR #68 Gemini F2: `af plan` must reject branchy SOPs while gate is closed.
 
-    Otherwise the renderer-readiness gate is `af validate`-only and `af plan`
-    silently emits sub-stepped surface (`"index": "1.3a"`, ASCII collisions)
-    before CHG-2227 ships. The test fixture's `_BRANCHES_RENDERER_READY` is
-    False at module level (Path B default), so this should fail with a
-    ClickException directing the author to wait for CHG-2227.
+    CHG-2227 Phase 8a flips the default to True; this test patches back to
+    False to retain coverage of the blocking path.
     """
     rules_dir = sample_project / "rules"
     _create_sop_with_branches(rules_dir)
     monkeypatch.chdir(sample_project)
-    # NO monkeypatch of the flag — exercise the default-closed gate.
+    monkeypatch.setattr("fx_alfred.commands.plan_cmd._BRANCHES_RENDERER_READY", False)
     result = CliRunner().invoke(cli, ["plan", "TST-9001", "--todo", "--json"])
     assert result.exit_code != 0, (
         "Expected af plan to reject Workflow branches: while gate closed; "
@@ -170,7 +167,9 @@ A test SOP authoring an empty Workflow branches: list.
 """
     (rules_dir / filename).write_text(content)
     monkeypatch.chdir(sample_project)
-    # NO monkeypatch of the flag — exercise default-closed gate.
+    # Patch flag to False to retain coverage of the blocking path (default is
+    # now True after CHG-2227 Phase 8a).
+    monkeypatch.setattr("fx_alfred.commands.plan_cmd._BRANCHES_RENDERER_READY", False)
     result = CliRunner().invoke(cli, ["plan", "TST-9003", "--todo", "--json"])
     assert result.exit_code != 0, (
         f"Expected af plan to reject empty Workflow branches: field; "
@@ -208,7 +207,9 @@ A test SOP with sub-step lines in body but no Workflow branches: metadata.
 """
     (rules_dir / filename).write_text(content)
     monkeypatch.chdir(sample_project)
-    # NO monkeypatch of the flag — exercise default-closed gate.
+    # Patch flag to False to retain coverage of the blocking path (default is
+    # now True after CHG-2227 Phase 8a).
+    monkeypatch.setattr("fx_alfred.commands.plan_cmd._BRANCHES_RENDERER_READY", False)
     result = CliRunner().invoke(cli, ["plan", "TST-9004", "--todo", "--json"])
     assert result.exit_code != 0, (
         f"Expected af plan to reject undeclared sub-step lines; "

--- a/tests/test_workflow_branches_validate.py
+++ b/tests/test_workflow_branches_validate.py
@@ -41,14 +41,31 @@ def _doc(yaml_branches: str, steps_section: str) -> str:
     )
 
 
-def test_renderer_readiness_gate_default_blocks() -> None:
-    """Default `_BRANCHES_RENDERER_READY = False` makes ANY Workflow branches:
-    SOP fail validation with a clear message instructing authors to wait for
-    CHG-2227.
+def test_renderer_readiness_gate_default_open() -> None:
+    """CHG-2227 Phase 8a flips `_BRANCHES_RENDERER_READY = True`; the gate is
+    now open by default so well-formed Workflow branches: SOPs pass validation.
     """
-    assert _BRANCHES_RENDERER_READY is False, (
-        "CHG-2226 ships with the gate CLOSED; CHG-2227 Phase 8a flips it open"
+    assert _BRANCHES_RENDERER_READY is True, (
+        "CHG-2227 Phase 8a must ship with the gate OPEN"
     )
+
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}]}]",
+        "1. Setup\n2. Decision\n3a. A path\n3b. B path\n4. After\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches)
+    assert errors == []
+
+
+def test_renderer_readiness_gate_blocks_when_flag_false(monkeypatch) -> None:
+    """When `_BRANCHES_RENDERER_READY` is patched back to False the gate still
+    blocks validation with a clear message — keeps coverage of the blocking path.
+    """
+    import fx_alfred.core.workflow as _wf
+
+    monkeypatch.setattr(_wf, "_BRANCHES_RENDERER_READY", False)
 
     body = _doc(
         "[{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}]}]",
@@ -170,22 +187,50 @@ def test_branches_valid_3way_passes_when_gate_open() -> None:
     assert errors == []
 
 
-def test_gate_fires_on_empty_field_authored() -> None:
-    """Per Codex PR #68 R2 review: ``Workflow branches: []`` (or ``null``)
-    must trigger the gate too.
+def test_empty_field_authored_passes_after_renderer_ready() -> None:
+    """With the gate open (CHG-2227 Phase 8a), ``Workflow branches: []`` no
+    longer triggers a gate error — the field is permitted.
 
-    Spec is "MUST NOT author this field until CHG-2227 lands" — authoring an
-    empty list still authors the field. Pre-fix, the gate only fired when
-    `parse_workflow_branches()` returned a non-empty list, so an SOP could
-    sneak past the gate by writing `Workflow branches: []`.
+    The gate-fires-on-empty behavior when the flag is False is retained in
+    ``test_gate_fires_on_empty_when_flag_false`` below.
     """
     body = _doc("[]", "1. A\n2. B\n3. C\n")
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
     assert branches == []  # parsed-empty
-    # Gate should still fire on field presence even though branches=[].
+    # Gate is open; no blocking errors.
+    errors = validate_branches(parsed, branches)
+    assert not any("renderer support is not yet shipped" in e.msg for e in errors)
+
+
+def test_gate_fires_on_empty_when_flag_false(monkeypatch) -> None:
+    """When `_BRANCHES_RENDERER_READY` is False, ``Workflow branches: []``
+    still triggers the gate (field-presence check, not list-emptiness check).
+    """
+    import fx_alfred.core.workflow as _wf
+
+    monkeypatch.setattr(_wf, "_BRANCHES_RENDERER_READY", False)
+
+    body = _doc("[]", "1. A\n2. B\n3. C\n")
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    assert branches == []
     errors = validate_branches(parsed, branches)
     assert any("renderer support is not yet shipped" in e.msg for e in errors)
+
+
+def test_branches_validates_after_renderer_ready() -> None:
+    """New test (CHG-2227 Phase 8a): load a branches_3way SOP shape, run
+    validate_branches, assert no errors now that the renderer is ready.
+    """
+    body = _doc(
+        "[{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}, {id: 3c, label: escalate}]}]",
+        "1. Setup\n2. Decision\n3a. Pass\n3b. Fail\n3c. Escalate\n4. Continue\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches)
+    assert errors == []
 
 
 def test_branches_legacy_loops_unaffected() -> None:


### PR DESCRIPTION
## Summary

CHG-2227 Phase 8a (Commit 8a, separately reviewable per Codex R5 advisory):

Flip `core/workflow.py:_BRANCHES_RENDERER_READY = False → True`. All renderer phases are now in main:
- ✅ Phase 3: `branch_geometry` primitive (PR #69)
- ✅ Phase 4: `dag_graph.py` nested integration (PR #70)
- ✅ Phase 5: `ascii_graph.py` flat integration (PR #71)
- ✅ Phase 7: `mermaid.py` sub-step IDs (PR #72)

`af validate` and `af plan` now accept SOPs declaring `Workflow branches:` without the "renderer support is not yet shipped" gate error.

This commit is the **cross-CHG handoff with CHG-2226**: it unblocks authoring `Workflow branches:` SOPs in the wild. Lands AFTER all renderers ship so `af plan --graph-format=both` (default) and `--graph-layout=flat` render branchy SOPs correctly — preventing the misrender vector Codex P1 caught on PR #67.

## Test changes

- 2 existing tests renamed + asserts inverted (gate now passes by default)
- 2 new tests added with `monkeypatch` to `_BRANCHES_RENDERER_READY = False` — retains full coverage of the blocking path so future regressions don't go silent
- 1 new test `test_branches_validates_after_renderer_ready` — loads a 3-way branch fixture, runs `validate_branches`, asserts no errors
- 3 plan-gate tests updated to monkeypatch the flag back to False (preserves blocking coverage)

## Test plan

- [x] Full suite: 832/832 pass
- [x] Pyright: 0 errors
- [x] Ruff: clean
- [x] Existing gate-blocking coverage preserved via monkeypatch
- [x] New "validation passes" test covers the new default state

## Next phases (NOT in this PR)

- Phase 8b: docs + version bump 1.7.1 → 1.8.0 + add `wcwidth` to dependencies
- Phase 9: multi-model code review
- Phase 10: PyPI release with manual smoke test