### PR TITLE
Add COR-1801 pattern promotion SOP

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -148,6 +148,7 @@
 | 2236 | CHG | Implement Agent Editable Helpers And Skills |
 | 2237 | REF | Agent Helpers And Skills Usage |
 | 2238 | CHG | Add COR 1615 Operator Checklist |
+| 2239 | CHG | Add COR 1801 Pattern Promotion SOP |
 
 ---
 

--- a/rules/FXA-2239-CHG-Add-COR-1801-Pattern-Promotion-SOP.md
+++ b/rules/FXA-2239-CHG-Add-COR-1801-Pattern-Promotion-SOP.md
@@ -1,0 +1,170 @@
+# CHG-2239: Add COR-1801 Pattern Promotion SOP
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** Completed
+**Date:** 2026-05-05
+**Requested by:** Frank
+**Priority:** Medium
+**Change Type:** Normal
+**Related:** GitHub issue #62, COR-1800, COR-1000, COR-1102, COR-1101, COR-1300, COR-1301, COR-1500, COR-1602, COR-1613
+
+---
+
+## What
+
+Add a new PKG-level SOP, `COR-1801: Pattern Promotion`, that formalizes how a proven PRJ-layer trial pattern is evaluated and promoted into the PKG/COR layer.
+
+The proposed SOP will cover:
+
+- candidate pattern definition;
+- evidence and promotion criteria templates;
+- promotion issue workflow;
+- reviewer decision states;
+- PKG authoring conventions;
+- PRJ historical-retention rules after promotion;
+- de-promotion / reversal workflow;
+- a worked example based on KIW-0710 as illustrative source material only.
+
+## Why
+
+GitHub issue #62 identifies a current gap: Alfred supports PKG / USR / PRJ layers, but it does not document a reusable workflow for lifting a pattern from PRJ trial status into a universal PKG/COR SOP after the pattern proves itself.
+
+Without a promotion SOP:
+
+- useful PRJ patterns can remain local and rediscovered by each project;
+- immature or project-specific patterns can be promoted too early;
+- reviewers lack a shared rubric for deciding `promote`, `defer`, `reject`, or `revise`;
+- PRJ source documents may be deleted or overwritten, losing the evidence trail.
+
+This CHG creates the missing governance path without changing CLI behavior.
+
+## Impact Analysis
+
+- **Systems affected:**
+  - `src/fx_alfred/rules/COR-1801-SOP-Pattern-Promotion.md` — new PKG SOP.
+  - `src/fx_alfred/rules/COR-0000-REF-Document-Index.md` — add COR-1801.
+  - `src/fx_alfred/rules/COR-1800-REF-Evolution-Philosophy.md` — add relationship pointer to COR-1801.
+  - `src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md` — add routing hint for PRJ-to-PKG pattern promotion.
+  - `rules/FXA-0000-REF-Document-Index.md` — add this CHG entry.
+- **Not affected:**
+  - CLI commands, package version, schema fields, and templates.
+  - Any local Kiwari files; KIW-0710 is not a runtime or validation dependency.
+  - Automatic promotion tooling. Promotion remains a reviewed document workflow.
+- **Rollback plan:** Commit the implementation atomically; rollback is reverting that document-only commit and rerunning `PYTHONPATH=src .venv/bin/af validate --root .`. If implementation is split across multiple commits, revert all related commits together.
+
+## Implementation Plan
+
+1. **Review this CHG first** — completed via `trinity review --preset fast-review --scope rules/FXA-2239-CHG-Add-COR-1801-Pattern-Promotion-SOP.md`; implementation may start only after the CHG status is `Approved`.
+2. **Create COR-1801** in PKG:
+   - filename: `src/fx_alfred/rules/COR-1801-SOP-Pattern-Promotion.md`;
+   - title: `Pattern Promotion`;
+   - type: SOP;
+   - status: Active.
+3. **Author COR-1801 core sections:**
+   - What Is It?
+   - Why
+   - When to Use
+   - When NOT to Use
+   - Candidate Pattern Contract
+   - Promotion Criteria
+   - Promotion Workflow
+   - PKG Authoring Conventions
+   - PRJ Retention After Promotion
+   - De-promotion / Reversal
+   - Worked Example
+   - Steps
+   - Completion Criteria
+   The `Steps` section must include this decision workflow:
+   1. Nominate candidate pattern from PRJ evidence.
+   2. Validate candidate contract completeness.
+   3. Gather evidence against explicit criteria.
+   4. Classify relationship to existing PKG documents: amend existing SOP/REF, create new COR document, defer, or reject.
+   5. Run promotion review and choose exactly one first-time promotion state: `promote`, `defer`, `reject`, or `revise`.
+   6. If promoting, author the PKG change through the normal CHG/PRP lifecycle and assign a new COR ACID.
+   7. Retain and update the originating PRJ document as historical evidence.
+   8. Verify PKG references, indexes, validation, and review evidence.
+4. **Define interaction with existing governance SOPs:**
+   - Use GitHub issue + CHG as the default promotion vehicle.
+   - Use COR-1000 when promotion creates a new PKG SOP; use COR-1300 when promotion amends an existing PKG document instead.
+   - Require PRP first when the promotion creates a new governance family, changes schema/CLI behavior, has unresolved design trade-offs, or would substantially alter multiple COR workflows.
+   - Use COR-1101 for the implementation CHG and COR-1500 for code-bearing promotions.
+   - Use COR-1602 / COR-1608 / COR-1609 / COR-1610 / COR-1613 review gates according to artifact type.
+   - Assign a new COR ACID to promoted PKG documents; never reuse the originating PRJ ACID.
+   - If the candidate overlaps an existing PKG SOP, prefer amending the existing SOP unless the pattern is atomic and independently reusable.
+5. **Resolve issue #62 placement decision:**
+   - Use `COR-1801`, adjacent to `COR-1800 Evolution Philosophy`.
+   - Rationale: pattern promotion is part of COR evolution governance, so the 18xx family is the closest existing namespace.
+6. **Use KIW-0710 only as a summarized example:**
+   - Mention it as an originating PRJ trial SOP from the Kiwari project.
+   - Do not require `/Users/frank/Projects/martin/kiwari` or any local path in COR-1801.
+   - Define the example inline. The R3-outcome triple-fork pattern is: after a multi-reviewer round, classify the outcome as exactly one of `unanimous pass`, `leader accept with logged residual`, or `escalate`, instead of treating review completion as binary pass/fail.
+   - Use outcome `defer unless maintainer endorsement or cross-project evidence is supplied`, because the summarized tracker evidence alone does not meet the pattern's own threshold.
+7. **Update PKG references:**
+   - Add COR-1801 to `src/fx_alfred/rules/COR-0000-REF-Document-Index.md`.
+   - Add a relationship pointer from `src/fx_alfred/rules/COR-1800-REF-Evolution-Philosophy.md` to COR-1801 as a peer 18xx governance SOP, not as a PRJ derivative under the existing project-SOP relationship diagram.
+   - Add a routing hint in `src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md` for "promote PRJ pattern to PKG".
+8. **Verify:**
+   - `PYTHONPATH=src .venv/bin/af validate --root .`
+   - `PYTHONPATH=src .venv/bin/af read --root . COR-1801`
+   - `PYTHONPATH=src .venv/bin/af plan --root . COR-1801 --todo --graph-format=ascii --graph`
+   - `PYTHONPATH=src .venv/bin/af list --root . --source pkg --type SOP`
+9. **Implementation review:** run Trinity fast-review on the implementation diff and revise until pass.
+10. **Open a normal PR** referencing issue #62. If COR-1801 satisfies the issue acceptance criteria, the PR body may use `Closes #62`; otherwise it must leave follow-up promotion exercise explicit.
+
+## Acceptance Criteria
+
+- [x] `COR-1801-SOP-Pattern-Promotion.md` exists in the PKG layer.
+- [x] COR-1801 defines candidate pattern requirements: PRJ source, trial status, origin, rule, when/when-not, and explicit promotion criteria.
+- [x] COR-1801 includes promotion criteria templates: use-count, cross-project evidence, failure-mode demo, time-in-trial, and counter-evidence review.
+- [x] COR-1801 defines promotion states: promote, defer, reject, and revise, plus a separate de-promotion / reversal path for already-promoted PKG documents.
+- [x] COR-1801 defines how promotion reuses GitHub issues, CHGs, PRPs, COR ACID assignment, and existing SOP amendments.
+- [x] COR-1801 defines PKG authoring conventions that abstract away project-specific details while retaining origin traceability.
+- [x] COR-1801 requires retaining the originating PRJ SOP as historical evidence after promotion.
+- [x] COR-1801 includes a worked example based on KIW-0710 without depending on KIW files being available on another machine.
+- [x] COR-0000 and relevant routing/evolution references are updated.
+
+## Open Questions / Defaults
+
+- **PKG or USR?** Default: PKG. The workflow standardizes a multi-project promotion mechanism, not Frank-only preference.
+- **Cross-project threshold?** Default: at least one independent project adoption or explicit maintainer endorsement for initial promotion eligibility. COR-1801 should present stricter templates for high-risk patterns.
+- **De-promotion weight?** Default: issue + CHG. No new CLI command; reversal should be auditable and reviewed. A de-promoted PKG document is deprecated per COR-1301, not deleted, unless the CHG proves that amendment is safer than deprecation.
+- **Does implementing COR-1801 itself promote a KIW pattern?** Default: no. The worked example exercises the evaluation workflow and may produce `defer` when evidence is insufficient.
+
+## Testing / Verification
+
+- [x] CHG review: `trinity review --preset fast-review --scope rules/FXA-2239-CHG-Add-COR-1801-Pattern-Promotion-SOP.md`
+- [x] Implementation review: `trinity review --preset fast-review --scope "FXA-2239 COR-1801 implementation"`
+- [x] `PYTHONPATH=src .venv/bin/af validate --root .`
+- [x] `PYTHONPATH=src .venv/bin/af read --root . COR-1801`
+- [x] `PYTHONPATH=src .venv/bin/af plan --root . COR-1801 --todo --graph-format=ascii --graph`
+- [x] `PYTHONPATH=src .venv/bin/af list --root . --source pkg --type SOP`
+
+## Approval
+
+- [x] CHG reviewed by Trinity fast-review
+- [x] Approved for COR-1801 implementation
+
+## Execution Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-05-05 | Created CHG from GitHub issue #62. | Ready for Trinity fast-review before implementation. |
+| 2026-05-05 | Trinity fast-review R1. | GLM PASS; DeepSeek FIX. Revised for self-contained worked example, cross-SOP workflow interactions, COR-1301 de-promotion default, Approval section, and explicit PKG paths. |
+| 2026-05-05 | Trinity fast-review R2. | GLM PASS; DeepSeek PASS. Addressed remaining advisory notes before implementation. |
+| 2026-05-05 | Trinity fast-review R3. | GLM FIX; DeepSeek PASS. Fixed CHG lifecycle status, completed-review checkbox, and governance cross-references. |
+| 2026-05-05 | Trinity fast-review R4. | GLM PASS; DeepSeek PASS. CHG approved for implementation. |
+| 2026-05-05 | Implemented COR-1801 and PKG references. | Added COR-1801, COR-0000 index entry, COR-1800 relationship pointer, and COR-1103 routing hints. |
+| 2026-05-05 | Ran validation and COR-1801 CLI checks. | `af validate`, `af read`, `af plan`, and `af list` passed. |
+| 2026-05-05 | Trinity implementation review R1. | GLM PASS; DeepSeek content clean but flagged unrelated untracked `.claude/` and `tmp/` files. Those files remain excluded from the commit. |
+| 2026-05-05 | Ran full local verification. | `ruff check`, `ruff format --check`, `pytest`, and `pyright` passed. |
+| 2026-05-05 | Trinity implementation review R2. | GLM PASS; DeepSeek PASS on commit-scoped `main..HEAD` review. |
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-05 | Initial CHG for COR-1801 Pattern Promotion SOP. | Codex |

--- a/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
+++ b/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
@@ -64,6 +64,7 @@ A reference index of all documents in the COR system.
 | 1702 | SOP | Sync Project |
 | 1703 | SOP | Fork Project |
 | 1800 | REF | Evolution Philosophy |
+| 1801 | SOP | Pattern Promotion |
 
 ---
 
@@ -76,3 +77,4 @@ A reference index of all documents in the COR system.
 | 2026-05-03 | Added COR-1503 (Diagnose Feedback Loop), COR-1504 (Diagnose Phase Gates), COR-1613 (Council Review — was shipped in PR #88, index entry missed) | Frank Xu |
 | 2026-05-03 | Added COR-1202 (Compose Session Plan — was shipped but index entry missed), COR-1203 (Pre-Task Alignment), COR-1204 (CTX Format) | Frank Xu |
 | 2026-05-05 | Added COR-1615 (GitHub App PR Review Bot Loop). | Codex |
+| 2026-05-05 | Added COR-1801 (Pattern Promotion). | Codex |

--- a/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
+++ b/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
@@ -89,6 +89,7 @@ material (REF, Glossary, Index) — NOT creating lifecycle documents
 like PRP, CHG, ADR, PLN, INC. Those match branches 2-6.
 
 1. Pure document management? (REF, Glossary, SOP creation, metadata update)
+   ├── Promote PRJ pattern to PKG → COR-1801, then CHG/PRP as required
    ├── New SOP               → COR-1000
    ├── New reference doc     → COR-1001
    └── Update existing doc   → COR-1300
@@ -137,6 +138,7 @@ like PRP, CHG, ADR, PLN, INC. Those match branches 2-6.
 • GitHub App PR review bot loop → COR-1615 (trigger/poll/match current head), then COR-1612 for fetched findings
 • Diagnose bug/perf regression → COR-1503 (Diagnose Feedback Loop: build feedback loop → reproduce → hypothesise → instrument → fix → regression-test)
 • Pre-task alignment       → COR-1203 (Socratic interview: 7-step loop before PRP/non-trivial code; challenge against glossary, stop when crisp or user-declined)
+• PRJ-to-PKG pattern promotion → COR-1801 (evaluate candidate evidence, decide promote/defer/reject/revise, then route to CHG/PRP)
 • SOP section compliance   → af validate checks required sections (What/Why/When to Use/When NOT/Steps)
 ```
 
@@ -163,6 +165,7 @@ COR-1613: Multi-reviewer decision → declare Review Unit before reviewers begin
 COR-1615: GitHub App PR review bot loop → request once per head, poll without spam, match result to current head, hand findings to COR-1612
 COR-1503: Diagnose bug/perf regression → build feedback loop → reproduce → hypothesise (3-5 ranked) → instrument (one variable/round) → fix → regression-test (hand off to COR-1500)
 COR-1203: Pre-task alignment → before PRP/non-trivial code, offer 7-step Socratic interview; challenge against glossary (COR-1204 CTX), sharpen terms, stop when crisp or user-declined; record one-line outcome
+COR-1801: Pattern promotion → evaluate PRJ pattern contract and evidence before creating or amending PKG/COR documents
 Reading an SOP: af read → What + Why → When to Use → When NOT → Prerequisites → Pitfalls → Steps (COR-1402 each step)
 ```
 
@@ -239,3 +242,4 @@ To create a routing document, follow **COR-1004** (Create Routing Document).
 | 2026-05-03 | FXA-2118: add COR-1503 (Diagnose Feedback Loop) routing entries — OVERLAYS line, PRIMARY ROUTE branch 2 sub-branch, Golden Rule line. | Frank Xu |
 | 2026-05-05 | Add COR-1615 routing entries for GitHub App PR review bot loops. | Codex |
 | 2026-05-03 | FXA-2122: add COR-1203 (Pre-Task Alignment) to Workflow Sequence diagram (after COR-1201, before af guide), OVERLAYS line, and Golden Rule line. | Frank Xu |
+| 2026-05-05 | Add COR-1801 routing entries for PRJ-to-PKG pattern promotion. | Codex |

--- a/src/fx_alfred/rules/COR-1800-REF-Evolution-Philosophy.md
+++ b/src/fx_alfred/rules/COR-1800-REF-Evolution-Philosophy.md
@@ -1,8 +1,8 @@
 # REF-1800: Evolution Philosophy
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-04-04
-**Last reviewed:** 2026-04-04
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
 **Status:** Active
 
 ---
@@ -91,6 +91,14 @@ Reference catalog. Projects pick what applies to their context.
 
 ---
 
+## Relationship to Pattern Promotion
+
+COR-1800 defines the philosophy and evaluation rubrics for evolution. COR-1801 is the peer 18xx governance SOP that defines how a proven PRJ-layer pattern is promoted into PKG/COR.
+
+Use COR-1801 when the evolution candidate is not just an improvement inside one project, but a local practice being considered as reusable package governance.
+
+---
+
 ## COR-to-PRJ Override Contract
 
 Projects customize evolution by creating a PRJ-layer REF that overrides COR-1800 defaults.
@@ -126,3 +134,4 @@ COR-1800-REF (philosophy + rubrics + override contract)
 | Date | Change | By |
 |------|--------|----|
 | 2026-04-04 | Initial version per PRP FXA-2198 and CHG FXA-2199 | Claude Code |
+| 2026-05-05 | Added peer relationship pointer to COR-1801 Pattern Promotion. | Codex |

--- a/src/fx_alfred/rules/COR-1801-SOP-Pattern-Promotion.md
+++ b/src/fx_alfred/rules/COR-1801-SOP-Pattern-Promotion.md
@@ -1,0 +1,253 @@
+# SOP-1801: Pattern Promotion
+
+**Applies to:** All projects using the COR document system
+**Last updated:** 2026-05-05
+**Last reviewed:** 2026-05-05
+**Status:** Active
+**Related:** COR-1800, COR-1000, COR-1101, COR-1102, COR-1300, COR-1301, COR-1500, COR-1602, COR-1608, COR-1609, COR-1610, COR-1613
+**Task tags:** [pattern-promotion, prj-to-pkg, promotion, evolution, governance]
+
+---
+
+## What Is It?
+
+A workflow for evaluating a proven PRJ-layer trial pattern and promoting it into the PKG/COR layer when it is reusable across projects.
+
+Pattern promotion converts local practice into shared package governance without losing the originating evidence trail.
+
+---
+
+## Why
+
+Projects often discover useful operating patterns before the package does. Without a promotion workflow, those patterns either stay trapped in one project or get copied into PKG too early while still carrying project-specific assumptions.
+
+This SOP creates a reviewed path for deciding when a PRJ pattern should become a COR document, when an existing COR document should be amended instead, and when the pattern should stay local.
+
+---
+
+## When to Use
+
+- A PRJ SOP, REF, checklist, prompt, or review loop has worked repeatedly and may benefit other projects.
+- A project maintainer asks whether a local pattern should be generalized into PKG.
+- A GitHub issue or CHG proposes moving a project-specific practice into a COR document.
+- A pattern overlaps existing COR governance and needs a decision: create a new COR document, amend an existing one, defer, revise, or reject.
+- A promoted PKG document may need reversal because later evidence shows it should not remain active.
+
+---
+
+## When NOT to Use
+
+- The pattern is still an untested idea. Use a PRJ trial document first.
+- The pattern only applies to one repository, host, account, vendor setup, or local environment.
+- The request is just a normal edit to an existing COR document with no PRJ-to-PKG promotion question; use COR-1300.
+- The request creates a new product capability, schema, CLI behavior, or architecture before the governance question is clear; use COR-1102 first.
+- The promoted document is already active and only needs retirement; use COR-1301 directly unless a promotion-specific reversal decision is needed.
+
+---
+
+## Prerequisites
+
+- An originating PRJ artifact exists or is summarized well enough to audit.
+- The candidate pattern has trial evidence, not only author preference.
+- The operator can identify the pattern rule, its scope, and at least one case where it should not be used.
+- The promotion work has a GitHub issue or CHG so the decision is reviewable.
+- If the promotion changes code, schema, CLI behavior, or tests, COR-1500 applies as an overlay.
+
+---
+
+## Candidate Pattern Contract
+
+A candidate is ready for promotion review only when it defines these fields:
+
+| Field | Required content |
+|-------|------------------|
+| Origin | PRJ document ID, issue, PR, CHG, discussion note, or summarized source |
+| Trial status | Active trial, completed trial, superseded local pattern, or failed trial |
+| Pattern rule | The reusable decision rule or operating loop in one paragraph |
+| Scope | Who should use it and which artifact or workflow it governs |
+| When to use | Concrete triggers that start the pattern |
+| When not to use | Cases where the pattern would be noise, unsafe, or too local |
+| Evidence | Linked or summarized uses, failures, reviews, and maintainer endorsements |
+| Promotion criteria | Explicit threshold for promote, defer, revise, or reject |
+| Retention plan | How the originating PRJ artifact will remain traceable after promotion |
+
+If any field is missing, choose `revise` unless the pattern is clearly unsuitable.
+
+---
+
+## Promotion Criteria
+
+Use these templates as the default evidence bar. A CHG may raise the bar, but it should not lower it without recording maintainer approval.
+
+| Criterion | Normal pattern baseline | High-risk pattern baseline |
+|-----------|-------------------------|----------------------------|
+| Use count | At least 3 successful uses, or 2 substantial uses plus explicit maintainer endorsement | At least 5 successful uses across 2 projects, or explicit maintainer endorsement with risk rationale |
+| Cross-project evidence | At least 1 independent project adoption, or maintainer endorsement that the pattern is intentionally PKG-level | At least 2 independent project adoptions, or council/maintainer endorsement recorded in the CHG |
+| Failure-mode demo | At least 1 known failure mode, "when not to use" case, or defer/reject example | Failure modes plus mitigations for the most likely misuse cases |
+| Time in trial | At least 14 days or 1 complete review/release/change cycle | At least 30 days or 2 complete review/release/change cycles |
+| Counter-evidence review | Search issues, PR reviews, retrospectives, or discussion notes for objections and failures | Same as normal, plus explicit residual-risk notes in the CHG |
+
+A high-risk pattern changes governance families, review thresholds, release gates, schema, CLI behavior, security-sensitive operations, or multi-project workflow contracts.
+
+Maintainer endorsement can substitute for cross-project adoption when the pattern is foundational package governance and the CHG explains why waiting for another project would block useful standardization.
+
+---
+
+## Promotion Decisions
+
+Choose exactly one first-time promotion state:
+
+| State | Meaning | Required next action |
+|-------|---------|----------------------|
+| `promote` | The pattern is reusable, evidence meets the bar, and PKG is the right layer | Implement the PKG change through CHG/PR and assign a new COR ACID |
+| `defer` | The pattern may be useful, but evidence is not strong enough yet | Keep the PRJ trial; record the re-nomination trigger |
+| `reject` | The pattern is too local, unsafe, obsolete, or conflicts with COR principles | Record the reason; do not promote unless new evidence changes the decision |
+| `revise` | The idea is promising but the candidate is incomplete or too project-specific | Revise the candidate contract or PRJ source, then rerun promotion review |
+
+Use `defer` when the main gap is evidence. Use `revise` when the main gap is document quality, abstraction, or missing contract fields.
+
+---
+
+## Governance Interactions
+
+- Use a GitHub issue plus CHG as the default promotion vehicle.
+- Use COR-1102 first when the promotion creates a new governance family, changes schema or CLI behavior, has unresolved design trade-offs, or substantially changes multiple COR workflows.
+- Use COR-1101 for the implementation CHG.
+- Use COR-1000 when promotion creates a new PKG SOP.
+- Use COR-1300 when promotion amends an existing PKG document instead of creating a new one.
+- Use COR-1301 when a promoted document must be deprecated or superseded.
+- Use COR-1500 when the promotion includes code, tests, CLI behavior, or package assets beyond documents.
+- Use COR-1608 for PRP scoring, COR-1609 for CHG scoring, COR-1610 for code review scoring, and COR-1613 for the multi-reviewer decision rule.
+- Use COR-1602 or another COR-1600 through COR-1605 workflow according to the review or implementation shape.
+
+---
+
+## PKG Authoring Conventions
+
+- Assign a new COR ACID. Never reuse the originating PRJ ACID in the PKG layer.
+- Prefer amending an existing COR document when the pattern is an extension of that document's current responsibility.
+- Create a new COR document only when the pattern is atomic, reusable, and not already owned by an existing SOP or REF.
+- Remove project names, local paths, local accounts, private hostnames, and repository-specific commands from normative steps.
+- Keep project-specific facts only in examples or an origin-evidence section.
+- Preserve origin traceability with `Related` metadata, an `Authored from` field when appropriate, or a short example that names the originating PRJ artifact.
+- Turn local commands into variables or generic command templates.
+- Define both positive triggers and "when not to use" cases.
+- Keep the originating PRJ document after promotion. Do not delete the evidence trail.
+
+---
+
+## PRJ Retention After Promotion
+
+After a PRJ pattern is promoted:
+
+1. Leave the originating PRJ artifact in place unless there is a separate deprecation CHG.
+2. Add a note to the PRJ artifact pointing to the promoted COR document.
+3. If the PRJ document should no longer be executed locally, deprecate it per the PRJ equivalent of COR-1301.
+4. Preserve links to trial evidence, review notes, and failures.
+5. Do not rewrite the PRJ history to make the promotion appear inevitable.
+
+The PRJ artifact remains historical evidence. The COR document becomes the reusable source of truth.
+
+---
+
+## De-promotion / Reversal
+
+Use this path only after a pattern has already been promoted.
+
+1. Open or reuse a GitHub issue describing why the PKG document may no longer be valid.
+2. File a CHG that cites the promoted COR document, the originating PRJ evidence, and the new counter-evidence.
+3. Decide whether to amend, supersede, deprecate, or keep the COR document.
+4. If the document should retire, deprecate it per COR-1301 instead of deleting it.
+5. Update indexes and references so users are routed to the replacement or warned that no replacement exists.
+6. Keep both the original promotion record and reversal record auditable.
+
+---
+
+## Guard Rails
+
+- Do not promote a pattern only because it worked once.
+- Do not promote host-specific, account-specific, or repository-specific details into normative PKG text.
+- Do not let the promotion workflow modify its own evidence standards without a separate CHG or PRP.
+- Do not treat a `defer` decision as rejection; it is a request for more evidence.
+- Do not delete source PRJ artifacts during promotion.
+- Do not use COR-1801 to bypass COR-1102 when the proposed change needs design approval first.
+
+---
+
+## Steps
+
+### 1. Nominate the candidate pattern
+
+Create or identify a GitHub issue and CHG that states the originating PRJ artifact, the pattern rule, why it may be PKG-level, and the requested outcome.
+
+### 2. Validate the candidate contract
+
+Check the Candidate Pattern Contract table. If origin, scope, when-to-use, when-not-to-use, evidence, or retention plan is missing, choose `revise` or update the CHG before implementation.
+
+### 3. Gather evidence
+
+Collect use count, cross-project evidence, failure modes, time-in-trial, and counter-evidence. Summaries are acceptable when the originating project is not available on the current machine, but the summary must be specific enough for reviewers to evaluate.
+
+### 4. Classify the PKG relationship
+
+Decide whether the pattern should amend an existing COR document, create a new COR document, remain PRJ-local, or be rejected. Prefer amendment when an existing SOP already owns the responsibility.
+
+### 5. Run promotion review
+
+Review the CHG using the selected COR-1600 through COR-1605 workflow and declare the COR-1613 decision rule if multiple reviewers are used. For CHGs, apply COR-1609 scoring. For PRPs, apply COR-1608 scoring.
+
+### 6. Choose the decision state
+
+Record exactly one of `promote`, `defer`, `reject`, or `revise` in the CHG or issue. For `defer`, include the re-nomination trigger. For `revise`, list the missing candidate-contract fields or abstraction fixes.
+
+### 7. Implement the PKG change when promoting
+
+If creating a new SOP, follow COR-1000 and assign a new COR ACID. If amending an existing document, follow COR-1300. If code is involved, follow COR-1500. Update package indexes, routing references, and related documents.
+
+### 8. Retain the origin and verify
+
+Update the originating PRJ artifact with a pointer to the promoted COR document or recorded decision. Run package validation and any relevant CLI read/plan/list checks. Record review artifacts and verification results in the CHG or PR.
+
+---
+
+## Completion Criteria
+
+- Candidate contract is complete or the decision explicitly explains why it is not.
+- Promotion criteria are evaluated against evidence, not preference.
+- Decision state is recorded as `promote`, `defer`, `reject`, or `revise`.
+- If promoted, the PKG document uses a new COR ACID and does not reuse the PRJ ACID.
+- If promoted, project-specific details are abstracted out of normative text.
+- Existing COR documents are amended instead of duplicated when they already own the behavior.
+- Originating PRJ evidence is retained and linked or summarized.
+- Related indexes, routing documents, and references are updated.
+- Review and validation results are recorded.
+
+---
+
+## Examples
+
+### Example 1: Promoting a PR review bot loop
+
+An originating PRJ SOP, `BAB-1504-SOP-GitHub-Codex-PR-Review-Loop`, proved a repeatable loop for requesting and interpreting a Codex GitHub App review. Promotion review found the core pattern was not BAB-specific: request once, poll without spam, match the review to the current PR head, and hand actionable findings to the PR-comment response SOP.
+
+The PKG version became COR-1615. It removed project-specific assumptions, generalized the wording to GitHub App PR review bots including Codex and Copilot, retained origin traceability, and added package-level guard rails for visible-write identity and current-head matching.
+
+Decision: `promote`.
+
+### Example 2: Deferring the KIW-0710 R3-outcome triple fork
+
+An originating PRJ trial SOP from the Kiwari project, known as KIW-0710, describes an R3 review outcome pattern. The inline pattern is: after a multi-reviewer round, classify the outcome as exactly one of `unanimous pass`, `leader accept with logged residual`, or `escalate`, instead of treating review completion as binary pass/fail.
+
+Summarized evidence cites use in Kiwari review tracking, including CHG-1300 Track A2 and CHG-1400. The rule is clear and potentially useful, but this summarized evidence alone does not show independent project adoption or explicit maintainer endorsement for PKG-level promotion.
+
+Decision: `defer`.
+
+Re-nomination trigger: provide at least one independent project adoption, or record maintainer endorsement that this is intentionally PKG-level despite limited cross-project evidence.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-05 | Initial SOP for PRJ-to-PKG pattern promotion per FXA-2239. | Codex |


### PR DESCRIPTION
## Summary

- Add `COR-1801: Pattern Promotion` as the PKG-level SOP for promoting proven PRJ trial patterns into COR governance.
- Define candidate contracts, evidence thresholds, promote/defer/reject/revise decisions, PKG authoring rules, PRJ retention, and de-promotion/reversal handling.
- Add a self-contained KIW-0710 defer example and a COR-1615 promote example.
- Update COR index, COR-1800 peer relationship pointer, COR-1103 routing hints, and the FXA CHG/index.

Closes #62

## Trinity review

- CHG gate: `trinity review --preset fast-review --scope rules/FXA-2239-CHG-Add-COR-1801-Pattern-Promotion-SOP.md` -> GLM PASS / DeepSeek PASS in R4.
- Implementation gate: `trinity review --preset fast-review --base main --head HEAD --scope "FXA-2239 COR-1801 implementation commit"` -> GLM PASS / DeepSeek PASS.
- Unrelated local `.claude/` and `tmp/` scratch files are not part of the commit.

## Verification

- `PYTHONPATH=src .venv/bin/af validate --root .` -> 204 documents checked, 0 issues found.
- `PYTHONPATH=src .venv/bin/af read --root . COR-1801` -> OK.
- `PYTHONPATH=src .venv/bin/af plan --root . COR-1801 --todo --graph-format=ascii --graph` -> OK.
- `PYTHONPATH=src .venv/bin/af list --root . --source pkg --type SOP` -> `PKG  COR-1801  SOP  Pattern Promotion`.
- `PYTHONPATH=src .venv/bin/ruff check .` -> all checks passed.
- `PYTHONPATH=src .venv/bin/ruff format --check .` -> 90 files already formatted.
- `PYTHONPATH=src .venv/bin/pytest -q` -> 866 passed.
- `PYTHONPATH=src .venv/bin/pyright` -> 0 errors.
