### PR TITLE
feat(FXA-2231): Phase 0 — scaffolding placeholders + .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,8 @@ site/
 .omx/
 .factory/
 
+# Activity logs (per PRP-2230) — per-machine artifacts, never commit
+rules/logs/
+
 # macOS
 .DS_Store

--- a/hooks/emit-activity.sh
+++ b/hooks/emit-activity.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Reference Claude Code Stop hook for the Alfred activity log protocol.
+#
+# Per PRP-2230 + CHG-2231 Phase 5: emits one task.done event per Claude
+# Code turn via `af log ... || true` (fail-open at the hook boundary —
+# emit failure cannot break a coding session).
+#
+# Per PRP-2230 §Decisions §"session_id and agent_version: agent-provided
+# when available, sentinel fallback":
+#   - $ALFRED_SESSION_ID is read by `af log` if exported (preserves
+#     cross-tool correlation when harness exposes a stable session id);
+#     otherwise UUIDv4 is generated.
+#   - $ALFRED_AGENT_VERSION is read by `af log` if exported; otherwise
+#     the literal sentinel "unknown" is used.
+#
+# This file is a Phase 0 scaffolding placeholder per CHG-2231 §Phase 0;
+# the actual emit-activity invocation lands with the Phase 5
+# implementation, alongside settings.json hook registration and the
+# integration smoke test.
+
+# Phase 5 will replace this with the live invocation:
+# af log "${CLAUDE_TURN_DESCRIPTION:-claude-code turn complete}" \
+#   --event task.done \
+#   --agent claude-code \
+#   --agent-version "${CLAUDE_VERSION:-unknown}" \
+#   || true
+
+exit 0

--- a/src/fx_alfred/commands/log_archive_cmd.py
+++ b/src/fx_alfred/commands/log_archive_cmd.py
@@ -1,0 +1,23 @@
+"""Click command for `af log-archive` — explicit archival.
+
+Per PRP-2230 §"`af log-archive`" (lines 174–196 of merged spec). Calls
+`core/activity_log.archive_directory()` on the resolved log directory.
+Implements the 5-step §Archival procedure: step 0 `fcntl.flock` lock
+(try-lock-and-skip on contention), step 1 build
+`archive.zip.tmp.<pid>.<rand6>`, step 2 `os.replace`, step 3 unlink raw
+files with self-healing on partial failure, step 4 PID-based stale
+tmpfile cleanup.
+
+CLI options: `--root <DIR>` (layer resolution), `--force` (overwrite
+corrupt existing archive). Exit codes: 0 (archived or nothing to do),
+2 (invalid CLI args), 4 (filesystem error), 5 (corrupt archive without
+--force). Standalone lock-contention behavior: exit code 0 with stderr
+"another archiver is running, skipping" (preserves try-lock-and-skip
+semantics consistent with lazy `af log` path; avoids blocking cron/CI).
+
+Implementation lands in CHG-2231 Phase 4 with 12 TDD tests (8 archive
+behavior + 4 scanner-skip enforcement regression tests).
+
+This file is a Phase 0 scaffolding placeholder per CHG-2231 §Phase 0;
+NOT wired into `cli.py` yet.
+"""

--- a/src/fx_alfred/commands/log_cmd.py
+++ b/src/fx_alfred/commands/log_cmd.py
@@ -1,0 +1,11 @@
+"""Click command for `af log` — universal activity-log writer.
+
+Per PRP-2230 §"`af log`" (lines 119–148 of merged spec). Implementation lands
+in CHG-2231 Phase 2 with 18 TDD tests covering layer resolution, auto-fill,
+line-size cap with summary_truncated, pre-condition rotation, lazy startup
+archival, exit codes, fail-open mode.
+
+This file is a Phase 0 scaffolding placeholder per CHG-2231 §Phase 0; it is
+NOT wired into `cli.py`'s LazyGroup yet (registration lands with the Phase 2
+implementation).
+"""

--- a/src/fx_alfred/commands/log_validate_cmd.py
+++ b/src/fx_alfred/commands/log_validate_cmd.py
@@ -1,0 +1,12 @@
+"""Click command for `af log-validate` — activity-log schema checker.
+
+Per PRP-2230 §"`af log-validate`" (lines 150–172 of merged spec).
+Transparent reader for both loose `*.jsonl` and entries inside
+`archive.zip` via `core/activity_log.iter_records()`. Implementation
+lands in CHG-2231 Phase 3 with 16 TDD tests including zip-aware paths
+and `archive.zip::<member>:<lineno>:` violation notation.
+
+This file is a Phase 0 scaffolding placeholder per CHG-2231 §Phase 0;
+NOT wired into `cli.py` yet (registration lands with the Phase 3
+implementation).
+"""

--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -1,0 +1,20 @@
+"""Activity log schema, validator, reader, and archive helpers.
+
+Framework-agnostic implementation of PRP-2230 (Agent Activity Log Protocol v1).
+Click-free per FXA-2230 Decisions §"vendor-neutral protocol" — Click wrappers
+live in `commands/log_cmd.py`, `commands/log_validate_cmd.py`,
+`commands/log_archive_cmd.py`.
+
+Phase 2 (af log) populates: SCHEMA_LITERAL, AGENT_WHITELIST, EVENT_ENUM,
+RECORD_LINE_CAP_BYTES, FILE_SIZE_CAP_BYTES, RETENTION_DAYS_DEFAULT,
+DIR_SOFT_CAP_BYTES, validate_record(), compose_record().
+
+Phase 3 (af log-validate) populates: iter_records() — transparent
+loose-jsonl + archive.zip union reader.
+
+Phase 4 (af log-archive) populates: archive_directory() — atomic 5-step
+procedure (flock + tmpfile + os.replace + unlink + cleanup) per
+PRP-2230 §Archival.
+
+This file is a Phase 0 scaffolding placeholder per CHG-2231 §Phase 0.
+"""


### PR DESCRIPTION
## Summary

Implements **CHG-2231 Phase 0** per the merged spec at `rules/FXA-2231-CHG-Agent-Activity-Log-Protocol-v1-Implementation.md` § Phase 0 — Branch + scaffolding.

Five empty/docstring-only placeholder files so subsequent phases (1 docs, 2 `af log`, 3 `af log-validate`, 4 `af log-archive`, 5 reference hook + release) can stage individually without rebase conflicts.

## Files added (5 placeholders)

| File | Phase that fills it | Lines |
|---|---|---|
| `src/fx_alfred/core/activity_log.py` | 2/3/4 (schema + validator + reader + archive helpers, Click-free) | docstring only |
| `src/fx_alfred/commands/log_cmd.py` | 2 (`af log` writer) | docstring only |
| `src/fx_alfred/commands/log_validate_cmd.py` | 3 (`af log-validate`) | docstring only |
| `src/fx_alfred/commands/log_archive_cmd.py` | 4 (`af log-archive`) | docstring only |
| `hooks/emit-activity.sh` | 5 (reference Claude Code `Stop` hook) | docstring + `exit 0` |

Each placeholder docstring refers to the relevant PRP-2230 section + the CHG-2231 phase that will populate it. They are **NOT** yet wired into `cli.py`'s `LazyGroup` — command registration lands with each phase's actual implementation.

## File modified

| File | Change |
|---|---|
| `.gitignore` | Adds `rules/logs/` per PRP-2230 default git policy (activity logs are per-machine artifacts, never committed) |

## Verification

- ✅ All 4 Python modules importable: `from fx_alfred.core import activity_log; from fx_alfred.commands import log_cmd, log_validate_cmd, log_archive_cmd`
- ✅ `af list` and `af validate` unchanged behavior (182 docs, 0 issues)
- ✅ `hooks/emit-activity.sh` is executable and exits 0 cleanly
- ⚠️ Pre-existing pytest collection error (`ModuleNotFoundError: wcwidth`) is unrelated — Phase 0 introduces no new tests and changes no behavior. To be addressed separately if it blocks CI; my local `.venv` appears stale on `pip install -e .`

## Test plan

- [x] Imports verify (placeholder modules don't break Python's import machinery)
- [x] `af` CLI surface unchanged
- [x] No new commands wired (Phase 2/3/4 will register `log`, `log-validate`, `log-archive` via `LazyGroup` when they actually implement)
- [x] No tests added (TDD red-green commits start in Phase 2)
- [ ] After merge: open Phase 1 PR (docs-only — `COR-1205` REF + `COR-1206` SOP + `COR-1200` additive bullet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)