### PR TITLE
feat(FXA-2231): Phase 1 — COR-1205 REF + COR-1206 SOP + COR-1200 retrospective bullet

### DIFF
--- a/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
+++ b/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
@@ -1,8 +1,8 @@
 # REF-0000: Document Index
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-04-04
-**Last reviewed:** 2026-03-19
+**Last updated:** 2026-05-02
+**Last reviewed:** 2026-05-02
 **Status:** Active
 
 ---
@@ -25,6 +25,8 @@ A reference index of all documents in the COR system.
 | 1102 | SOP | Create Proposal |
 | 1200 | SOP | Session Retrospective |
 | 1201 | SOP | Discussion Tracking |
+| 1205 | REF | Agent Activity Log Format |
+| 1206 | SOP | Emit Agent Activity |
 | 1300 | SOP | Update Document |
 | 1301 | SOP | Deprecate Document |
 | 1302 | SOP | Maintain Document Index |

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -60,6 +60,11 @@ TODAY=$(date -u +%F)
 YESTERDAY=$(date -u -d 'yesterday' +%F 2>/dev/null \
             || date -u -v-1d +%F)   # GNU first (-d), BSD/macOS fallback (-v-1d)
 
+# Define the event-extraction jq filter once and reuse for today + yesterday.
+JQ_FILTER='select(.event == "task.done" or .event == "doc.created"
+                  or .event == "doc.updated" or .event == "decision")
+           | "\(.ts)  \(.event)  \(.summary)\(if .refs then "  refs=" + (.refs|join(",")) else "" end)"'
+
 # 1. (Optional) Verify schema before relying on the log. Quiet on success,
 #    prints "<path>:<lineno>: <field>: <reason>" on violations.
 #    Validating the directory picks up today's .jsonl, any .partN.jsonl
@@ -67,18 +72,23 @@ YESTERDAY=$(date -u -d 'yesterday' +%F 2>/dev/null \
 af log-validate ./rules/logs/
 
 # 2. Read today's event stream. JSONL is one-per-line so plain jq works.
-#    Glob across ${TODAY}.jsonl AND any ${TODAY}.partN.jsonl rollover so
-#    high-volume sessions don't silently drop events. The 2>/dev/null
-#    suppresses jq's "file not found" when no rollover happened today.
-jq -r 'select(.event == "task.done" or .event == "doc.created"
-              or .event == "doc.updated" or .event == "decision")
-       | "\(.ts)  \(.event)  \(.summary)\(if .refs then "  refs=" + (.refs|join(",")) else "" end)"' \
-   ./rules/logs/${TODAY}.jsonl ./rules/logs/${TODAY}.part*.jsonl 2>/dev/null
+#    Concatenate ${TODAY}.jsonl AND any ${TODAY}.partN.jsonl rollover with
+#    explicit existence guards so the recipe stays `set -e` safe whether or
+#    not rollover happened. (The earlier shell-glob form was unsafe: bash
+#    leaves an unmatched glob literal, jq fails to open it, and the non-zero
+#    exit propagates through `set -e`.)
+{
+  if [ -e "./rules/logs/${TODAY}.jsonl" ]; then cat "./rules/logs/${TODAY}.jsonl"; fi
+  for f in ./rules/logs/${TODAY}.part*.jsonl; do
+    if [ -e "$f" ]; then cat "$f"; fi
+  done
+} | jq -r "$JQ_FILTER"
 
 # 3. Yesterday's records (after archival). `unzip -p` accepts globs, so
 #    "${YESTERDAY}*.jsonl" picks up ${YESTERDAY}.jsonl AND any
-#    ${YESTERDAY}.partN.jsonl entries inside archive.zip:
-unzip -p ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" | jq -r '...'
+#    ${YESTERDAY}.partN.jsonl entries inside archive.zip. Reuse $JQ_FILTER
+#    instead of an ellipsis placeholder.
+unzip -p ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" | jq -r "$JQ_FILTER"
 ```
 
 Note: `af log-validate` is a **schema checker** (quiet on success, emits only violations); it does not output the event stream itself. Read the JSONL bytes via `jq` (or `cat`) to extract events. The glob in step 2 covers both the base `<today>.jsonl` and any `<today>.partN.jsonl` rollover segments per COR-1205 §Rotation; `2>/dev/null` suppresses jq's "file not found" when no rollover happened. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both **scaffolded in CHG-2231 Phase 0**; mandatory triggers and CLI surfaces land across Phases 2–5; target release v1.9.0.)*

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -54,25 +54,31 @@ See COR-1201 (Discussion Tracking) for the full D item protocol.
 Two-step recipe — validate first (optional schema check), then read:
 
 ```bash
+# Resolve UTC dates (cross-platform — GNU date on Linux, BSD date on macOS).
+# These are real shell variables; the recipe is copy-paste runnable.
+TODAY=$(date -u +%F)
+YESTERDAY=$(date -u -d 'yesterday' +%F 2>/dev/null \
+            || date -u -v-1d +%F)   # GNU first (-d), BSD/macOS fallback (-v-1d)
+
 # 1. (Optional) Verify schema before relying on the log. Quiet on success,
 #    prints "<path>:<lineno>: <field>: <reason>" on violations.
-#    Note the glob: today's file may have rolled over to .partN.jsonl
-#    once it hit the 8 MiB cap (per COR-1205 §Rotation).
+#    Validating the directory picks up today's .jsonl, any .partN.jsonl
+#    rollover (per COR-1205 §Rotation), and entries inside archive.zip.
 af log-validate ./rules/logs/
 
-# 2. Read the event stream. The record JSON is one-per-line so plain
-#    jq filtering works. Glob across <today>.jsonl AND any
-#    <today>.partN.jsonl rollover segments so high-volume sessions
-#    don't silently drop events.
+# 2. Read today's event stream. JSONL is one-per-line so plain jq works.
+#    Glob across ${TODAY}.jsonl AND any ${TODAY}.partN.jsonl rollover so
+#    high-volume sessions don't silently drop events. The 2>/dev/null
+#    suppresses jq's "file not found" when no rollover happened today.
 jq -r 'select(.event == "task.done" or .event == "doc.created"
               or .event == "doc.updated" or .event == "decision")
        | "\(.ts)  \(.event)  \(.summary)\(if .refs then "  refs=" + (.refs|join(",")) else "" end)"' \
-   ./rules/logs/<today>.jsonl ./rules/logs/<today>.part*.jsonl 2>/dev/null
+   ./rules/logs/${TODAY}.jsonl ./rules/logs/${TODAY}.part*.jsonl 2>/dev/null
 
-# Yesterday's records (after archival) — `unzip -p` accepts globs, so
-# this picks up <yesterday>.jsonl AND any <yesterday>.partN.jsonl
-# entries inside archive.zip:
-unzip -p ./rules/logs/archive.zip '<yesterday>*.jsonl' | jq -r '...'
+# 3. Yesterday's records (after archival). `unzip -p` accepts globs, so
+#    "${YESTERDAY}*.jsonl" picks up ${YESTERDAY}.jsonl AND any
+#    ${YESTERDAY}.partN.jsonl entries inside archive.zip:
+unzip -p ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" | jq -r '...'
 ```
 
 Note: `af log-validate` is a **schema checker** (quiet on success, emits only violations); it does not output the event stream itself. Read the JSONL bytes via `jq` (or `cat`) to extract events. The glob in step 2 covers both the base `<today>.jsonl` and any `<today>.partN.jsonl` rollover segments per COR-1205 §Rotation; `2>/dev/null` suppresses jq's "file not found" when no rollover happened. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both **scaffolded in CHG-2231 Phase 0**; mandatory triggers and CLI surfaces land across Phases 2–5; target release v1.9.0.)*

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -88,7 +88,18 @@ af log-validate ./rules/logs/
 #    "${YESTERDAY}*.jsonl" picks up ${YESTERDAY}.jsonl AND any
 #    ${YESTERDAY}.partN.jsonl entries inside archive.zip. Reuse $JQ_FILTER
 #    instead of an ellipsis placeholder.
-unzip -p ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" | jq -r "$JQ_FILTER"
+#
+#    Guards required for `set -euo pipefail` callers: unzip exits non-zero
+#    when archive.zip is absent (fresh project) OR when no entries match
+#    the glob (quiet day) — both are normal states, not errors. The two-
+#    stage check below silently skips both cases and only invokes unzip -p
+#    when there is something to read. Real corruption / IO errors still
+#    surface because `unzip -l ... >/dev/null 2>&1` returns non-zero only
+#    when the operation truly failed.
+if [ -e "./rules/logs/archive.zip" ] \
+   && unzip -l ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" >/dev/null 2>&1; then
+  unzip -p ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" | jq -r "$JQ_FILTER"
+fi
 ```
 
 Note: `af log-validate` is a **schema checker** (quiet on success, emits only violations); it does not output the event stream itself. Read the JSONL bytes via `jq` (or `cat`) to extract events. The glob in step 2 covers both the base `<today>.jsonl` and any `<today>.partN.jsonl` rollover segments per COR-1205 §Rotation; `2>/dev/null` suppresses jq's "file not found" when no rollover happened. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both **scaffolded in CHG-2231 Phase 0**; mandatory triggers and CLI surfaces land across Phases 2–5; target release v1.9.0.)*

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -49,7 +49,27 @@ See COR-1201 (Discussion Tracking) for the full D item protocol.
 
 ### 1. List all actions taken this session
 
-**Before reconstructing actions:** if `./rules/logs/<today UTC>.jsonl` exists (or `./rules/logs/archive.zip` contains today's entry), read it via `af log-validate` (verifies schema) and use its `task.done` / `doc.created` / `doc.updated` / `decision` events as the ground truth for what happened this session. The chat-history reconstruction below remains the fallback when the log is empty or absent. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both new in v1.9.0.)*
+**Before reconstructing actions:** if `./rules/logs/<today UTC>.jsonl` exists (or today's entry is inside `./rules/logs/archive.zip`), read its event records as the ground truth for what happened this session. Use the records' `task.done` / `doc.created` / `doc.updated` / `decision` events to populate "Actions Taken" below; the chat-history reconstruction is the fallback when the log is empty or absent.
+
+Two-step recipe — validate first (optional schema check), then read:
+
+```bash
+# 1. (Optional) Verify schema before relying on the log. Quiet on success,
+#    prints "<path>:<lineno>: <field>: <reason>" on violations.
+af log-validate ./rules/logs/<today>.jsonl
+
+# 2. Read the event stream. The record JSON is one-per-line so plain
+#    jq filtering works; the same form works on archive.zip via unzip -p.
+jq -r 'select(.event == "task.done" or .event == "doc.created"
+              or .event == "doc.updated" or .event == "decision")
+       | "\(.ts)  \(.event)  \(.summary)\(if .refs then "  refs=" + (.refs|join(",")) else "" end)"' \
+   ./rules/logs/<today>.jsonl
+
+# Yesterday's records (after archival) — pipe through unzip:
+unzip -p ./rules/logs/archive.zip '<yesterday>.jsonl' | jq -r '...'
+```
+
+Note: `af log-validate` is a **schema checker** (quiet on success, emits only violations); it does not output the event stream itself. Read the JSONL bytes via `jq` (or `cat`) to extract events. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both new in v1.9.0.)*
 
 Review the conversation and list every meaningful action:
 - Files created, edited, or deleted

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -82,7 +82,17 @@ JQ_FILTER='select(
 #    prints "<path>:<lineno>: <field>: <reason>" on violations.
 #    Validating the directory picks up today's .jsonl, any .partN.jsonl
 #    rollover (per COR-1205 §Rotation), and entries inside archive.zip.
-af log-validate ./rules/logs/
+#
+#    Feature-check guard: `af log-validate` ships in CHG-2231 Phase 3
+#    (target v1.9.0). Before then the subcommand isn't registered, so a
+#    bare invocation halts `set -e` callers. The check below silently
+#    skips validation when the command isn't available — the actual log
+#    read in step 2 still runs.
+if af log-validate --help >/dev/null 2>&1; then
+  af log-validate ./rules/logs/
+else
+  echo "INFO: af log-validate not yet available (CHG-2231 Phase 3 not shipped); skipping schema check" >&2
+fi
 
 # 2. Read today's event stream. JSONL is one-per-line so plain jq works.
 #    Concatenate ${TODAY}.jsonl AND any ${TODAY}.partN.jsonl rollover with

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -56,20 +56,26 @@ Two-step recipe — validate first (optional schema check), then read:
 ```bash
 # 1. (Optional) Verify schema before relying on the log. Quiet on success,
 #    prints "<path>:<lineno>: <field>: <reason>" on violations.
-af log-validate ./rules/logs/<today>.jsonl
+#    Note the glob: today's file may have rolled over to .partN.jsonl
+#    once it hit the 8 MiB cap (per COR-1205 §Rotation).
+af log-validate ./rules/logs/
 
 # 2. Read the event stream. The record JSON is one-per-line so plain
-#    jq filtering works; the same form works on archive.zip via unzip -p.
+#    jq filtering works. Glob across <today>.jsonl AND any
+#    <today>.partN.jsonl rollover segments so high-volume sessions
+#    don't silently drop events.
 jq -r 'select(.event == "task.done" or .event == "doc.created"
               or .event == "doc.updated" or .event == "decision")
        | "\(.ts)  \(.event)  \(.summary)\(if .refs then "  refs=" + (.refs|join(",")) else "" end)"' \
-   ./rules/logs/<today>.jsonl
+   ./rules/logs/<today>.jsonl ./rules/logs/<today>.part*.jsonl 2>/dev/null
 
-# Yesterday's records (after archival) — pipe through unzip:
-unzip -p ./rules/logs/archive.zip '<yesterday>.jsonl' | jq -r '...'
+# Yesterday's records (after archival) — `unzip -p` accepts globs, so
+# this picks up <yesterday>.jsonl AND any <yesterday>.partN.jsonl
+# entries inside archive.zip:
+unzip -p ./rules/logs/archive.zip '<yesterday>*.jsonl' | jq -r '...'
 ```
 
-Note: `af log-validate` is a **schema checker** (quiet on success, emits only violations); it does not output the event stream itself. Read the JSONL bytes via `jq` (or `cat`) to extract events. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both new in v1.9.0.)*
+Note: `af log-validate` is a **schema checker** (quiet on success, emits only violations); it does not output the event stream itself. Read the JSONL bytes via `jq` (or `cat`) to extract events. The glob in step 2 covers both the base `<today>.jsonl` and any `<today>.partN.jsonl` rollover segments per COR-1205 §Rotation; `2>/dev/null` suppresses jq's "file not found" when no rollover happened. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both **scaffolded in CHG-2231 Phase 0**; mandatory triggers and CLI surfaces land across Phases 2–5; target release v1.9.0.)*
 
 Review the conversation and list every meaningful action:
 - Files created, edited, or deleted

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -60,10 +60,23 @@ TODAY=$(date -u +%F)
 YESTERDAY=$(date -u -d 'yesterday' +%F 2>/dev/null \
             || date -u -v-1d +%F)   # GNU first (-d), BSD/macOS fallback (-v-1d)
 
-# Define the event-extraction jq filter once and reuse for today + yesterday.
-JQ_FILTER='select(.event == "task.done" or .event == "doc.created"
-                  or .event == "doc.updated" or .event == "decision")
-           | "\(.ts)  \(.event)  \(.summary)\(if .refs then "  refs=" + (.refs|join(",")) else "" end)"'
+# Resolve THIS session's id so cross-tool contamination is filtered out
+# (multiple agent sessions can share a UTC day). If $ALFRED_SESSION_ID
+# wasn't exported during the session, leave SID empty — the filter falls
+# back to whole-day view (with a caveat: results may include other agents'
+# work). Tip to find your session_id retroactively:
+#   jq -r '.session_id' ./rules/logs/${TODAY}.jsonl | sort -u
+SID="${ALFRED_SESSION_ID:-}"
+
+# Event-extraction jq filter, parameterised by --arg sid:
+#   - When $sid is non-empty, only records with matching session_id pass
+#   - When $sid is empty, all records pass (whole-day view)
+JQ_FILTER='select(
+    (.event == "task.done" or .event == "doc.created"
+     or .event == "doc.updated" or .event == "decision")
+    and ($sid == "" or .session_id == $sid)
+  )
+  | "\(.ts)  \(.event)  \(.summary)\(if .refs then "  refs=" + (.refs|join(",")) else "" end)"'
 
 # 1. (Optional) Verify schema before relying on the log. Quiet on success,
 #    prints "<path>:<lineno>: <field>: <reason>" on violations.
@@ -74,35 +87,43 @@ af log-validate ./rules/logs/
 # 2. Read today's event stream. JSONL is one-per-line so plain jq works.
 #    Concatenate ${TODAY}.jsonl AND any ${TODAY}.partN.jsonl rollover with
 #    explicit existence guards so the recipe stays `set -e` safe whether or
-#    not rollover happened. (The earlier shell-glob form was unsafe: bash
-#    leaves an unmatched glob literal, jq fails to open it, and the non-zero
-#    exit propagates through `set -e`.)
+#    not rollover happened.
 {
   if [ -e "./rules/logs/${TODAY}.jsonl" ]; then cat "./rules/logs/${TODAY}.jsonl"; fi
   for f in ./rules/logs/${TODAY}.part*.jsonl; do
     if [ -e "$f" ]; then cat "$f"; fi
   done
-} | jq -r "$JQ_FILTER"
+} | jq -r --arg sid "$SID" "$JQ_FILTER"
 
 # 3. Yesterday's records (after archival). `unzip -p` accepts globs, so
 #    "${YESTERDAY}*.jsonl" picks up ${YESTERDAY}.jsonl AND any
-#    ${YESTERDAY}.partN.jsonl entries inside archive.zip. Reuse $JQ_FILTER
-#    instead of an ellipsis placeholder.
+#    ${YESTERDAY}.partN.jsonl entries inside archive.zip.
 #
-#    Guards required for `set -euo pipefail` callers: unzip exits non-zero
-#    when archive.zip is absent (fresh project) OR when no entries match
-#    the glob (quiet day) — both are normal states, not errors. The two-
-#    stage check below silently skips both cases and only invokes unzip -p
-#    when there is something to read. Real corruption / IO errors still
-#    surface because `unzip -l ... >/dev/null 2>&1` returns non-zero only
-#    when the operation truly failed.
-if [ -e "./rules/logs/archive.zip" ] \
-   && unzip -l ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" >/dev/null 2>&1; then
-  unzip -p ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" | jq -r "$JQ_FILTER"
+#    Three-state guard distinguishing real errors from benign skip cases:
+#    (a) no archive.zip → silent skip (fresh project / first day)
+#    (b) archive corrupt or unreadable → STDERR warning + don't halt
+#        (we do NOT want a corrupt archive to block today's retrospective;
+#        the warning surfaces the issue without losing the rest of the run)
+#    (c) archive readable but no <yesterday>*.jsonl entry → silent skip
+#        (quiet day — normal state, not an error)
+#    (d) archive readable AND has matching entries → extract
+#
+#    The previous one-liner form (`if [ -e ] && unzip -l ... >/dev/null;
+#    then ... fi`) collapsed (b) and (c) into the same false branch and
+#    silently dropped corruption errors — that masking is now gone.
+if [ -e "./rules/logs/archive.zip" ]; then
+  if ! unzip -l ./rules/logs/archive.zip >/dev/null 2>&1; then
+    echo "WARNING: ./rules/logs/archive.zip exists but is unreadable" \
+         "(corruption / IO error / permission). Yesterday's records skipped." \
+         "Recover: af log-archive --force." >&2
+  elif unzip -l ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" >/dev/null 2>&1; then
+    unzip -p ./rules/logs/archive.zip "${YESTERDAY}*.jsonl" \
+      | jq -r --arg sid "$SID" "$JQ_FILTER"
+  fi
 fi
 ```
 
-Note: `af log-validate` is a **schema checker** (quiet on success, emits only violations); it does not output the event stream itself. Read the JSONL bytes via `jq` (or `cat`) to extract events. The glob in step 2 covers both the base `<today>.jsonl` and any `<today>.partN.jsonl` rollover segments per COR-1205 §Rotation; `2>/dev/null` suppresses jq's "file not found" when no rollover happened. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both **scaffolded in CHG-2231 Phase 0**; mandatory triggers and CLI surfaces land across Phases 2–5; target release v1.9.0.)*
+Note: `af log-validate` is a **schema checker** (quiet on success, emits only violations); it does not output the event stream itself. Read the JSONL bytes via `jq` (or `cat`) to extract events. The glob in step 2 covers both the base `<today>.jsonl` and any `<today>.partN.jsonl` rollover segments per COR-1205 §Rotation. The `--arg sid` parameter constrains output to the current session when `$ALFRED_SESSION_ID` is exported; otherwise the recipe shows the whole-day view (call out that other agents' work may be mixed in). *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both **scaffolded in CHG-2231 Phase 0**; mandatory triggers and CLI surfaces land across Phases 2–5; target release v1.9.0.)*
 
 Review the conversation and list every meaningful action:
 - Files created, edited, or deleted

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -49,6 +49,8 @@ See COR-1201 (Discussion Tracking) for the full D item protocol.
 
 ### 1. List all actions taken this session
 
+**Before reconstructing actions:** if `./rules/logs/<today UTC>.jsonl` exists (or `./rules/logs/archive.zip` contains today's entry), read it via `af log-validate` (verifies schema) and use its `task.done` / `doc.created` / `doc.updated` / `decision` events as the ground truth for what happened this session. The chat-history reconstruction below remains the fallback when the log is empty or absent. *(See COR-1205 for the activity log format and COR-1206 for the per-agent emit protocol — both new in v1.9.0.)*
+
 Review the conversation and list every meaningful action:
 - Files created, edited, or deleted
 - Commands run

--- a/src/fx_alfred/rules/COR-1205-REF-Agent-Activity-Log-Format.md
+++ b/src/fx_alfred/rules/COR-1205-REF-Agent-Activity-Log-Format.md
@@ -12,7 +12,7 @@
 
 The canonical data contract for the Alfred activity log protocol. Defines the on-disk format, schema (`alfred.activity/v1`), required + optional fields, event enum, file rotation, archival procedure, and operational constraints. Any coding agent — Claude Code, GitHub Copilot, Cursor, Cline, Aider, Codex CLI, Gemini CLI, or any future tool — emits structured events to this format so "what was done in this session" becomes machine-readable across tools.
 
-This document defines the **format**. The **emit protocol** (mandatory triggers, per-agent integration recipes, scanner-skip enforcement) lives in COR-1206. The **CLI surfaces** that read and write this format are `af log`, `af log-validate`, `af log-archive` (shipped in fx-alfred v1.9.0).
+This document defines the **format**. The **emit protocol** (mandatory triggers, per-agent integration recipes, scanner-skip enforcement) lives in COR-1206. The **CLI surfaces** that read and write this format are `af log`, `af log-validate`, `af log-archive` — **scaffolded in CHG-2231 Phase 0 and implemented across Phases 2–5; target release v1.9.0**. Until those phases land in `main`, the commands are placeholder modules and `af <log|log-validate|log-archive>` will return non-zero (command not registered); this REF still describes the eventual contract authoritatively.
 
 ---
 

--- a/src/fx_alfred/rules/COR-1205-REF-Agent-Activity-Log-Format.md
+++ b/src/fx_alfred/rules/COR-1205-REF-Agent-Activity-Log-Format.md
@@ -1,0 +1,210 @@
+# REF-1205: Agent Activity Log Format
+
+**Applies to:** All projects using the COR document system
+**Last updated:** 2026-05-02
+**Last reviewed:** 2026-05-02
+**Status:** Active
+**Related:** COR-1206 (Emit Agent Activity SOP), COR-1200 (Session Retrospective — log consumer), PRP-2230 (originating proposal)
+
+---
+
+## What Is It?
+
+The canonical data contract for the Alfred activity log protocol. Defines the on-disk format, schema (`alfred.activity/v1`), required + optional fields, event enum, file rotation, archival procedure, and operational constraints. Any coding agent — Claude Code, GitHub Copilot, Cursor, Cline, Aider, Codex CLI, Gemini CLI, or any future tool — emits structured events to this format so "what was done in this session" becomes machine-readable across tools.
+
+This document defines the **format**. The **emit protocol** (mandatory triggers, per-agent integration recipes, scanner-skip enforcement) lives in COR-1206. The **CLI surfaces** that read and write this format are `af log`, `af log-validate`, `af log-archive` (shipped in fx-alfred v1.9.0).
+
+---
+
+## Why
+
+Without a stable cross-tool format, each agent's session work lives in a private store and `COR-1200` step 1 reduces to chat-history recollection. Standardizing the format unlocks:
+- Shared session memory across agents (Claude Code morning, Cursor afternoon, Copilot evening — one trail).
+- Replay-not-recall retrospectives (`COR-1200` step 1 reads the log).
+- Forensic auditability of agent behavior (append-only, schema-validated, line-atomic).
+
+---
+
+## Storage Location
+
+- **PRJ layer**: `./rules/logs/YYYY-MM-DD.jsonl` (one file per UTC day in the project)
+- **USR layer fallback**: `~/.alfred/logs/YYYY-MM-DD.jsonl` when no project context resolves
+
+The `rules/logs/` subtree is **reserved**: all `af` document scanners — present (`af list`, `af search`, `af status`, `af validate`) and any future scanner — MUST hard-skip it (see COR-1206 for enforcement at `core/scanner.py` walk layer). Only these files are allowed under `rules/logs/`:
+- `*.jsonl` (today's loose file)
+- `*.partN.jsonl` (rolled-over segments when today exceeds 8 MiB)
+- `archive.zip` (closed-day archive)
+- `archive.zip.tmp.*` (per-process unique tmpfile during archival; see §Archival)
+
+---
+
+## Encoding
+
+UTF-8, LF line terminator, one JSON object per line, no embedded newlines, no trailing comma, **append-only**.
+
+---
+
+## Required Fields (every record)
+
+| Field | Type | Constraint |
+|---|---|---|
+| `ts` | string | RFC 3339 UTC timestamp, e.g. `"2026-05-02T14:23:11Z"` |
+| `agent` | string | One of v1 whitelist: `claude-code`, `copilot`, `cursor`, `cline`, `aider`, `codex-cli`, `gemini-cli`, `other`. Whitelist is hardcoded in the validator constant. Adding a new entry requires a new PRP. |
+| `agent_version` | string | 1–64 ASCII chars, no whitespace, no newlines. Auto-filled by `af log` from `$ALFRED_AGENT_VERSION` env var, or the literal sentinel `"unknown"` if neither flag nor env var is set. |
+| `session_id` | string | 1–128 chars, no whitespace. Auto-filled by `af log` from `$ALFRED_SESSION_ID` env var, or generated UUIDv4 if absent. |
+| `event` | string | One of v1 enum (see §Event Enum below) |
+| `summary` | string | UTF-8, 1–500 characters, no newlines, no NUL bytes |
+| `schema` | string | Exact literal `"alfred.activity/v1"` |
+
+---
+
+## Optional Fields
+
+| Field | Type | Constraint |
+|---|---|---|
+| `refs` | array of string | `PREFIX-ACID` strings, deduplicated, ≤ 16 entries |
+| `files` | array of string | Repo-relative POSIX paths, deduplicated, ≤ 32 entries |
+| `duration_ms` | integer | Non-negative, ≤ 86_400_000 (one day) |
+| `parent_event` | string | Same format as `session_id`; correlation id |
+| `agent_name` | string | **Required when `agent: "other"`**, MUST be omitted otherwise. 1–64 chars; identifies the unrecognized harness (e.g. `"qodo"`, `"continue"`). |
+| `summary_truncated` | boolean | `true` only when `af log` truncated `summary` or trimmed `files`/`refs` to fit the 4 KiB line cap. MUST be omitted otherwise. `false` is **not allowed** in v1 (absence implies no truncation). |
+
+---
+
+## v1 Event Enum
+
+| Event | Meaning |
+|---|---|
+| `session.start` | Agent session begins |
+| `session.end` | Agent session ends |
+| `task.start` | Long-running task begins (optional, for traceability) |
+| `task.done` | User-facing turn completed with non-trivial action (mandatory per turn — see COR-1206) |
+| `task.aborted` | Task abandoned mid-execution |
+| `doc.created` | Alfred document created via `af create` (`refs` SHOULD be set) |
+| `doc.updated` | Alfred document updated via `af update` / `af fmt` (`refs` SHOULD be set) |
+| `decision` | Material decision: D-item resolution, PRP convergence, scope cut |
+| `note` | Free-form fallback when no other event applies |
+
+---
+
+## Per-Record Line Size Cap (4 KiB)
+
+Each JSONL line (including the trailing `\n`) MUST be ≤ **4096 bytes**.
+
+This bound enables the multi-process atomicity guarantee: on Linux/macOS/BSD, `O_APPEND` provides per-write atomicity for regular files at the kernel level (inode lock); `PIPE_BUF` (≥ 4096) is the related guarantee for pipes/FIFOs that motivates the conservative line-size cap. The 4 KiB cap is well within atomicity windows on every supported OS.
+
+When a record would exceed the cap, `af log` truncates `summary` and trims `files` / `refs` from the end to fit, then sets the optional `summary_truncated: true` field on that record so downstream readers can detect partial data.
+
+---
+
+## Rotation (8 MiB Pre-condition)
+
+- New file per UTC calendar day.
+- The 8 MiB per-file cap is enforced as a **pre-condition** check on every append: before writing, `af log` checks `current_file_size + len(new_record_line) > 8 MiB`. If so, it rolls over to `YYYY-MM-DD.partN.jsonl` (N starts at 1, smallest unused) **before** writing.
+- As a result, no file ever exceeds 8 MiB by even one byte.
+- A purely post-condition check (the early-draft bug) would let a file grow past the cap whenever the last record straddles the boundary — that is forbidden.
+
+---
+
+## Archival (5-step procedure, atomic-replace + eventually-consistent cleanup)
+
+All closed days (any `YYYY-MM-DD.jsonl` or `YYYY-MM-DD.partN.jsonl` whose date is < today UTC) are folded into a **single `archive.zip` per log directory**, so the directory holds at most today's loose files plus `archive.zip`. The current day's file MUST stay loose because zip does not support append-atomic writes — emitting directly into a zip would force file-locking and defeat the 4 KiB / `O_APPEND` multi-process atomicity guarantee.
+
+Archival is performed by `af log` lazily (on the first invocation that detects ≥ 1 closed-day raw file) or on demand via `af log-archive`.
+
+### Procedure (5 steps)
+
+**Step 0 — Acquire archival lock (try-lock).** Acquire a POSIX advisory lock on the log directory. Reference Python form:
+
+```python
+fd = os.open(log_dir, os.O_RDONLY | os.O_DIRECTORY)
+fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)  # raises BlockingIOError on contention
+```
+
+The builtin `open()` raises `IsADirectoryError` on a directory, so `os.open()` MUST be used. **If the lock is already held by another process** (`BlockingIOError` / `EWOULDBLOCK`), **skip this archival cycle entirely** and proceed with today's append (the other archiver completes the work; closed-day files remain on disk and will be archived on the next `af log` invocation that finds the lock free).
+
+This serializes archival without blocking `af log` emit (which never touches `archive.zip` and acquires no lock). Lock holders MUST release in a `finally` clause and `os.close(fd)` after; POSIX advisory locks are released automatically on process exit (or when the last fd referencing the inode is closed), so SIGKILL is safe.
+
+The lock prevents a race where Process A enumerates closed-day files at T0, Process B enumerates a superset at T1 and archives + unlinks at T2, then A's stale enumeration at T3 would have built a tmpfile missing the entries B added — leading to data loss when A's `os.replace` overwrites B's archive.
+
+**Step 1 — Build tmpfile.** Build `archive.zip.tmp.<pid>.<rand6>` (PID + 6 random hex chars; per-process unique even in the unlikely event a misbehaving non-locked archiver runs concurrently). Contents: union of the existing archive's entries plus the closed-day raw files. Filename collisions inside the zip are deduplicated by entry name — same `<date>.jsonl` from disk overwrites the existing zip entry; this is harmless because raw files are immutable once their day closes.
+
+**Step 2 — Atomic replace (linearization point).** `os.replace(archive.zip.tmp.<pid>.<rand6>, archive.zip)`. POSIX rename is atomic; this is the linearization point. Because step 0 serializes archivers via the directory lock, no concurrent racer can have produced a newer archive between step 1 enumeration and step 2 replace; the new `archive.zip` is the strict superset of the prior version.
+
+**Step 3 — Unlink raw files.** `unlink` the closed-day raw files. **Partial-failure semantics:** if any unlink fails (permission denied, file already removed by a concurrent run, etc.), the affected raw files remain on disk. They are *not* lost — they exist in `archive.zip` already, and the next archival run will re-include them by entry name (overwriting the existing zip entry harmlessly) and re-attempt unlink. Readers that union loose + zip MUST deduplicate by `(filename, lineno)` — entries with the same key from both sources are the same record. The "atomic" label thus applies to step 2 (the visible archive state); steps 1 and 3 are best-effort with self-healing on retry.
+
+**Step 4 — Tmpfile cleanup.** Before starting step 1 (in the next archival cycle), the archiver removes any `archive.zip.tmp.<pid>.<rand6>` whose `<pid>` no longer corresponds to a live process (interrupted prior run; the owning archiver is gone). Tmp files whose PID is still live are left alone (another archiver actively writing). PID liveness via `os.kill(pid, 0)` with explicit POSIX-correct exception handling:
+
+| Exception | Interpretation | Action |
+|---|---|---|
+| `ProcessLookupError` (`ESRCH`) | Process is dead | Remove the tmpfile |
+| `PermissionError` (`EPERM`) | Process exists but is owned by another user (shared host, container, sudo'd archiver) | Leave the tmpfile alone |
+| Any other exception, or success | Process exists | Leave the tmpfile alone |
+
+The `EPERM` branch is critical — treating it as "dead" would let one user's archiver delete another user's live tmpfile and corrupt their in-flight archive. Wall-clock-based age checks were rejected because backward NTP / VM-resume skew can mistakenly delete live tmpfiles.
+
+Compression typically reduces 30 days of logs by 7–10× (raw 30–50 MiB → zip 4–7 MiB).
+
+---
+
+## File Permissions
+
+Log files are created with mode `0644`; the `rules/logs/` directory (and any parent created on demand) is created with mode `0755`. Agents MUST NOT relax these permissions. Activity logs are not secrets per the privacy constraints below; they are designed to be auditable by the user.
+
+---
+
+## Default Git Policy
+
+Activity logs are per-machine artifacts and SHOULD be gitignored by default. The exact `.gitignore` snippet (a single line: `rules/logs/`) is shipped in CHG-2231 Phase 0. Projects MAY commit logs deliberately; that is a project-level choice and not the protocol default.
+
+---
+
+## Privacy & Safety Constraints
+
+**Forbidden content in any field:**
+- API keys, OAuth tokens
+- Full prompt text
+- Full tool call arguments
+- Raw file contents (file *paths* are fine)
+- User PII
+- Environment variable values
+
+Agents are responsible for their own redaction; the validator does not detect secrets. The 500-character `summary` cap enforces concision.
+
+---
+
+## Retention Policy
+
+- **Default retention**: keep activity log files (loose `*.jsonl` and entries inside `archive.zip`) for **30 days**; older entries MAY be deleted by the agent runtime or by user cron.
+- **Aggregate disk-space soft cap**: **256 MiB per `rules/logs/` directory** (raw + zip combined). Beyond this the runtime SHOULD warn; deletion is user-driven, not automatic.
+- **Compression policy**: closed days are stored only inside `archive.zip` (DEFLATE provides 7–10× on JSONL). No additional gzip layer in v1.
+
+---
+
+## Versioning
+
+Schema version is fixed in the `schema` field as the literal string `"alfred.activity/v1"`. Breaking changes ship as `alfred.activity/v2` and require a new PRP. v1 readers MUST ignore unknown optional fields they encounter (forward compatibility); v1 writers MUST NOT emit fields not listed in v1.
+
+---
+
+## Out-of-Scope Substrates (v1)
+
+Two filesystem classes are explicitly unsupported in v1:
+
+- **Windows** — `O_APPEND` and `flock(2)` semantics differ; v1 is best-effort. Revisit if concrete need surfaces.
+- **Network filesystems (NFS / SMB / fuse-based remote mounts)** for **either log root** — both PRJ `rules/logs/` and USR `~/.alfred/logs/` (which on enterprise / Kerberos / LDAP-managed Linux setups is frequently NFS-mounted via the user's `$HOME`). `O_APPEND` and `flock(2)` semantics are implementation-defined and may silently no-op, breaking both per-line atomicity and archival serialization. Local POSIX filesystems (`ext4`, `xfs`, `btrfs`, `apfs`, `hfs+`, `ufs`, `zfs`) are the v1 supported substrate.
+
+The implementing CHG SHOULD detect the filesystem type of the resolved log directory at `af log` startup using the **OS-appropriate API**:
+- **Linux**: `statfs(2)` `f_type` magic numbers — `NFS_SUPER_MAGIC = 0x6969`, `SMB_SUPER_MAGIC`, `CIFS_MAGIC_NUMBER`, `FUSE_SUPER_MAGIC` — accessed via `ctypes` to libc, OR parse `/proc/self/mountinfo`
+- **macOS / BSD**: `statfs(2)` `f_fstypename` via `ctypes` to libc, or shell out to `stat -f "%T"`
+- **Avoid `os.statvfs`** — it returns block/inode counts but does NOT expose filesystem type
+
+On detection, emit a one-time stderr warning. Hard refusal is deferred to v2 to avoid breaking existing setups during rollout.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-02 | Initial version. Implements PRP-2230 (Agent Activity Log Protocol v1) §"Storage location" + §"Required/Optional fields" + §"v1 event enum" + §"Per-record line size cap" + §"Rotation" + §"Archival" + §"File permissions" + §"Default git policy" + §"Privacy & safety" + §"Versioning". Adds retention policy (30-day default + 256 MiB soft cap) and explicit OS-appropriate filesystem-type detection guidance per PRP-2230 R5+R7 advisories. | Frank + Claude |

--- a/src/fx_alfred/rules/COR-1206-SOP-Emit-Agent-Activity.md
+++ b/src/fx_alfred/rules/COR-1206-SOP-Emit-Agent-Activity.md
@@ -71,7 +71,8 @@ The v1 whitelist for the `agent` field is `claude-code`, `copilot`, `cursor`, `c
 | **Cursor** | `.cursorrules` directive | Rule instructs the model to call `af log --agent cursor ... \|\| true` after each turn |
 | **Cline / Roo Code** | Custom MCP tool | Expose `af log` as an MCP tool; rules instruct usage |
 | **Aider** | `--cmd-stop` callback OR git post-commit hook | Shell script invokes `af log --agent aider ... \|\| true` |
-| **Codex CLI / Gemini CLI** | Each SDK's lifecycle event hook | Shell script writes JSONL via `af log --agent {codex,gemini}-cli ... \|\| true` |
+| **Codex CLI** | SDK lifecycle event hook | Shell script writes JSONL via `af log --agent codex-cli ... \|\| true` |
+| **Gemini CLI** | SDK lifecycle event hook | Shell script writes JSONL via `af log --agent gemini-cli ... \|\| true` |
 | **Universal fallback** | None — direct shell-out | Any tool that can shell out invokes `af log` directly with appropriate `--agent` value (or `--agent other --agent-name <id>` for unrecognized harnesses) |
 
 ### Example: Claude Code reference hook

--- a/src/fx_alfred/rules/COR-1206-SOP-Emit-Agent-Activity.md
+++ b/src/fx_alfred/rules/COR-1206-SOP-Emit-Agent-Activity.md
@@ -1,0 +1,155 @@
+# SOP-1206: Emit Agent Activity
+
+**Applies to:** All projects using the COR document system
+**Last updated:** 2026-05-02
+**Last reviewed:** 2026-05-02
+**Status:** Active
+**Related:** COR-1205 (Agent Activity Log Format — data contract), COR-1200 (Session Retrospective — log consumer), PRP-2230 (originating proposal)
+
+---
+
+## What Is It?
+
+The implementation guide for the cross-agent activity log protocol. Tells every coding agent (Claude Code, GitHub Copilot, Cursor, Cline, Aider, Codex CLI, Gemini CLI, …) **when to emit**, **how to emit**, and **how to map native lifecycle events** onto the canonical schema defined in COR-1205. Also defines the **scanner-skip contract** that protects `rules/logs/` from `af` document-walk commands.
+
+This document defines the **emit protocol**. The **format** lives in COR-1205. The **CLI surfaces** are `af log` (writer), `af log-validate` (schema checker), `af log-archive` (explicit archival), all shipped in fx-alfred v1.9.0.
+
+---
+
+## Why
+
+Without explicit emit-trigger rules, each agent integrates differently and `COR-1200` retrospectives can't rely on the log being populated. Mandating triggers at the SOP level ensures every compliant integration produces interoperable records.
+
+---
+
+## When to Use
+
+- Implementing a new agent integration (per-agent recipe — see §Per-Agent Mapping below).
+- Writing a hook script that calls `af log`.
+- Reviewing whether an existing integration is COR-1206-compliant.
+
+---
+
+## When NOT to Use
+
+- Document validation — see COR-0002 (Document Format Contract).
+- Retrospective consumption of the log — see COR-1200 step 1.
+- v1 schema details — see COR-1205.
+
+---
+
+## Mandatory Triggers
+
+Every agent MUST emit at minimum:
+
+1. **One `session.start`** per agent session.
+2. **One `session.end`** per agent session.
+3. **At least one `task.done`** (or `task.aborted` / `note`) per user-facing turn that resulted in non-trivial action.
+4. **One `doc.created`** per Alfred document created via `af create`.
+5. **One `doc.updated`** per Alfred document updated via `af update` / `af fmt`.
+
+---
+
+## Optional Triggers
+
+Agents MAY emit:
+
+- `task.start` for long-running tasks (useful for traceability when paired with `task.done` via `parent_event` correlation id).
+- `decision` for material decisions: D-item resolutions, PRP convergences, scope cuts, retrospective conclusions.
+- `note` for anything that doesn't fit elsewhere (debugging breadcrumbs, free-form annotations).
+
+---
+
+## Per-Agent Mapping Table
+
+The v1 whitelist for the `agent` field is `claude-code`, `copilot`, `cursor`, `cline`, `aider`, `codex-cli`, `gemini-cli`, `other`. Adding a new entry requires a follow-on PRP.
+
+| Agent | Native lifecycle hook | Emit mechanism |
+|---|---|---|
+| **Claude Code** | `settings.json` `Stop` and `PostToolUse` hooks | `hooks/emit-activity.sh` reads `$CLAUDE_*` env vars and invokes `af log "<turn-summary>" --event task.done --agent claude-code --agent-version "${CLAUDE_VERSION:-unknown}" \|\| true` |
+| **GitHub Copilot (VS Code)** | No native lifecycle hook | Companion VS Code extension listening to `chat.acceptResponse` events; extension shells out to `af log --agent copilot ... \|\| true` |
+| **Cursor** | `.cursorrules` directive | Rule instructs the model to call `af log --agent cursor ... \|\| true` after each turn |
+| **Cline / Roo Code** | Custom MCP tool | Expose `af log` as an MCP tool; rules instruct usage |
+| **Aider** | `--cmd-stop` callback OR git post-commit hook | Shell script invokes `af log --agent aider ... \|\| true` |
+| **Codex CLI / Gemini CLI** | Each SDK's lifecycle event hook | Shell script writes JSONL via `af log --agent {codex,gemini}-cli ... \|\| true` |
+| **Universal fallback** | None — direct shell-out | Any tool that can shell out invokes `af log` directly with appropriate `--agent` value (or `--agent other --agent-name <id>` for unrecognized harnesses) |
+
+### Example: Claude Code reference hook
+
+The reference Stop hook ships under `hooks/emit-activity.sh` (Phase 5 of CHG-2231). Conceptual form:
+
+```bash
+#!/usr/bin/env bash
+# Claude Code Stop hook — emits one task.done per turn.
+af log "${CLAUDE_TURN_DESCRIPTION:-claude-code turn complete}" \
+  --event task.done \
+  --agent claude-code \
+  --agent-version "${CLAUDE_VERSION:-unknown}" \
+  || true     # fail-open: emit failure MUST NOT break the session
+```
+
+Wire-up in `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {"hooks": [{"type": "command", "command": "/path/to/hooks/emit-activity.sh"}]}
+    ]
+  }
+}
+```
+
+---
+
+## Compliance Test (mandatory before adding to mapping table)
+
+Every implementation MUST pass `af log-validate <one-session-log.jsonl>` on its emitted output for at least one full session before being added to the mapping table above. The test must cover, at minimum:
+
+- One `session.start`, one `session.end`.
+- At least three `task.done` records across the session.
+- All required fields populated correctly.
+- `summary` ≤ 500 chars; line ≤ 4096 bytes.
+- No forbidden content (secrets, full prompts, etc.) per COR-1205 §Privacy.
+
+---
+
+## Scanner-Skip Enforcement (`rules/logs/` is reserved)
+
+**All `af` document scanners — present (`af list`, `af search`, `af status`, `af validate`) and any future scanner — MUST hard-skip the `rules/logs/` subtree.**
+
+- Implementations enforce this at the `core/scanner.py` directory-walk layer (mirroring how `__pycache__` and `.git` are skipped) so the rule applies uniformly to every command that walks `rules/`.
+- Only `*.jsonl`, `*.partN.jsonl`, `archive.zip`, and `archive.zip.tmp.*` are allowed inside `rules/logs/` per COR-1205 §Storage location.
+- A regression test in CHG-2231 Phase 4 asserts that placing a `rules/logs/2026-05-02.jsonl`, a `rules/logs/archive.zip`, and even a misplaced `rules/logs/FXA-9999-PRP-Test.md` does not affect the output of any scanner-based command and produces no warnings.
+
+This skip is implemented at the walk layer (not per-command) so future scanners inherit the rule automatically. Without this enforcement, future scanner improvements (e.g. "warn on unknown files in `rules/`") could interact badly with the activity log subtree.
+
+---
+
+## .gitignore Snippet
+
+Activity logs are per-machine artifacts and SHOULD be gitignored. Add this single line to your project root `.gitignore`:
+
+```
+rules/logs/
+```
+
+Projects MAY commit logs deliberately (some teams do this for shared session memory across machines), but that is a project-level choice and not the protocol default.
+
+---
+
+## Fail-Open Hook Boundary
+
+`af log` MUST NOT block or error a calling agent's user-visible operation. **Hook scripts SHOULD invoke it with `af log ... || true`** so an emit failure cannot cascade into a session break. `af log` itself returns non-zero on failure for diagnostic visibility, but the caller swallows that exit code.
+
+This is the same fail-open posture as the rest of `af` (per FXA-2230 §Decisions §"`af log` is fail-open at the hook boundary").
+
+Callers that find per-invocation warnings noisy can redirect stderr (`af log ... 2>/dev/null` or `2>>~/.alfred/logs/.warn.log`).
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-02 | Initial version. Implements PRP-2230 (Agent Activity Log Protocol v1) §"COR-1206-SOP-Emit-Agent-Activity" + scanner-skip enforcement rule (3/4 trinity advisory R5) + per-agent integration recipes for the 7-agent mapping table + `.gitignore` snippet + fail-open hook boundary. | Frank + Claude |

--- a/src/fx_alfred/rules/COR-1206-SOP-Emit-Agent-Activity.md
+++ b/src/fx_alfred/rules/COR-1206-SOP-Emit-Agent-Activity.md
@@ -12,7 +12,7 @@
 
 The implementation guide for the cross-agent activity log protocol. Tells every coding agent (Claude Code, GitHub Copilot, Cursor, Cline, Aider, Codex CLI, Gemini CLI, …) **when to emit**, **how to emit**, and **how to map native lifecycle events** onto the canonical schema defined in COR-1205. Also defines the **scanner-skip contract** that protects `rules/logs/` from `af` document-walk commands.
 
-This document defines the **emit protocol**. The **format** lives in COR-1205. The **CLI surfaces** are `af log` (writer), `af log-validate` (schema checker), `af log-archive` (explicit archival), all shipped in fx-alfred v1.9.0.
+This document defines the **emit protocol**. The **format** lives in COR-1205. The **CLI surfaces** are `af log` (writer), `af log-validate` (schema checker), `af log-archive` (explicit archival) — **scaffolded in CHG-2231 Phase 0 and implemented across Phases 2–5; target release v1.9.0**. Until those phases land in `main`, the commands are placeholder modules and the mandatory triggers below cannot yet be exercised end-to-end; this SOP still defines the eventual integration contract authoritatively, and integrators preparing per-agent recipes can stub against the CLI surfaces in advance.
 
 ---
 


### PR DESCRIPTION
## Summary

Implements **CHG-2231 Phase 1** per the merged spec. Doc-only phase — no code, no tests; ships independently of subsequent CLI phases.

| File | Status | Lines |
|---|---|---|
| `src/fx_alfred/rules/COR-1205-REF-Agent-Activity-Log-Format.md` | NEW | ~200 |
| `src/fx_alfred/rules/COR-1206-SOP-Emit-Agent-Activity.md` | NEW | ~150 |
| `src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md` | MODIFIED (1 additive bullet) | +2 |
| `src/fx_alfred/rules/COR-0000-REF-Document-Index.md` | MODIFIED (2 new entries + dates) | +4/-2 |

## What's in COR-1205 (REF — canonical data contract)

Sourced from PRP-2230 with **all R5 + R7 satellite corrections folded in**:

- Storage location (PRJ `rules/logs/` + USR `~/.alfred/logs/` fallback) + reserved-subtree rule
- Encoding (UTF-8 JSONL, append-only, no embedded newlines)
- 7 required fields + 6 optional fields with full type/length/regex constraints
- 9-value v1 event enum (`session.start/end`, `task.start/done/aborted`, `doc.created/updated`, `decision`, `note`)
- Per-record 4 KiB cap (POSIX `O_APPEND` atomicity provable)
- 8 MiB rotation **pre-condition** (no file ever exceeds cap by even one byte)
- 5-step archival procedure: step 0 `fcntl.flock` lock + step 1 `archive.zip.tmp.<pid>.<rand6>` build + step 2 `os.replace` linearization + step 3 unlink with self-healing + step 4 PID-liveness tmpfile cleanup
- File permissions (0644/0755), gitignore policy, privacy & safety constraints
- Retention (30-day default + 256 MiB soft cap)
- Versioning (literal `"alfred.activity/v1"`)
- Out-of-scope substrates: **Windows + NFS/SMB on either log root** with OS-appropriate filesystem-type detection guidance (`statfs(2)` `f_type` / `f_fstypename`, explicit "avoid `os.statvfs`" anti-pattern note)

## What's in COR-1206 (SOP — implementation guide)

- Mandatory triggers (5) + optional triggers (3)
- Per-agent mapping table for 7 agents (Claude Code, Copilot, Cursor, Cline, Aider, Codex CLI, Gemini CLI) + universal fallback
- Inline integration recipes including the reference Claude Code Stop hook example
- Compliance test (must pass `af log-validate` over a real session before being added to mapping)
- **Scanner-skip enforcement rule**: ALL `af` document scanners — present (`af list`/`af search`/`af status`/`af validate`) AND any future scanner — MUST hard-skip `rules/logs/` at the `core/scanner.py` directory-walk layer
- `.gitignore` snippet (`rules/logs/`)
- Fail-open hook boundary policy (`af log ... || true`)

## What changes in COR-1200 (retrospective)

Single additive bullet at top of step 1:

> **Before reconstructing actions:** if `./rules/logs/<today UTC>.jsonl` exists (or `./rules/logs/archive.zip` contains today's entry), read it via `af log-validate` (verifies schema) and use its `task.done` / `doc.created` / `doc.updated` / `decision` events as the ground truth for what happened this session. The chat-history reconstruction below remains the fallback when the log is empty or absent.

The 6-step retrospective protocol and outputs are otherwise **unchanged** per PRP-2230 §Out of scope.

## R5/R7 advisories folded into Phase 1

| Origin | Fix in this PR |
|---|---|
| R5 4/4 advisory: NFS coverage | COR-1205 §Out-of-Scope Substrates explicitly lists NFS/SMB with both log roots |
| R5 3/3 advisory: `os.statvfs` is wrong API | COR-1205 §Out-of-Scope Substrates spells out OS-appropriate `statfs(2)` family + "avoid `os.statvfs`" anti-pattern |
| R7 collective: scanner-skip "all present and future" | COR-1206 §Scanner-Skip Enforcement makes this mandatory at the walk layer |

## Verification

- ✅ `af validate --root .` → 0 issues across 182 PRJ docs
- ✅ Direct `scan_documents()` via dev `.venv` → 184 total (PKG + PRJ); all 3 new/modified PKG docs visible
- ✅ COR-1200 modification preserves all 6 existing steps verbatim
- ✅ Phase 1 Definition of Done from CHG-2231 met (2 new PKG + 1 modified + .gitignore already in main from PR #83)

## Test plan

- [x] `af validate --root .` → 0 issues
- [x] Editable .venv discovers all new docs at correct PKG layer
- [x] No code changes (Phase 1 is doc-only); no tests added (TDD red-green commits start in Phase 2)
- [ ] After merge: open Phase 2 PR (`af log` command — TDD with 18 unit tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)