### PR TITLE
fix(FXA-2233): renumber CHG to free FXA-2232 for PR #86

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -141,7 +141,7 @@
 | 2229 | PRP | Layered SOP Memory Model |
 | 2230 | PRP | Agent Activity Log Protocol |
 | 2231 | CHG | Agent Activity Log Protocol v1 Implementation |
-| 2232 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 |
+| 2233 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 |
 
 ---
 

--- a/rules/FXA-2233-CHG-Subsection-Guard-Symmetry-in-COR-1612-Step-6.md
+++ b/rules/FXA-2233-CHG-Subsection-Guard-Symmetry-in-COR-1612-Step-6.md
@@ -1,4 +1,4 @@
-# CHG-2232: Subsection Guard Symmetry in COR-1612 Step 6
+# CHG-2233: Subsection Guard Symmetry in COR-1612 Step 6
 
 **Applies to:** FXA project
 **Last updated:** 2026-05-03
@@ -62,3 +62,4 @@ Sub-blocks currently in the §Step 6 stop-cond #1 example fence:
 | Date | Change | By |
 |------|--------|----|
 | 2026-05-03 | Initial version — deferred from PR #85 trinity 3:1 vote (Codex/Gemini/GLM MERGE-AS-IS, DeepSeek FIX) | Claude Code |
+| 2026-05-03 | Renumbered FXA-2232 → FXA-2233; FXA-2232 was already claimed by PR #86 (Quarkdown PRP) which had been open since before this CHG was filed. ACID first-come-first-served convention. | Claude Code |


### PR DESCRIPTION
## Summary

Renumbers the COR-1612 sub-block guard symmetry CHG from `FXA-2232` to `FXA-2233` to resolve the ACID collision with PR #86.

## Why

When merging PR #85, I created a follow-up CHG (deferred per trinity 3:1 vote) and asked `af list` for the next available FXA ACID — got `2232`. But PR #86 (`docs(FXA-2232): PRP for Quarkdown documentation rendering layer`) was already open since `2026-05-02T18:48:02Z` claiming FXA-2232. Local `af list` only sees merged-or-local files; it doesn't know about ACIDs reserved by open PRs.

After PR #85 squashed-merged with `FXA-2232-CHG-...`, PR #86 went DIRTY/CONFLICTING because both branches added an `FXA-2232` row to `rules/FXA-0000-REF-Document-Index.md`.

ACID first-come-first-served convention: PR #86 was filed first, so this CHG renumbers.

## What changed

- `rules/FXA-2232-CHG-Subsection-Guard-Symmetry-in-COR-1612-Step-6.md` → `rules/FXA-2233-CHG-...`
- `# CHG-2232` heading → `# CHG-2233`
- Change History appended with renumber rationale
- `rules/FXA-0000-REF-Document-Index.md` regenerated via `af index` — FXA-2232 row gone, FXA-2233 row added

## Verification

- `af validate` — 183 docs, 0 issues
- `af where FXA-2233` resolves
- `af where FXA-2232` errors (expected — slot is now free for PR #86)

## After this merges

PR #86 rebases on main; its FXA-2232-PRP-... slot is no longer taken; conflict resolves automatically.

## Future-defense note

When assigning a new ACID, run `gh pr list --state open --json title | grep '<PREFIX>-'` BEFORE trusting `af list`'s "highest local" answer. Open PRs hold ACIDs but local scans don't see them.