### PR TITLE
feat: add agent helpers and skill docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,11 @@
 
 Alfred is a CLI-based agent runbook (`af`) that manages SOPs, workflows, and structured documents across three layers (PKG, USR, PRJ). It provides:
 
-- **NEW in v1.9.1** — [GitHub App PR Review Bot Loop (COR-1615)](src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md) for Codex Connector / Copilot PR review loops; v1.9.0 added [Council Review (COR-1613)](src/fx_alfred/rules/COR-1613-SOP-Council-Review.md) and [Diagnose Feedback Loop (COR-1503)](src/fx_alfred/rules/COR-1503-SOP-Diagnose-Feedback-Loop.md)
+- **NEW in v1.10.0** — Agent-editable helpers and skill documents: `af agent call/run`, `af skill list/read`, and `af plan --with-skills`
+- **v1.9.1** — [GitHub App PR Review Bot Loop (COR-1615)](src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md) for Codex Connector / Copilot PR review loops; v1.9.0 added [Council Review (COR-1613)](src/fx_alfred/rules/COR-1613-SOP-Council-Review.md) and [Diagnose Feedback Loop (COR-1503)](src/fx_alfred/rules/COR-1503-SOP-Diagnose-Feedback-Loop.md)
 - **Workflow Routing** — `af guide` tells AI agents which SOP to follow for any task
-- **Workflow Checklists** — `af plan` generates step-by-step checklists from SOPs. With `--task "<description>"` auto-composes the SOP set from tags; `--todo` flattens into a unified checklist; `--graph` renders ASCII + Mermaid flowcharts with intra-SOP loops and gates
+- **Workflow Checklists** — `af plan` generates step-by-step checklists from SOPs. With `--task "<description>"` auto-composes the SOP set from tags; `--todo` flattens into a unified checklist; `--graph` renders ASCII + Mermaid flowcharts with intra-SOP loops and gates; `--with-skills` recommends matching skill docs
+- **Agent Helpers & Skills** — `af agent` runs explicitly gated local Python helpers/scripts, while `af skill` discovers and reads reusable REF/SOP skill documents without executing code
 - **Document Validation** — `af validate` enforces metadata format, status values, and section structure
 - **Document Formatting** — `af fmt` normalizes metadata order, whitespace, and table alignment to canonical style
 - **File Path Lookup** — `af where` prints the absolute filesystem path of any document by identifier
@@ -75,6 +77,7 @@ af plan COR-1102 COR-1602 COR-1500            # phased checklist from named SOPs
 af plan --human COR-1102                       # human-readable format
 af plan --task "implement FXA-XXXX PRP"        # auto-compose SOPs from tags (COR-1202)
 af plan --task "..." --todo --graph            # flat TODO + ASCII + Mermaid graph
+af plan --task "..." --with-skills             # append matching skill docs
 af plan --task "..." --graph --graph-format=ascii    # ASCII only (terminal)
 af plan --task "..." --graph --graph-format=mermaid  # Mermaid only (GitHub / Obsidian)
 af setup                                       # suggested prompts for agent config
@@ -104,6 +107,34 @@ intra-SOP loops only) for downstream tooling pinned on the legacy shape.
 
 See [COR-1202 (Compose Session Plan)](src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md)
 for the canonical usage procedure.
+
+### Agent Helpers and Skills
+
+Run explicit local helper code only after opting in:
+
+```bash
+ALFRED_AGENT_TOOLS=1 af agent call collect_review_pack --arg root=. --json
+ALFRED_AGENT_TOOLS=1 af agent run scripts/check_release.py --json
+```
+
+`af agent call` loads public functions from `<project-root>/.alfred/agent_helpers.py`
+first, then `~/.alfred/agent_helpers.py`. The exact
+`ALFRED_AGENT_TOOLS=1` gate is checked before importing helper code.
+
+Discover reusable skill documents without executing code:
+
+```bash
+af skill list
+af skill list --task "release fx-alfred to pypi" --json
+af skill read skill-release-to-pypi
+```
+
+A skill is a `REF` or `SOP` document with explicit `Tags: skill` metadata.
+`af plan --task "..." --with-skills` appends matched skills to the plan; JSON
+output adds `recommended_skills` and uses schema version `3`.
+
+See [FXA-2237](rules/FXA-2237-REF-Agent-Helpers-And-Skills-Usage.md) for the
+full usage reference.
 
 ### Document Validation (`af validate`)
 
@@ -314,7 +345,11 @@ Pass threshold: >= 9.0/10. All deductions must cite specific lines.
 
 ```
 af guide [--root DIR] [--json]
-af plan [SOP_ID ...] [--root DIR] [--task TEXT] [--todo] [--graph] [--graph-format ascii|mermaid|both] [--human] [--json]
+af plan [SOP_ID ...] [--root DIR] [--task TEXT] [--with-skills] [--todo] [--graph] [--graph-format ascii|mermaid|both] [--human] [--json]
+af agent call HELPER_NAME [--arg key=value ...] [--json]
+af agent run SCRIPT_PATH [--json]
+af skill list [--task TEXT] [--layer PKG|USR|PRJ|all] [--json]
+af skill read ID_OR_NAME [--json]
 af list [--type TYPE] [--prefix PREFIX] [--source SOURCE] [--tag TAG] [--json]
 af read IDENTIFIER [--json]
 af create TYPE --prefix P --acid N|--area N --title T [--layer project|user] [--subdir DIR] [--spec FILE] [--dry-run]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.9.1"
+version = "1.10.0"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -145,6 +145,8 @@
 | 2233 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 |
 | 2234 | CHG | Promote GitHub App PR Review Bot Loop SOP |
 | 2235 | PRP | Agent Editable Helpers And Skills |
+| 2236 | CHG | Implement Agent Editable Helpers And Skills |
+| 2237 | REF | Agent Helpers And Skills Usage |
 
 ---
 

--- a/rules/FXA-2236-CHG-Implement-Agent-Editable-Helpers-And-Skills.md
+++ b/rules/FXA-2236-CHG-Implement-Agent-Editable-Helpers-And-Skills.md
@@ -1,0 +1,123 @@
+# CHG-2236: Implement Agent Editable Helpers And Skills
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** Completed
+**Date:** 2026-05-05
+**Requested by:** Frank
+**Priority:** Medium
+**Change Type:** Normal
+**Related:** FXA-2235, GitHub issue #94
+**Reviewed by:** Pre-approved by FXA-2235 PRP strict review
+
+---
+
+## What
+
+Implement the approved P0 surface from `FXA-2235: Agent Editable Helpers And Skills`:
+
+- `af agent call` and `af agent run` for explicitly gated local helper/script execution.
+- `af skill list` and `af skill read` for read-only skill-document discovery.
+- `af plan --with-skills` for task-scoped skill recommendations.
+- A PRJ REF usage document for Agent Helpers and Skills.
+
+---
+
+## Why
+
+FXA-2235 established that Alfred needs a controlled learn-by-doing surface for reusable local helper functions and skill documents while preserving deterministic, safe-by-default behavior for existing commands. The implementation makes that approved design available behind explicit command surfaces and tests the safety boundary.
+
+---
+
+## Impact Analysis
+
+- **Systems affected:**
+  - `src/fx_alfred/cli.py` — register lazy `agent` and `skill` command groups.
+  - `src/fx_alfred/commands/agent_cmd.py` — implement `af agent call/run`.
+  - `src/fx_alfred/commands/skill_cmd.py` — implement `af skill list/read`.
+  - `src/fx_alfred/core/agent_helpers.py` — helper discovery, gated import, execution envelopes.
+  - `src/fx_alfred/core/skills.py` — skill classification, matching, JSON result shapes, resolution.
+  - `src/fx_alfred/commands/plan_cmd.py` — add `--with-skills` and JSON schema version `3` when `recommended_skills` is present.
+  - `tests/test_agent_cmd.py`, `tests/test_skill_cmd.py`, `tests/test_plan_cmd.py`, `tests/test_lazy.py` — TDD coverage.
+  - `rules/FXA-2237-REF-Agent-Helpers-And-Skills-Usage.md` — usage guidance, created via `af create ref --prefix FXA --area 22`.
+  - `rules/FXA-0000-REF-Document-Index.md` — index updates for CHG/REF.
+- **Not affected:**
+  - Existing command behavior for `af guide`, `af validate`, and normal `af plan` without `--with-skills`.
+  - Schema metadata fields; P0 does not add `SKL`, `Skill status`, or `Helper functions`.
+  - PKG helper registry; P0 supports only PRJ and USR helper files.
+- **Rollback plan:** Revert the implementation commit. Verify `af agent` / `af skill` no longer appear in `af --help`, `af plan --with-skills` is rejected as an unknown option, and `PYTHONPATH=src .venv/bin/af validate --root .` remains clean.
+
+---
+
+## Implementation Plan
+
+1. Add RED tests for lazy nested groups and helper gate behavior.
+2. Implement `core/agent_helpers.py`:
+   - exact `ALFRED_AGENT_TOOLS=1` gate,
+   - PRJ/USR helper path resolution,
+   - PRJ import-failure no-fallback rule,
+   - public function registration,
+   - duplicate arg rejection,
+   - async execution,
+   - JSON envelopes.
+3. Implement `commands/agent_cmd.py`.
+4. Add RED tests for skill classification, matching, resolution, and JSON output.
+5. Implement `core/skills.py` and `commands/skill_cmd.py`.
+6. Add RED tests for `af plan --with-skills`, including JSON schema `3`, empty matches, text placement, and no helper imports.
+7. Extend `commands/plan_cmd.py`.
+8. Create the PRJ usage REF with `af create ref --prefix FXA --area 22 --title "Agent Helpers And Skills Usage"`.
+9. Run full verification and address review findings before opening a normal PR.
+
+---
+
+## Testing / Verification
+
+- [x] `PYTHONPATH=src .venv/bin/pytest tests/test_agent_cmd.py tests/test_skill_cmd.py tests/test_plan_cmd.py tests/test_lazy.py -q`
+- [x] `PYTHONPATH=src .venv/bin/pytest -q`
+- [x] `PYTHONPATH=src .venv/bin/ruff check .`
+- [x] `PYTHONPATH=src .venv/bin/ruff format --check .`
+- [x] `PYTHONPATH=src .venv/bin/pyright src/`
+- [x] `PYTHONPATH=src .venv/bin/af validate --root .`
+
+---
+
+## Approval
+
+- [x] Reviewed by: FXA-2235 PRP strict review (GLM 9.1/10, DeepSeek 9.0/10)
+- [x] Approved on: 2026-05-05
+
+---
+
+## Execution Log
+
+| Date       | Action | Result |
+|------------|--------|--------|
+| 2026-05-05 | Created CHG from approved FXA-2235 PRP. | Ready for TDD implementation. |
+| 2026-05-05 | Added RED tests for agent helpers, skill docs, plan recommendations, and lazy command help. | Failed for missing command surface as expected. |
+| 2026-05-05 | Implemented `af agent`, `af skill`, `af plan --with-skills`, README/changelog/version updates, and FXA-2237 usage REF. | Targeted and full verification passed. |
+| 2026-05-05 | Ran Trinity fast-review. | PASS from GLM and DeepSeek; addressed low-risk clarity/test-coverage advisories before final verification. |
+
+---
+
+## Post-Change Review
+
+Implemented per FXA-2235 P0. The only intentional contract tightening versus
+the original issue text is skill classification: P0 requires explicit
+`Tags: skill` on REF/SOP documents and does not classify by title alone. This
+keeps `Skill:` headings descriptive rather than executable/discoverable
+metadata.
+
+Trinity fast-review passed with no blocking findings. Follow-up edits removed
+redundant control-flow/readability code and added tests for skill layer
+filtering, full-ID skill reads, not-found skill reads, and text-mode agent
+errors. Deferred advisories: script-run timeout and skill scoring stop-word
+tuning are P1 design choices, not P0 blockers.
+
+---
+
+## Change History
+
+| Date       | Change                                                | By    |
+|------------|-------------------------------------------------------|-------|
+| 2026-05-05 | Initial implementation CHG from approved FXA-2235 PRP. | Codex |

--- a/rules/FXA-2237-REF-Agent-Helpers-And-Skills-Usage.md
+++ b/rules/FXA-2237-REF-Agent-Helpers-And-Skills-Usage.md
@@ -1,0 +1,186 @@
+# REF-2237: Agent Helpers And Skills Usage
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** Active
+**Tags:** agent-tools, helpers, skills, usage
+
+---
+
+## What Is It?
+
+This reference explains the P0 agent-editable extension surface added by
+FXA-2236:
+
+- `af agent call` runs explicitly gated PRJ/USR Python helper functions.
+- `af agent run` runs explicitly gated project-relative Python scripts.
+- `af skill list` discovers REF/SOP documents that are explicitly tagged as
+  `skill`.
+- `af skill read` opens one skill document by ID, ACID, exact title, or slug.
+- `af plan --with-skills --task ...` appends task-matched skill
+  recommendations to a composed SOP plan.
+
+These surfaces are intended for local agent workflows and project-specific
+knowledge reuse. They do not add a new document type and they do not import
+helper code during normal document scanning, skill listing, or planning.
+
+---
+
+## Content
+
+## Safety Model
+
+Agent helper execution is disabled by default. A command that can execute local
+code must be run with the exact environment gate:
+
+```bash
+ALFRED_AGENT_TOOLS=1 af agent call <helper_name>
+ALFRED_AGENT_TOOLS=1 af agent run <script_path>
+```
+
+Any other value, including `true`, is refused before Alfred imports helper
+files or runs scripts.
+
+Helper lookup order is:
+
+1. PRJ: `<project-root>/.alfred/agent_helpers.py`
+2. USR: `~/.alfred/agent_helpers.py`
+
+PRJ overrides USR. If the PRJ helper file exists but fails to import, Alfred
+returns that import failure and does not fall back to USR.
+
+Only functions defined directly in the loaded helper module are callable. Names
+beginning with `_` and imported callables are ignored.
+
+## Calling Helpers
+
+Create a project helper:
+
+```python
+# .alfred/agent_helpers.py
+def release_note(version, package):
+    return {"version": version, "package": package}
+```
+
+Call it:
+
+```bash
+ALFRED_AGENT_TOOLS=1 af agent call release_note \
+  --arg version=1.9.2 \
+  --arg package=fx-alfred \
+  --json
+```
+
+`--arg` values are strings. Alfred splits on the first `=`, rejects duplicate
+keys, and does not evaluate values.
+
+JSON helper output uses a stable envelope:
+
+```json
+{
+  "schema_version": "1",
+  "helper": "release_note",
+  "source": {"layer": "PRJ", "path": "/path/to/.alfred/agent_helpers.py"},
+  "status": "ok",
+  "result": {"version": "1.9.2", "package": "fx-alfred"}
+}
+```
+
+If a helper raises or returns a value that cannot be serialized to JSON, Alfred
+returns an error envelope instead of a partial result.
+
+## Running Scripts
+
+`af agent run` executes Python scripts with the current interpreter and no shell:
+
+```bash
+ALFRED_AGENT_TOOLS=1 af agent run scripts/check_release.py --json
+```
+
+Relative script paths resolve from the active project root. JSON output includes
+`exit_code`, `stdout`, and `stderr`. Text output replays stdout/stderr and exits
+with the script return code.
+
+## Declaring Skills
+
+A skill is an existing `REF` or `SOP` document with explicit metadata:
+
+```markdown
+**Tags:** skill, release, pypi
+**Task tags:** release, pypi
+```
+
+Skill discovery intentionally ignores title conventions such as `Skill: ...`
+unless the document also has `Tags: skill`.
+
+Recommended skill documents should explain a reusable method, decision pattern,
+checklist, tool recipe, or local workflow that an agent can apply across tasks.
+
+## Discovering Skills
+
+List all skills:
+
+```bash
+af skill list
+af skill list --json
+```
+
+Score skills for a task:
+
+```bash
+af skill list --task "release fx-alfred to pypi" --json
+```
+
+Matching is local and deterministic. Task tokens score against:
+
+- `Task tags`: +4
+- `Tags`: +3
+- title: +2
+- body: +1
+
+Results sort by score, then layer precedence `PRJ > USR > PKG`, then document
+ID. Without `--task`, all skills are listed with `score: null`.
+
+## Reading Skills
+
+Read by full ID:
+
+```bash
+af skill read FXA-2237
+```
+
+Read by exact normalized slug:
+
+```bash
+af skill read skill-release-to-pypi --json
+```
+
+ACID-only lookup is allowed only when it is unambiguous across skill documents.
+
+## Planning With Skills
+
+Use `--with-skills` only with a task:
+
+```bash
+af plan --task "release fx-alfred to pypi" --with-skills FXA-2108
+```
+
+For JSON output, Alfred adds a top-level `recommended_skills` array and sets
+`schema_version` to `"3"`:
+
+```bash
+af plan --task "release fx-alfred to pypi" --with-skills --json FXA-2108
+```
+
+For text output, Alfred appends `# Recommended Skills` after the normal plan
+and graph output. If no skill matches the task, the text block is omitted and
+the JSON array is `[]`.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-05 | Initial usage guidance for agent helpers and skills. | Codex |

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## v1.10.0 (2026-05-05)
+
+Feature release: agent-editable helpers and reusable skill documents.
+
+### Added
+
+- **`af agent call`** — explicitly gated PRJ/USR Python helper execution with `ALFRED_AGENT_TOOLS=1`, PRJ-over-USR resolution, async helper support, string-only `--arg key=value`, and JSON success/error envelopes. (FXA-2236, issue #94)
+- **`af agent run`** — explicitly gated Python script runner using the current interpreter, no shell, and process-style JSON envelopes with `stdout`, `stderr`, and `exit_code`. (FXA-2236)
+- **`af skill list/read`** — read-only discovery and reading for REF/SOP documents explicitly tagged with `Tags: skill`, including deterministic task scoring across `Task tags`, `Tags`, title, and body. (FXA-2236)
+- **`af plan --with-skills`** — task-scoped skill recommendations appended to text plans and emitted as top-level `recommended_skills` in JSON schema version `3`. (FXA-2236)
+- **FXA-2237 usage REF** — examples and safety guidance for agent helpers and skill documents.
+
+### Safety
+
+- Normal `af guide`, `af plan`, `af validate`, and `af skill` paths do not import or execute `agent_helpers.py`.
+- Helper execution refuses unless the exact opt-in gate `ALFRED_AGENT_TOOLS=1` is set before import or script execution.
+
 ## v1.9.1 (2026-05-05)
 
 Patch release: PKG SOP promotion for GitHub App PR review bot loops.

--- a/src/fx_alfred/cli.py
+++ b/src/fx_alfred/cli.py
@@ -31,6 +31,7 @@ Quick Start:
 @click.group(
     cls=LazyGroup,
     lazy_subcommands={
+        "agent": "fx_alfred.commands.agent_cmd:agent_cmd",
         "changelog": "fx_alfred.commands.changelog_cmd:changelog_cmd",
         "create": "fx_alfred.commands.create_cmd:create_cmd",
         "fmt": "fx_alfred.commands.fmt_cmd:fmt_cmd",
@@ -41,6 +42,7 @@ Quick Start:
         "read": "fx_alfred.commands.read_cmd:read_cmd",
         "setup": "fx_alfred.commands.setup_cmd:setup_cmd",
         "search": "fx_alfred.commands.search_cmd:search_cmd",
+        "skill": "fx_alfred.commands.skill_cmd:skill_cmd",
         "status": "fx_alfred.commands.status_cmd:status_cmd",
         "update": "fx_alfred.commands.update_cmd:update_cmd",
         "validate": "fx_alfred.commands.validate_cmd:validate_cmd",

--- a/src/fx_alfred/commands/agent_cmd.py
+++ b/src/fx_alfred/commands/agent_cmd.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+
+import click
+
+from fx_alfred.context import get_root, root_option
+from fx_alfred.core.agent_helpers import (
+    AgentArgError,
+    agent_tools_enabled,
+    call_helper,
+    gate_error_envelope,
+    parse_arg_pairs,
+    run_script,
+)
+
+
+def _emit_json(envelope: dict) -> None:
+    click.echo(json.dumps(envelope, ensure_ascii=False))
+
+
+@click.group("agent")
+@root_option
+def agent_cmd() -> None:
+    """Run explicitly enabled agent helper tools."""
+
+
+@agent_cmd.command("call")
+@click.argument("helper_name")
+@click.option(
+    "--arg",
+    "arg_pairs",
+    multiple=True,
+    help="Helper argument as key=value. May be repeated.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON envelope.")
+@click.pass_context
+def agent_call_cmd(
+    ctx: click.Context,
+    helper_name: str,
+    arg_pairs: tuple[str, ...],
+    json_output: bool,
+) -> None:
+    """Call a PRJ or USR helper function."""
+    if not agent_tools_enabled():
+        envelope = gate_error_envelope("helper", helper_name)
+        if json_output:
+            _emit_json(envelope)
+            ctx.exit(1)
+        else:
+            raise click.ClickException(envelope["error"]["message"])
+
+    try:
+        kwargs = parse_arg_pairs(arg_pairs)
+    except AgentArgError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    envelope = call_helper(get_root(ctx), helper_name, kwargs)
+    if json_output:
+        _emit_json(envelope)
+        ctx.exit(0 if envelope["status"] == "ok" else 1)
+    elif envelope["status"] == "ok":
+        click.echo(str(envelope["result"]))
+        return
+    else:
+        raise click.ClickException(envelope["error"]["message"])
+
+
+@agent_cmd.command("run")
+@click.argument("script_path")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON envelope.")
+@click.pass_context
+def agent_run_cmd(
+    ctx: click.Context,
+    script_path: str,
+    json_output: bool,
+) -> None:
+    """Run a Python script through the current interpreter."""
+    if not agent_tools_enabled():
+        envelope = gate_error_envelope("script", script_path)
+        if json_output:
+            _emit_json(envelope)
+            ctx.exit(1)
+        else:
+            raise click.ClickException(envelope["error"]["message"])
+
+    envelope = run_script(get_root(ctx), script_path)
+    if json_output:
+        _emit_json(envelope)
+        ctx.exit(0 if envelope["status"] == "ok" else 1)
+    else:
+        click.echo(envelope["stdout"], nl=False)
+        click.echo(envelope["stderr"], nl=False, err=True)
+        exit_code = envelope["exit_code"]
+        ctx.exit(exit_code if isinstance(exit_code, int) else 1)

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -22,6 +22,7 @@ from fx_alfred.core.compose import resolve_sops_from_task
 from fx_alfred.core.mermaid import render_mermaid
 from fx_alfred.core.phases import PhaseDict
 from fx_alfred.core.schema import TASK_TAGS
+from fx_alfred.core.skills import list_skills
 from fx_alfred.core.workflow import (
     BranchSignature,
     LoopSignature,
@@ -479,6 +480,22 @@ def _emit_graph(
         click.echo("```")
 
 
+def _emit_recommended_skills(recommended_skills: list[dict] | None) -> None:
+    """Append a compact recommended skills block to text output."""
+    if not recommended_skills:
+        return
+    click.echo()
+    click.echo("# Recommended Skills")
+    click.echo()
+    for item in recommended_skills:
+        source = item["source"]["layer"]
+        score = item.get("score")
+        suffix = "" if score is None else f" (score {score})"
+        click.echo(
+            f"- [{source}] {item['id']} {item['type_code']} {item['title']}{suffix}"
+        )
+
+
 @click.command("plan")
 @root_option
 @click.argument("sop_ids", nargs=-1)
@@ -520,6 +537,11 @@ def _emit_graph(
     default=None,
     help="Auto-compose SOPs by matching Task tags against task description",
 )
+@click.option(
+    "--with-skills",
+    is_flag=True,
+    help="Recommend matching skill documents for the task.",
+)
 @click.pass_context
 def plan_cmd(
     ctx: click.Context,
@@ -531,6 +553,7 @@ def plan_cmd(
     graph_format: str,
     graph_layout: str,
     task_description: str | None,
+    with_skills: bool,
 ) -> None:
     """Generate workflow checklist from SOPs."""
     # ── Validate --graph-format / --graph coupling ──
@@ -547,8 +570,14 @@ def plan_cmd(
         if layout_source is not None and layout_source.name != "DEFAULT":
             raise click.UsageError("--graph-layout requires --graph")
 
+    if with_skills and task_description is None:
+        raise click.UsageError("--with-skills requires --task")
+
     # Scan documents first (needed for --task resolution)
     docs = scan_or_fail(ctx)
+    recommended_skills = (
+        list_skills(docs, task=task_description) if with_skills else None
+    )
 
     # Handle --task flag for auto-composition
     composed_from_provenance: dict[str, list[str]] | None = None
@@ -735,6 +764,7 @@ def plan_cmd(
             provenance_map = _build_provenance_map(composed_from_provenance)
             click.echo()
             _emit_graph(phase_info, provenance_map, graph_format, graph_layout)
+        _emit_recommended_skills(recommended_skills)
         return
 
     # ── JSON output mode ──
@@ -789,9 +819,12 @@ def plan_cmd(
                     )
 
         has_new_keys = (
-            output_todo or output_graph or (composed_from_provenance is not None)
+            output_todo
+            or output_graph
+            or (composed_from_provenance is not None)
+            or with_skills
         )
-        schema_ver = "2" if has_new_keys else "1"
+        schema_ver = "3" if with_skills else ("2" if has_new_keys else "1")
 
         result = {
             "schema_version": schema_ver,
@@ -827,6 +860,9 @@ def plan_cmd(
                 )
             if graph_format in ("mermaid", "both"):
                 result["graph_mermaid"] = render_mermaid(mermaid_phases)
+
+        if with_skills:
+            result["recommended_skills"] = recommended_skills or []
 
         click.echo(json.dumps(result, ensure_ascii=False, indent=2))
         return
@@ -879,3 +915,4 @@ def plan_cmd(
     if output_graph:
         provenance_map = _build_provenance_map(composed_from_provenance)
         _emit_graph(phase_info, provenance_map, graph_format, graph_layout)
+    _emit_recommended_skills(recommended_skills)

--- a/src/fx_alfred/commands/skill_cmd.py
+++ b/src/fx_alfred/commands/skill_cmd.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import json
+
+import click
+
+from fx_alfred.commands._helpers import scan_or_fail
+from fx_alfred.context import root_option
+from fx_alfred.core.skills import (
+    SCHEMA_VERSION,
+    SkillLookupError,
+    list_skills,
+    read_skill,
+    skill_metadata,
+)
+
+
+@click.group("skill")
+@root_option
+def skill_cmd() -> None:
+    """Discover and read explicit skill documents."""
+
+
+@skill_cmd.command("list")
+@click.option("--task", default=None, help="Score skills for a task description.")
+@click.option(
+    "--layer",
+    type=click.Choice(["PKG", "USR", "PRJ", "all"], case_sensitive=False),
+    default="all",
+    help="Filter by document layer.",
+)
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON object.")
+@click.pass_context
+def skill_list_cmd(
+    ctx: click.Context,
+    task: str | None,
+    layer: str,
+    json_output: bool,
+) -> None:
+    """List skill documents."""
+    docs = scan_or_fail(ctx)
+    results = list_skills(docs, task=task, layer=layer)
+
+    if json_output:
+        click.echo(
+            json.dumps(
+                {"schema_version": SCHEMA_VERSION, "results": results},
+                ensure_ascii=False,
+            )
+        )
+        return
+
+    if not results:
+        click.echo("No matching skills found." if task else "No skills found.")
+        return
+
+    for item in results:
+        layer_label = item["source"]["layer"]
+        score = "" if item["score"] is None else f"  score={item['score']}"
+        click.echo(
+            f"{layer_label:<3}  {item['id']}  {item['type_code']:<3}  "
+            f"{item['title']}{score}"
+        )
+
+
+@skill_cmd.command("read")
+@click.argument("identifier")
+@click.option(
+    "--json",
+    "json_output",
+    is_flag=True,
+    help="Output as JSON object with metadata and content.",
+)
+@click.pass_context
+def skill_read_cmd(
+    ctx: click.Context,
+    identifier: str,
+    json_output: bool,
+) -> None:
+    """Read a skill by ID, ACID, exact title, or slug."""
+    docs = scan_or_fail(ctx)
+    try:
+        doc, content = read_skill(docs, identifier)
+    except SkillLookupError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if json_output:
+        click.echo(
+            json.dumps(
+                {
+                    "schema_version": SCHEMA_VERSION,
+                    "document": skill_metadata(doc),
+                    "content": content,
+                },
+                ensure_ascii=False,
+            )
+        )
+        return
+
+    click.echo(content)

--- a/src/fx_alfred/core/agent_helpers.py
+++ b/src/fx_alfred/core/agent_helpers.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import inspect
+import json
+import os
+import subprocess
+import sys
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Iterator
+
+
+SCHEMA_VERSION = "1"
+AGENT_TOOLS_ENV = "ALFRED_AGENT_TOOLS"
+
+
+class AgentArgError(ValueError):
+    """Raised when helper arguments are malformed."""
+
+
+def agent_tools_enabled() -> bool:
+    """Return True only when agent tooling is explicitly enabled."""
+    return os.environ.get(AGENT_TOOLS_ENV) == "1"
+
+
+def parse_arg_pairs(arg_pairs: tuple[str, ...]) -> dict[str, str]:
+    """Parse repeated key=value options, splitting only on the first equals."""
+    result: dict[str, str] = {}
+    for pair in arg_pairs:
+        if "=" not in pair:
+            raise AgentArgError(f"invalid --arg {pair!r}; expected key=value")
+        key, value = pair.split("=", 1)
+        if not key:
+            raise AgentArgError("invalid --arg with empty key")
+        if key in result:
+            raise AgentArgError(f"duplicate --arg key: {key}")
+        result[key] = value
+    return result
+
+
+def gate_error_envelope(kind: str, name: str) -> dict[str, Any]:
+    """Build a JSON error envelope for disabled agent tooling."""
+    envelope: dict[str, Any] = {
+        "schema_version": SCHEMA_VERSION,
+        "status": "error",
+        "source": None,
+        "error": {
+            "type": "PermissionError",
+            "message": f"{AGENT_TOOLS_ENV}=1 is required to run agent {kind}",
+        },
+    }
+    if kind == "helper":
+        envelope["helper"] = name
+    else:
+        envelope["script"] = name
+        envelope["exit_code"] = None
+        envelope["stdout"] = ""
+        envelope["stderr"] = envelope["error"]["message"]
+    return envelope
+
+
+def helper_candidates(root: Path) -> list[tuple[str, Path]]:
+    """Return PRJ then USR helper locations."""
+    return [
+        ("PRJ", root / ".alfred" / "agent_helpers.py"),
+        ("USR", Path.home() / ".alfred" / "agent_helpers.py"),
+    ]
+
+
+def _source(layer: str, path: Path) -> dict[str, str]:
+    return {"layer": layer, "path": str(path)}
+
+
+@contextmanager
+def _loaded_module(path: Path, layer: str) -> Iterator[ModuleType]:
+    """Load a helper module under a unique synthetic name, then remove it."""
+    module_name = f"_alfred_agent_helpers_{layer.lower()}_{uuid.uuid4().hex}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"cannot load helper module: {path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        sys.modules.pop(module_name, None)
+
+
+def _public_helpers(module: ModuleType) -> dict[str, Any]:
+    helpers: dict[str, Any] = {}
+    for name, value in vars(module).items():
+        if name.startswith("_"):
+            continue
+        if inspect.isfunction(value) and value.__module__ == module.__name__:
+            helpers[name] = value
+    return helpers
+
+
+def _error_envelope(
+    helper: str,
+    error_type: str,
+    message: str,
+    source: dict[str, str] | None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "helper": helper,
+        "source": source,
+        "status": "error",
+        "error": {"type": error_type, "message": message},
+    }
+
+
+def _ok_envelope(
+    helper: str,
+    source: dict[str, str],
+    result: Any,
+) -> dict[str, Any]:
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "helper": helper,
+        "source": source,
+        "status": "ok",
+        "result": result,
+    }
+
+
+def call_helper(root: Path, helper_name: str, kwargs: dict[str, str]) -> dict[str, Any]:
+    """Find and execute a helper, returning a JSON-serializable envelope."""
+    for layer, path in helper_candidates(root):
+        if not path.exists():
+            continue
+        source = _source(layer, path)
+        try:
+            with _loaded_module(path, layer) as module:
+                helpers = _public_helpers(module)
+                helper = helpers.get(helper_name)
+                if helper is None:
+                    continue
+
+                try:
+                    if inspect.iscoroutinefunction(helper):
+                        result = asyncio.run(helper(**kwargs))
+                    else:
+                        result = helper(**kwargs)
+                except Exception as exc:
+                    return _error_envelope(
+                        helper_name, type(exc).__name__, str(exc), source
+                    )
+
+                try:
+                    json.dumps(result)
+                except TypeError as exc:
+                    return _error_envelope(
+                        helper_name, type(exc).__name__, str(exc), source
+                    )
+                return _ok_envelope(helper_name, source, result)
+        except Exception as exc:
+            return _error_envelope(helper_name, type(exc).__name__, str(exc), source)
+
+    return _error_envelope(
+        helper_name,
+        "HelperNotFound",
+        f"helper not found: {helper_name}",
+        None,
+    )
+
+
+def resolve_script_path(root: Path, script_path: str) -> Path:
+    """Resolve script paths relative to the project root unless absolute."""
+    path = Path(script_path)
+    if not path.is_absolute():
+        path = root / path
+    return path
+
+
+def run_script(root: Path, script_path: str) -> dict[str, Any]:
+    """Execute a Python script through the current interpreter."""
+    path = resolve_script_path(root, script_path)
+    source = _source("explicit", path)
+    if not path.is_file():
+        message = f"script not found: {path}"
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "script": str(path),
+            "source": source,
+            "status": "error",
+            "exit_code": None,
+            "stdout": "",
+            "stderr": message,
+            "error": {"type": "FileNotFoundError", "message": message},
+        }
+
+    completed = subprocess.run(
+        [sys.executable, str(path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "script": str(path),
+        "source": source,
+        "status": "ok" if completed.returncode == 0 else "error",
+        "exit_code": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }

--- a/src/fx_alfred/core/skills.py
+++ b/src/fx_alfred/core/skills.py
@@ -1,0 +1,185 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from fx_alfred.core.document import Document
+from fx_alfred.core.parser import MalformedDocumentError, parse_metadata, parse_tags
+from fx_alfred.core.schema import TASK_TAGS
+
+
+SCHEMA_VERSION = "1"
+_SKILL_TYPES = {"REF", "SOP"}
+_SOURCE_PRECEDENCE = {"prj": 0, "usr": 1, "pkg": 2}
+
+
+class SkillLookupError(ValueError):
+    """Raised when a skill identifier cannot be resolved."""
+
+
+def doc_id(doc: Document) -> str:
+    return f"{doc.prefix}-{doc.acid}"
+
+
+def is_skill_doc(doc: Document) -> bool:
+    """Return True only for REF/SOP documents explicitly tagged as skills."""
+    return doc.type_code in _SKILL_TYPES and "skill" in doc.tags
+
+
+def _read_content(doc: Document) -> str:
+    return doc.resolve_resource().read_text()
+
+
+def _field_value(doc: Document, field: str) -> str | None:
+    try:
+        parsed = parse_metadata(_read_content(doc))
+    except (OSError, MalformedDocumentError):
+        return None
+    field_map = {mf.key: mf.value for mf in parsed.metadata_fields}
+    return field_map.get(field)
+
+
+def task_tags(doc: Document) -> list[str]:
+    raw = _field_value(doc, TASK_TAGS)
+    return parse_tags(raw) if raw else []
+
+
+def _body(doc: Document) -> str:
+    try:
+        return parse_metadata(_read_content(doc)).body
+    except (OSError, MalformedDocumentError):
+        return ""
+
+
+def _source(doc: Document) -> dict[str, str]:
+    try:
+        path = str(doc.resolve_resource())
+    except ValueError:
+        path = doc.filename
+    return {"layer": doc.source.upper(), "path": path}
+
+
+def skill_metadata(doc: Document) -> dict[str, Any]:
+    return {
+        "id": doc_id(doc),
+        "prefix": doc.prefix,
+        "acid": doc.acid,
+        "type_code": doc.type_code,
+        "title": doc.title,
+        "source": _source(doc),
+        "tags": doc.tags,
+        "task_tags": task_tags(doc),
+    }
+
+
+def _tokenize(text: str) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for token in re.findall(r"[a-z0-9]+", text.lower()):
+        if token in seen:
+            continue
+        seen.add(token)
+        result.append(token)
+    return result
+
+
+def _normalize(text: str) -> str:
+    return " ".join(_tokenize(text))
+
+
+def _slug(text: str) -> str:
+    return _normalize(text).replace(" ", "-")
+
+
+def _score_skill(doc: Document, task: str) -> tuple[int, list[str]]:
+    score = 0
+    reasons: list[str] = []
+    tokens = _tokenize(task)
+
+    task_tag_set = set(task_tags(doc))
+    tag_set = set(doc.tags)
+    title_tokens = set(_tokenize(doc.title))
+    body_tokens = set(_tokenize(_body(doc)))
+
+    for token in tokens:
+        if token in task_tag_set:
+            score += 4
+            reasons.append(f"task_tags:{token}")
+        if token in tag_set:
+            score += 3
+            reasons.append(f"tags:{token}")
+        if token in title_tokens:
+            score += 2
+            reasons.append(f"title:{token}")
+        if token in body_tokens:
+            score += 1
+            reasons.append(f"body:{token}")
+    return score, reasons
+
+
+def list_skills(
+    docs: list[Document],
+    task: str | None = None,
+    layer: str = "all",
+) -> list[dict[str, Any]]:
+    """Return skill metadata, optionally scored against a task description."""
+    layer_filter = layer.lower()
+    skills = [doc for doc in docs if is_skill_doc(doc)]
+    if layer_filter != "all":
+        skills = [doc for doc in skills if doc.source == layer_filter]
+
+    results: list[dict[str, Any]] = []
+    for doc in skills:
+        item = skill_metadata(doc)
+        if task:
+            score, reasons = _score_skill(doc, task)
+            if score <= 0:
+                continue
+            item["score"] = score
+            item["match_reasons"] = reasons
+        else:
+            item["score"] = None
+            item["match_reasons"] = []
+        results.append(item)
+
+    def sort_key(item: dict[str, Any]) -> tuple[Any, ...]:
+        source_layer = item["source"]["layer"].lower()
+        source_rank = _SOURCE_PRECEDENCE.get(source_layer, 99)
+        if task:
+            return (-int(item["score"]), source_rank, item["id"])
+        return (source_rank, item["id"])
+
+    results.sort(key=sort_key)
+    return results
+
+
+def read_skill(docs: list[Document], identifier: str) -> tuple[Document, str]:
+    """Resolve and read one skill document."""
+    skills = [doc for doc in docs if is_skill_doc(doc)]
+    identifier_norm = identifier.strip()
+    identifier_upper = identifier_norm.upper()
+    identifier_title = _normalize(identifier_norm)
+    identifier_slug = _slug(identifier_norm)
+
+    if "-" in identifier_norm and re.match(r"^[A-Za-z]{3}-\d{4}$", identifier_norm):
+        matches = [doc for doc in skills if doc_id(doc).upper() == identifier_upper]
+    elif re.match(r"^\d{4}$", identifier_norm):
+        matches = [doc for doc in skills if doc.acid == identifier_norm]
+    else:
+        matches = [
+            doc
+            for doc in skills
+            if _normalize(doc.title) == identifier_title
+            or _slug(doc.title) == identifier_slug
+        ]
+
+    if not matches:
+        raise SkillLookupError(f"No skill found: {identifier}")
+    if len(matches) > 1:
+        options = ", ".join(doc_id(doc) for doc in matches)
+        raise SkillLookupError(
+            f"Ambiguous skill identifier {identifier}. Multiple matches: {options}."
+        )
+
+    doc = matches[0]
+    return doc, _read_content(doc)

--- a/tests/test_agent_cmd.py
+++ b/tests/test_agent_cmd.py
@@ -1,0 +1,295 @@
+"""Tests for af agent command (FXA-2236)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from fx_alfred.cli import cli
+
+
+def _project_helper(root: Path, content: str) -> Path:
+    helper_dir = root / ".alfred"
+    helper_dir.mkdir(exist_ok=True)
+    helper = helper_dir / "agent_helpers.py"
+    helper.write_text(content)
+    return helper
+
+
+def _user_helper(content: str) -> Path:
+    helper_dir = Path.home() / ".alfred"
+    helper_dir.mkdir(exist_ok=True)
+    helper = helper_dir / "agent_helpers.py"
+    helper.write_text(content)
+    return helper
+
+
+def test_agent_call_without_gate_refuses_without_importing_project_helper(
+    sample_project,
+):
+    _project_helper(sample_project, 'raise RuntimeError("helper imported")\n')
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "call", "boom", "--json"],
+    )
+
+    assert result.exit_code != 0
+    data = json.loads(result.output)
+    assert data["status"] == "error"
+    assert data["error"]["type"] == "PermissionError"
+    assert "helper imported" not in result.output
+
+
+def test_agent_call_gate_requires_exact_one(sample_project):
+    _project_helper(sample_project, 'def hello():\n    return "ok"\n')
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "call", "hello", "--json"],
+        env={"ALFRED_AGENT_TOOLS": "true"},
+    )
+
+    assert result.exit_code != 0
+    data = json.loads(result.output)
+    assert data["error"]["type"] == "PermissionError"
+
+
+def test_agent_call_text_gate_disabled_errors_without_import(sample_project):
+    _project_helper(sample_project, 'raise RuntimeError("helper imported")\n')
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "call", "hello"],
+    )
+
+    assert result.exit_code != 0
+    assert "ALFRED_AGENT_TOOLS=1" in result.output
+    assert "helper imported" not in result.output
+
+
+def test_agent_call_user_helper_json_success(sample_project):
+    _user_helper('def hello(name):\n    return {"name": name}\n')
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--root",
+            str(sample_project),
+            "agent",
+            "call",
+            "hello",
+            "--arg",
+            "name=Frank",
+            "--json",
+        ],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["schema_version"] == "1"
+    assert data["status"] == "ok"
+    assert data["result"] == {"name": "Frank"}
+    assert data["source"]["layer"] == "USR"
+
+
+def test_agent_call_project_overrides_user_without_importing_user(sample_project):
+    _project_helper(sample_project, 'def who():\n    return "project"\n')
+    _user_helper('raise RuntimeError("user helper imported")\n')
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "call", "who", "--json"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["result"] == "project"
+    assert data["source"]["layer"] == "PRJ"
+
+
+def test_agent_call_project_import_failure_does_not_fallback_to_user(sample_project):
+    _project_helper(sample_project, "def broken(:\n    pass\n")
+    _user_helper('def broken():\n    return "user"\n')
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "call", "broken", "--json"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code != 0
+    data = json.loads(result.output)
+    assert data["status"] == "error"
+    assert data["source"]["layer"] == "PRJ"
+    assert data["error"]["type"] == "SyntaxError"
+    assert "user" not in result.output
+
+
+def test_agent_call_imported_callable_is_not_registered(sample_project):
+    _project_helper(sample_project, "from pathlib import Path\n")
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "call", "Path", "--json"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code != 0
+    data = json.loads(result.output)
+    assert data["error"]["type"] == "HelperNotFound"
+
+
+def test_agent_call_text_missing_helper_errors(sample_project):
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "call", "missing"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code != 0
+    assert "helper not found: missing" in result.output
+
+
+def test_agent_call_async_helper_is_awaited(sample_project):
+    _project_helper(
+        sample_project,
+        "async def async_hello(name):\n    return {'message': 'hello ' + name}\n",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--root",
+            str(sample_project),
+            "agent",
+            "call",
+            "async_hello",
+            "--arg",
+            "name=Frank",
+            "--json",
+        ],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["result"] == {"message": "hello Frank"}
+
+
+def test_agent_call_arg_splits_on_first_equals(sample_project):
+    _project_helper(sample_project, "def echo(url):\n    return url\n")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--root",
+            str(sample_project),
+            "agent",
+            "call",
+            "echo",
+            "--arg",
+            "url=https://example.com?a=1",
+            "--json",
+        ],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(result.output)["result"] == "https://example.com?a=1"
+
+
+def test_agent_call_duplicate_arg_is_usage_error(sample_project):
+    _project_helper(sample_project, "def echo(name):\n    return name\n")
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--root",
+            str(sample_project),
+            "agent",
+            "call",
+            "echo",
+            "--arg",
+            "name=one",
+            "--arg",
+            "name=two",
+        ],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code != 0
+    assert "duplicate" in result.output.lower()
+
+
+def test_agent_call_json_serialization_failure_returns_error(sample_project):
+    _project_helper(sample_project, "def bad():\n    return {1, 2, 3}\n")
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "call", "bad", "--json"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code != 0
+    data = json.loads(result.output)
+    assert data["status"] == "error"
+    assert data["error"]["type"] == "TypeError"
+
+
+def test_agent_run_json_root_relative_script_uses_current_python(sample_project):
+    script = sample_project / "show_executable.py"
+    script.write_text(
+        "import json, sys\nprint(json.dumps({'executable': sys.executable}))\n"
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "run", "show_executable.py", "--json"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["status"] == "ok"
+    assert data["source"]["layer"] == "explicit"
+    assert json.loads(data["stdout"])["executable"] == sys.executable
+
+
+def test_agent_run_missing_script_json_envelope(sample_project):
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "run", "missing.py", "--json"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code != 0
+    data = json.loads(result.output)
+    assert data["status"] == "error"
+    assert data["exit_code"] is None
+    assert "script not found" in data["stderr"]
+
+
+def test_agent_run_text_mode_replays_stdout_stderr_and_exit_code(sample_project):
+    script = sample_project / "noisy.py"
+    script.write_text(
+        "import sys\n"
+        "print('hello stdout')\n"
+        "print('hello stderr', file=sys.stderr)\n"
+        "raise SystemExit(3)\n"
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "run", "noisy.py"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    assert result.exit_code == 3
+    assert "hello stdout" in result.output
+    assert "hello stderr" in result.output

--- a/tests/test_lazy.py
+++ b/tests/test_lazy.py
@@ -151,3 +151,35 @@ class TestLazyCliIntegration:
         assert isinstance(cli, LazyGroup)
         assert hasattr(cli, "_lazy_subcommands")
         assert len(cli._lazy_subcommands) >= 8
+
+    def test_agent_nested_group_help_resolves(self):
+        """LazyGroup resolves af agent and its nested subcommands."""
+        from click.testing import CliRunner
+
+        from fx_alfred.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["agent", "--help"])
+        assert result.exit_code == 0
+        assert "call" in result.output
+        assert "run" in result.output
+
+        result = runner.invoke(cli, ["agent", "call", "--help"])
+        assert result.exit_code == 0
+        assert "--arg" in result.output
+
+    def test_skill_nested_group_help_resolves(self):
+        """LazyGroup resolves af skill and its nested subcommands."""
+        from click.testing import CliRunner
+
+        from fx_alfred.cli import cli
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["skill", "--help"])
+        assert result.exit_code == 0
+        assert "list" in result.output
+        assert "read" in result.output
+
+        result = runner.invoke(cli, ["skill", "list", "--help"])
+        assert result.exit_code == 0
+        assert "--task" in result.output

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -1,5 +1,6 @@
 """Tests for af plan command (FXA-2134)."""
 
+import json
 from pathlib import Path
 
 import click
@@ -130,6 +131,154 @@ def test_setup_outputs_prompts(sample_project, monkeypatch):
     assert result.exit_code == 0
     assert "af plan" in result.output
     assert "af guide" in result.output
+
+
+def _create_skill_ref(
+    rules_dir: Path,
+    prefix: str,
+    acid: str,
+    file_title: str,
+    *,
+    tags: str = "skill",
+    task_tags: str = "release",
+) -> Path:
+    """Helper to create a REF skill document."""
+    filename = f"{prefix}-{acid}-REF-{file_title}.md"
+    filepath = rules_dir / filename
+    filepath.write_text(
+        f"# REF-{acid}: {file_title.replace('-', ' ')}\n\n"
+        "**Applies to:** Test\n"
+        "**Last updated:** 2026-05-05\n"
+        "**Last reviewed:** 2026-05-05\n"
+        "**Status:** Active\n"
+        f"**Tags:** {tags}\n"
+        f"**Task tags:** {task_tags}\n\n"
+        "---\n\n"
+        "## What Is It?\n\n"
+        "A skill document for release work.\n\n"
+        "---\n\n"
+        "## Change History\n\n"
+        "| Date | Change | By |\n|------|--------|----|\n"
+        "| 2026-05-05 | Initial version | Test |\n"
+    )
+    return filepath
+
+
+def test_plan_with_skills_requires_task(sample_project, monkeypatch):
+    """--with-skills requires --task even in JSON mode."""
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+
+    result = runner.invoke(cli, ["plan", "--with-skills", "COR-1103"])
+    assert result.exit_code != 0
+    assert "--with-skills requires --task" in result.output
+
+    result = runner.invoke(cli, ["plan", "--with-skills", "--json", "COR-1103"])
+    assert result.exit_code != 0
+    assert "--with-skills requires --task" in result.output
+
+
+def test_plan_with_skills_json_top_level_schema_v3(sample_project, monkeypatch):
+    """--with-skills adds top-level recommended_skills and schema v3."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Release-Workflow")
+    _create_skill_ref(
+        rules_dir,
+        "TST",
+        "5002",
+        "Skill-Release-To-PyPI",
+        tags="skill, release, pypi",
+        task_tags="release, pypi",
+    )
+
+    monkeypatch.chdir(sample_project)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "plan",
+            "--task",
+            "release pypi",
+            "--with-skills",
+            "--json",
+            "TST-5001",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["schema_version"] == "3"
+    assert "recommended_skills" in data
+    assert data["recommended_skills"][0]["id"] == "TST-5002"
+
+
+def test_plan_with_skills_json_empty_match_keeps_empty_array(
+    sample_project, monkeypatch
+):
+    """--with-skills emits [] when no skill matches."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Release-Workflow")
+    _create_skill_ref(
+        rules_dir,
+        "TST",
+        "5002",
+        "Skill-Release-To-PyPI",
+        tags="skill, release, pypi",
+        task_tags="release, pypi",
+    )
+
+    monkeypatch.chdir(sample_project)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "plan",
+            "--task",
+            "no-match-token",
+            "--with-skills",
+            "--json",
+            "TST-5001",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["schema_version"] == "3"
+    assert data["recommended_skills"] == []
+
+
+def test_plan_with_skills_text_appends_after_graph(sample_project, monkeypatch):
+    """Recommended Skills block appears after normal text and graph output."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Release-Workflow")
+    _create_skill_ref(
+        rules_dir,
+        "TST",
+        "5002",
+        "Skill-Release-To-PyPI",
+        tags="skill, release, pypi",
+        task_tags="release, pypi",
+    )
+
+    monkeypatch.chdir(sample_project)
+    result = CliRunner().invoke(
+        cli,
+        [
+            "plan",
+            "--task",
+            "release pypi",
+            "--with-skills",
+            "--graph",
+            "--graph-format",
+            "ascii",
+            "TST-5001",
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "# Recommended Skills" in result.output
+    assert result.output.rfind("# Recommended Skills") > result.output.rfind("Phase")
 
 
 def test_plan_no_args(sample_project, monkeypatch):

--- a/tests/test_skill_cmd.py
+++ b/tests/test_skill_cmd.py
@@ -1,0 +1,366 @@
+"""Tests for af skill command (FXA-2236)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from fx_alfred.cli import cli
+
+
+def _doc_content(
+    type_code: str,
+    acid: str,
+    title: str,
+    *,
+    tags: str | None = None,
+    task_tags: str | None = None,
+    body: str = "Release packaging helper.",
+) -> str:
+    lines = [
+        f"# {type_code}-{acid}: {title}",
+        "",
+        "**Applies to:** TST project",
+        "**Last updated:** 2026-05-05",
+        "**Last reviewed:** 2026-05-05",
+        "**Status:** Active",
+    ]
+    if tags is not None:
+        lines.append(f"**Tags:** {tags}")
+    if task_tags is not None:
+        lines.append(f"**Task tags:** {task_tags}")
+    lines.extend(
+        [
+            "",
+            "---",
+            "",
+            "## What Is It?",
+            "",
+            body,
+            "",
+            "---",
+            "",
+            "## Change History",
+            "",
+            "| Date | Change | By |",
+            "|------|--------|----|",
+            "| 2026-05-05 | Initial version | Test |",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _project_doc(
+    root: Path,
+    prefix: str,
+    acid: str,
+    type_code: str,
+    file_title: str,
+    *,
+    h1_title: str | None = None,
+    tags: str | None = None,
+    task_tags: str | None = None,
+    body: str = "Release packaging helper.",
+) -> Path:
+    path = root / "rules" / f"{prefix}-{acid}-{type_code}-{file_title}.md"
+    path.write_text(
+        _doc_content(
+            type_code,
+            acid,
+            h1_title or file_title.replace("-", " "),
+            tags=tags,
+            task_tags=task_tags,
+            body=body,
+        )
+    )
+    return path
+
+
+def _user_doc(
+    prefix: str,
+    acid: str,
+    type_code: str,
+    file_title: str,
+    *,
+    h1_title: str | None = None,
+    tags: str | None = None,
+    task_tags: str | None = None,
+) -> Path:
+    user_dir = Path.home() / ".alfred"
+    user_dir.mkdir(exist_ok=True)
+    path = user_dir / f"{prefix}-{acid}-{type_code}-{file_title}.md"
+    path.write_text(
+        _doc_content(
+            type_code,
+            acid,
+            h1_title or file_title.replace("-", " "),
+            tags=tags,
+            task_tags=task_tags,
+        )
+    )
+    return path
+
+
+def test_skill_list_returns_only_marked_ref_or_sop(sample_project):
+    _project_doc(
+        sample_project,
+        "TST",
+        "5001",
+        "REF",
+        "Skill-Release",
+        h1_title="Skill: Release",
+        tags="Skill, release",
+        task_tags="release",
+    )
+    _project_doc(
+        sample_project,
+        "TST",
+        "5002",
+        "SOP",
+        "Task-Tagged-Only",
+        task_tags="release",
+    )
+    _project_doc(
+        sample_project,
+        "TST",
+        "5003",
+        "PRP",
+        "Skill-But-Wrong-Type",
+        tags="skill",
+    )
+
+    result = CliRunner().invoke(cli, ["--root", str(sample_project), "skill", "list"])
+
+    assert result.exit_code == 0
+    assert "TST-5001" in result.output
+    assert "TST-5002" not in result.output
+    assert "TST-5003" not in result.output
+
+
+def test_skill_list_title_skill_without_tag_is_not_classified(sample_project):
+    _project_doc(
+        sample_project,
+        "TST",
+        "5001",
+        "REF",
+        "Skill-Release",
+        h1_title="Skill: Release",
+    )
+
+    result = CliRunner().invoke(cli, ["--root", str(sample_project), "skill", "list"])
+
+    assert result.exit_code == 0
+    assert "TST-5001" not in result.output
+
+
+def test_skill_list_task_json_scores_and_match_reasons(sample_project):
+    _project_doc(
+        sample_project,
+        "TST",
+        "5001",
+        "REF",
+        "Skill-Release-To-PyPI",
+        h1_title="Skill: Release To PyPI",
+        tags="skill, packaging",
+        task_tags="release, pypi",
+        body="Build and publish a package release.",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--root",
+            str(sample_project),
+            "skill",
+            "list",
+            "--task",
+            "release pypi",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["schema_version"] == "1"
+    assert len(data["results"]) == 1
+    item = data["results"][0]
+    assert item["id"] == "TST-5001"
+    assert item["source"]["layer"] == "PRJ"
+    assert item["score"] > 0
+    assert "task_tags:release" in item["match_reasons"]
+
+
+def test_skill_list_without_task_defaults_all_layers_and_null_scores(sample_project):
+    _project_doc(
+        sample_project,
+        "TST",
+        "5001",
+        "REF",
+        "Skill-Project",
+        h1_title="Skill: Project",
+        tags="skill",
+    )
+    _user_doc(
+        "USR",
+        "5002",
+        "REF",
+        "Skill-User",
+        h1_title="Skill: User",
+        tags="skill",
+    )
+
+    result = CliRunner().invoke(
+        cli, ["--root", str(sample_project), "skill", "list", "--json"]
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    layers = [item["source"]["layer"] for item in data["results"]]
+    assert "PRJ" in layers
+    assert "USR" in layers
+    assert all(item["score"] is None for item in data["results"])
+    assert all(item["match_reasons"] == [] for item in data["results"])
+
+
+def test_skill_list_layer_filter_returns_only_selected_layer(sample_project):
+    _project_doc(
+        sample_project,
+        "TST",
+        "5001",
+        "REF",
+        "Skill-Project",
+        h1_title="Skill: Project",
+        tags="skill",
+    )
+    _user_doc(
+        "USR",
+        "5002",
+        "REF",
+        "Skill-User",
+        h1_title="Skill: User",
+        tags="skill",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "skill", "list", "--layer", "PRJ", "--json"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert [item["id"] for item in data["results"]] == ["TST-5001"]
+    assert all(item["source"]["layer"] == "PRJ" for item in data["results"])
+
+
+def test_skill_read_resolves_full_id(sample_project):
+    _project_doc(
+        sample_project,
+        "TST",
+        "5001",
+        "REF",
+        "Skill-Release-To-PyPI",
+        h1_title="Skill: Release To PyPI",
+        tags="skill, release, pypi",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "skill", "read", "TST-5001", "--json"],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["document"]["id"] == "TST-5001"
+
+
+def test_skill_read_resolves_slug_and_json_content(sample_project):
+    _project_doc(
+        sample_project,
+        "TST",
+        "5001",
+        "REF",
+        "Skill-Release-To-PyPI",
+        h1_title="Skill: Release To PyPI",
+        tags="skill, release, pypi",
+        task_tags="release",
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "--root",
+            str(sample_project),
+            "skill",
+            "read",
+            "skill-release-to-pypi",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["schema_version"] == "1"
+    assert data["document"]["id"] == "TST-5001"
+    assert data["document"]["tags"] == ["skill", "release", "pypi"]
+    assert data["content"].startswith("# REF-5001")
+
+
+def test_skill_read_acid_only_ambiguity_errors(sample_project):
+    _project_doc(
+        sample_project,
+        "TST",
+        "5007",
+        "REF",
+        "Skill-One",
+        h1_title="Skill: One",
+        tags="skill",
+    )
+    _project_doc(
+        sample_project,
+        "ABC",
+        "5007",
+        "REF",
+        "Skill-Two",
+        h1_title="Skill: Two",
+        tags="skill",
+    )
+
+    result = CliRunner().invoke(
+        cli, ["--root", str(sample_project), "skill", "read", "5007"]
+    )
+
+    assert result.exit_code != 0
+    assert "ambiguous" in result.output.lower()
+
+
+def test_skill_read_not_found_errors(sample_project):
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "skill", "read", "missing-skill"],
+    )
+
+    assert result.exit_code != 0
+    assert "No skill found: missing-skill" in result.output
+
+
+def test_skill_commands_do_not_import_agent_helpers(sample_project):
+    helper_dir = sample_project / ".alfred"
+    helper_dir.mkdir()
+    (helper_dir / "agent_helpers.py").write_text('raise RuntimeError("imported")\n')
+    _project_doc(
+        sample_project,
+        "TST",
+        "5001",
+        "REF",
+        "Skill-Release",
+        h1_title="Skill: Release",
+        tags="skill",
+    )
+
+    result = CliRunner().invoke(cli, ["--root", str(sample_project), "skill", "list"])
+
+    assert result.exit_code == 0
+    assert "TST-5001" in result.output
+    assert "imported" not in result.output


### PR DESCRIPTION
## Summary

- Add `af agent call` and `af agent run` behind the exact `ALFRED_AGENT_TOOLS=1` opt-in gate.
- Add read-only `af skill list/read` for explicit `REF`/`SOP` skill docs tagged with `Tags: skill`.
- Add `af plan --with-skills` with JSON schema v3 `recommended_skills` output.
- Add FXA-2236 CHG, FXA-2237 usage REF, README/changelog updates, and bump version to v1.10.0.

Closes #94

## Notes

Skill classification follows the approved FXA-2235 P0 contract: skill docs must be `REF`/`SOP` documents with explicit `Tags: skill`; title-only `Skill:` documents are not classified as skills.

## Verification

- `PYTHONPATH=src .venv/bin/pytest tests/test_agent_cmd.py tests/test_skill_cmd.py tests/test_plan_cmd.py tests/test_lazy.py -q` -> 130 passed
- `PYTHONPATH=src .venv/bin/pytest -q` -> 866 passed
- `PYTHONPATH=src .venv/bin/ruff check .` -> pass
- `PYTHONPATH=src .venv/bin/ruff format --check .` -> pass
- `PYTHONPATH=src .venv/bin/pyright src/` -> 0 errors
- `PYTHONPATH=src .venv/bin/af validate --root .` -> 201 documents checked, 0 issues found
- Trinity fast-review -> GLM PASS, DeepSeek PASS; low-risk advisories addressed where in P0 scope
