### PR TITLE
chore(FXA-2227): docs + version bump v1.7.1 → v1.8.0 (Phase 8b)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project
 
-- **Package:** fx-alfred v1.6.1
+- **Package:** fx-alfred v1.8.0
 - **Description:** Alfred — Agent Runbook: workflow routing, SOP checklists, and document management
 - **Language:** Python 3.10+, Click 8.0+
 - **Entry point:** `af = fx_alfred.cli:cli`
@@ -129,6 +129,7 @@ af list --root /Users/frank/Projects/alfred/fx_alfred
 - **Before every task:** Declare active SOP per COR-1402 before starting work (or flag if none exist)
 - **Workflow checklist:** `af plan <SOP_IDs>` (LLM-optimized, follow each phase)
 - **First time:** `af setup` (suggested prompts for agent config)
+- **Workflow branches:** SOPs can declare `Workflow branches:` metadata to express branching task flows (e.g., "do EITHER A or B"). `af plan --graph` renders these as ASCII/Mermaid branch diagrams. Branch targets use step indices; sub-steps use `{phase}.{step}{letter}` notation (e.g., `3.1a`).
 - **Routing:** COR-1103 (PKG) → ALF-2207 (USR) → FXA-2125 (PRJ)
 - All code changes go through `/trinity` dispatch (GLM = Worker, Codex/Gemini = Reviewer)
 - TDD mandatory: COR-1500 (Red-Green-Refactor)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.7.1"
+version = "1.8.0"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## v1.8.0 (2026-04-29)
+
+Feature release: branching ASCII rendering in `af plan --graph`, Mermaid sub-step IDs, and breaking `todo[].index` format extension.
+
+### Added
+
+- **Branching ASCII rendering** — `af plan --graph` supports nested and flat branch layouts driven by SOP `Workflow branches:` metadata. Three-way Audit Ledger goldens prove geometry invariants. (CHG-2226, CHG-2227)
+- **Mermaid sub-step IDs** — Mermaid output now includes sub-step nodes (`S1_3a`, `S1_3b`, `S1_3c`) with edges connecting parent → siblings → convergence, matching the ASCII renderer. (CHG-2227 Phase 7)
+- **`wcwidth` dependency** — declared explicitly (was previously transitive via `branch_geometry`).
+
+### Changed
+
+- **`_BRANCHES_RENDERER_READY` defaults to `True`** — `af plan --graph` renders branches by default when SOPs declare `Workflow branches:`. (CHG-2227 Phase 8a)
+- **`af validate` accepts `Workflow branches:` SOPs** — validator recognizes the new `Workflow branches:` metadata block. (CHG-2226)
+
+### Breaking
+
+- **`todo[].index` format extends from `^\\d+\\.\\d+$` to `^\\d+\\.\\d+[a-z]?$`** — sub-step IDs (e.g., `3.1a`) are now valid indices. Consumers parsing this with strict numeric regex must update.
+
+### Internal
+
+- New modules: `core/branch_geometry.py`, `core/branch_layout.py`, plus branching integration in `core/dag_graph.py`, `core/ascii_graph.py`, `core/mermaid.py`, `core/workflow.py`, `core/phases.py`.
+- 835 tests passing, pyright 0 errors, ruff clean.
+
+### Install / Upgrade
+
+```bash
+pip install fx-alfred==1.8.0       # install specific version
+pipx install fx-alfred              # first install
+pipx upgrade fx-alfred              # upgrade existing
+```
+
 ## v1.7.1 (2026-04-26)
 
 Patch release: housekeeping migration to resolve a duplicate-ACID block and consolidate the PRJ document namespace. No CLI behavior changes.


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` version `1.7.1` → `1.8.0`
- Adds v1.8.0 entry to `CHANGELOG.md` with breaking-change notice for `todo[].index` format
- Updates `CLAUDE.md` with `Workflow branches:` authoring note + version string

## Diff
3 files changed, 35 insertions(+), 2 deletions(-)

## Test plan
- [x] 835/835 tests pass
- [x] pyright 0 errors
- [x] ruff check clean

## Breaking change documented
`todo[].index` format extends from `^\d+\.\d+$` to `^\d+\.\d+[a-z]?$` (sub-step IDs). Consumers with strict numeric regex must update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)