### PR TITLE
docs: add COR-1615 operator checklist

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -147,6 +147,7 @@
 | 2235 | PRP | Agent Editable Helpers And Skills |
 | 2236 | CHG | Implement Agent Editable Helpers And Skills |
 | 2237 | REF | Agent Helpers And Skills Usage |
+| 2238 | CHG | Add COR 1615 Operator Checklist |
 
 ---
 

--- a/rules/FXA-2238-CHG-Add-COR-1615-Operator-Checklist.md
+++ b/rules/FXA-2238-CHG-Add-COR-1615-Operator-Checklist.md
@@ -58,6 +58,7 @@ The current SOP already contains these rules, but they are spread across Prerequ
 | Date | Action | Result |
 |------|--------|--------|
 | 2026-05-05 | Created CHG and updated COR-1615 with checklist/prompt. | Validation and representative read/plan checks passed. |
+| 2026-05-05 | Addressed Codex PR review feedback. | Replaced `P1/P2` wording with all actionable findings to match COR-1612 handoff semantics. |
 
 ---
 

--- a/rules/FXA-2238-CHG-Add-COR-1615-Operator-Checklist.md
+++ b/rules/FXA-2238-CHG-Add-COR-1615-Operator-Checklist.md
@@ -1,0 +1,68 @@
+# CHG-2238: Add COR 1615 Operator Checklist
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** Completed
+**Date:** 2026-05-05
+**Requested by:** Frank
+**Priority:** Medium
+**Change Type:** Normal
+**Related:** COR-1615, COR-1612, COR-1615 review-loop checklist notes
+
+---
+
+## What
+
+Add a compact operator checklist and portable prompt to `COR-1615: GitHub App PR Review Bot Loop`.
+
+The checklist makes the existing non-negotiables easier for agents to follow:
+
+- match every review result to the current `headRefOid`;
+- treat acknowledgement reactions as in-progress, not approval;
+- avoid duplicate review triggers while a request is pending;
+- verify visible-write identity before public GitHub writes;
+- avoid leaking local/private environment details;
+- hand off actionable findings to COR-1612, then restart COR-1615 after fix pushes.
+
+## Why
+
+The current SOP already contains these rules, but they are spread across Prerequisites, Status Vocabulary, Steps, Completion Criteria, Pitfalls, and Examples. A short checklist improves operator recall during active PR review loops without duplicating the COR-1612 fix workflow.
+
+## Impact Analysis
+
+- **Systems affected:**
+  - `src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md` - add checklist and portable prompt.
+  - `rules/FXA-0000-REF-Document-Index.md` - add this CHG entry.
+- **Not affected:**
+  - CLI behavior, package version, tests, and schema contracts.
+  - COR-1612 fix-loop details; COR-1615 references COR-1612 instead of duplicating it.
+- **Rollback plan:** Revert the document-only commit and rerun `PYTHONPATH=src .venv/bin/af validate --root .`.
+
+## Implementation Plan
+
+1. Create FXA-2238 CHG.
+2. Add `## Operator Checklist` after COR-1615 Prerequisites.
+3. Add `## Portable Operator Prompt` before COR-1615 References.
+4. Update COR-1615 Change History.
+5. Verify document validation and representative `af read` / `af plan` behavior.
+
+## Testing / Verification
+
+- [x] `PYTHONPATH=src .venv/bin/af validate --root .`
+- [x] `PYTHONPATH=src .venv/bin/af read --root . COR-1615`
+- [x] `PYTHONPATH=src .venv/bin/af plan --root . COR-1615 COR-1612 --todo --graph-format=ascii --graph`
+
+## Execution Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-05-05 | Created CHG and updated COR-1615 with checklist/prompt. | Validation and representative read/plan checks passed. |
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-05 | Added CHG for COR-1615 operator checklist. | Codex |

--- a/src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md
+++ b/src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md
@@ -52,6 +52,21 @@ GitHub App review bots are useful but easy to misread. A reaction on a request c
 
 ---
 
+## Operator Checklist
+
+Core invariant: a PR is not clear until the latest review result applies to the current `headRefOid` and no new actionable findings remain for that head.
+
+- Record the current `headRefOid` before triggering or interpreting a review.
+- After every push, return to Step 1 and compare any bot-reviewed commit with the new `headRefOid`.
+- Treat `eyes` or similar acknowledgement reactions as queued or in-progress, not approval.
+- Do not post duplicate `@codex review` comments or duplicate reviewer requests while a request for the same head is still pending.
+- Verify the visible-write identity with `gh auth status` before posting PR comments, reviewer requests, or replies.
+- Do not publish private IPs, local filesystem paths, tokens, private hostnames, or host-specific secrets in PR bodies, comments, commits, or review packets.
+- For actionable P1/P2 findings, hand off to COR-1612: classify comments, fix blockers, rerun relevant validation, commit, push, and reply where needed.
+- After pushing fixes from COR-1612, return to this SOP Step 1 for the new `headRefOid`.
+
+---
+
 ## Status Vocabulary
 
 | Signal | Meaning | What to do |
@@ -227,6 +242,23 @@ The loop is complete when the latest bot result applies to current `headRefOid`,
 
 ---
 
+## Portable Operator Prompt
+
+```md
+Use the GitHub App PR review bot loop:
+
+- Follow COR-1615 to trigger, poll, and match review results to the current PR head.
+- Follow COR-1612 to address fetched review comments.
+- After every push, compare the reviewed commit with the current headRefOid.
+- Treat eyes reactions as queued or in-progress, not approval.
+- Do not post duplicate review triggers while one request is in progress.
+- Fix actionable P1/P2 findings, validate, commit, push, and restart the current-head review loop.
+- Verify the visible-write identity with gh auth status.
+- Do not publish private IPs, local paths, tokens, or host-specific details in public PR text or commits.
+```
+
+---
+
 ## References
 
 - OpenAI Codex GitHub integration: https://developers.openai.com/codex/integrations/github
@@ -238,4 +270,5 @@ The loop is complete when the latest bot result applies to current `headRefOid`,
 
 | Date | Change | By |
 |------|--------|----|
+| 2026-05-05 | Added compact operator checklist and portable prompt for current-head review-loop non-negotiables. | Codex |
 | 2026-05-05 | Initial COR-level version promoted from BAB-1504, generalized from Codex-specific Babs wording to GitHub App PR review bots. | Codex |

--- a/src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md
+++ b/src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md
@@ -62,7 +62,7 @@ Core invariant: a PR is not clear until the latest review result applies to the 
 - Do not post duplicate `@codex review` comments or duplicate reviewer requests while a request for the same head is still pending.
 - Verify the visible-write identity with `gh auth status` before posting PR comments, reviewer requests, or replies.
 - Do not publish private IPs, local filesystem paths, tokens, private hostnames, or host-specific secrets in PR bodies, comments, commits, or review packets.
-- For actionable P1/P2 findings, hand off to COR-1612: classify comments, fix blockers, rerun relevant validation, commit, push, and reply where needed.
+- For all actionable findings, hand off to COR-1612: classify comments, fix blockers and adopted advisories, rerun relevant validation, commit, push, and reply where needed.
 - After pushing fixes from COR-1612, return to this SOP Step 1 for the new `headRefOid`.
 
 ---
@@ -252,7 +252,7 @@ Use the GitHub App PR review bot loop:
 - After every push, compare the reviewed commit with the current headRefOid.
 - Treat eyes reactions as queued or in-progress, not approval.
 - Do not post duplicate review triggers while one request is in progress.
-- Fix actionable P1/P2 findings, validate, commit, push, and restart the current-head review loop.
+- Fix all actionable findings, validate, commit, push, and restart the current-head review loop.
 - Verify the visible-write identity with gh auth status.
 - Do not publish private IPs, local paths, tokens, or host-specific details in public PR text or commits.
 ```


### PR DESCRIPTION
## Summary

- Add a compact `Operator Checklist` to COR-1615 for current-head review-loop non-negotiables.
- Add a portable operator prompt that points agents to COR-1615 for trigger/poll/current-head matching and COR-1612 for fetched findings.
- Add FXA-2238 CHG and update the project document index.

## Notes

This is a docs-only PKG SOP refinement. It does not change CLI behavior, package version, schemas, or tests.

## Verification

- `PYTHONPATH=src .venv/bin/af validate --root .` -> 202 documents checked, 0 issues found
- `PYTHONPATH=src .venv/bin/af read --root . COR-1615` -> rendered successfully
- `PYTHONPATH=src .venv/bin/af plan --root . COR-1615 COR-1612 --todo --graph-format=ascii --graph` -> rendered successfully
