### PR TITLE
[codex] release v1.9.1 README and version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 Alfred is a CLI-based agent runbook (`af`) that manages SOPs, workflows, and structured documents across three layers (PKG, USR, PRJ). It provides:
 
-- **NEW in v1.9.0** — [Council Review (COR-1613)](src/fx_alfred/rules/COR-1613-SOP-Council-Review.md) for multi-reviewer decisions with 14 voting mechanisms, and [Diagnose Feedback Loop (COR-1503)](src/fx_alfred/rules/COR-1503-SOP-Diagnose-Feedback-Loop.md) for disciplined bug/perf diagnosis
+- **NEW in v1.9.1** — [GitHub App PR Review Bot Loop (COR-1615)](src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md) for Codex Connector / Copilot PR review loops; v1.9.0 added [Council Review (COR-1613)](src/fx_alfred/rules/COR-1613-SOP-Council-Review.md) and [Diagnose Feedback Loop (COR-1503)](src/fx_alfred/rules/COR-1503-SOP-Diagnose-Feedback-Loop.md)
 - **Workflow Routing** — `af guide` tells AI agents which SOP to follow for any task
 - **Workflow Checklists** — `af plan` generates step-by-step checklists from SOPs. With `--task "<description>"` auto-composes the SOP set from tags; `--todo` flattens into a unified checklist; `--graph` renders ASCII + Mermaid flowcharts with intra-SOP loops and gates
 - **Document Validation** — `af validate` enforces metadata format, status values, and section structure
@@ -293,6 +293,7 @@ graph TD
 | COR-1500 | TDD Development Workflow |
 | COR-1602 | Multi-Model Parallel Review |
 | COR-1612 | Respond to PR review comments on GitHub |
+| COR-1615 | GitHub App PR Review Bot Loop — trigger/poll/match-head loop for Codex Connector, Copilot, and other GitHub App reviewers |
 | COR-1608 | PRP Review Scoring rubric |
 | COR-1611 | Reviewer Calibration Guide |
 | COR-1613 | Council Review — multi-reviewer decision mechanism (14 voting rules) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.9.0"
+version = "1.9.1"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,10 +1,12 @@
 # Changelog
 
-## Unreleased
+## v1.9.1 (2026-05-05)
+
+Patch release: PKG SOP promotion for GitHub App PR review bot loops.
 
 ### Added
 
-- **COR-1615 GitHub App PR Review Bot Loop** — PKG SOP promoted from BAB-1504. Standardizes GitHub App PR review bot triggering, conservative reaction interpretation, current-head matching, stale-thread checks, and handoff to COR-1612 for actionable findings. (FXA-2234)
+- **COR-1615 GitHub App PR Review Bot Loop** — PKG SOP promoted from BAB-1504. Standardizes GitHub App PR review bot triggering, conservative reaction interpretation, current-head matching, stale-thread checks, and handoff to COR-1612 for actionable findings. Covers both OpenAI Codex Connector (`@codex review`) and GitHub Copilot reviewer assignment (`@copilot`). (PR #91, FXA-2234)
 
 ## v1.9.0 (2026-05-03)
 


### PR DESCRIPTION
## Summary

Follow-up to PR #91 after merge.

- Bumps `fx-alfred` from `1.9.0` to `1.9.1`.
- Converts the COR-1615 changelog entry from `Unreleased` to `v1.9.1 (2026-05-05)`.
- Updates README to surface `COR-1615: GitHub App PR Review Bot Loop` and adds it to the Key SOPs table.

## Verification

- `PYTHONPATH=src af validate --root .` -> 198 documents checked, 0 issues found.
- `PYTHONPATH=src .venv/bin/ruff check .` -> all checks passed.
- `PYTHONPATH=src .venv/bin/pytest -q` -> 833 passed, 2 skipped.
- `.venv/bin/python -m build --wheel` -> successfully built `fx_alfred-1.9.1-py3-none-any.whl`.

## Notes

- Installed `build` into the local venv only to verify wheel creation; no repo dependency files changed.
- Existing untracked `.claude/` files remain out of scope and were not committed.
