### PR TITLE
docs: add COR-1614 execution contract SOP

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -151,6 +151,7 @@
 | 2239 | CHG | Add COR 1801 Pattern Promotion SOP |
 | 2240 | PRP | Code Review Checklist v2.0 as Alfred SOP REF |
 | 2241 | CHG | Create Code Review Checklist COR 1705 1709 |
+| 2242 | CHG | Promote Multi Phase Execution Contract SOP |
 
 ---
 

--- a/rules/FXA-2242-CHG-Promote-Multi-Phase-Execution-Contract-SOP.md
+++ b/rules/FXA-2242-CHG-Promote-Multi-Phase-Execution-Contract-SOP.md
@@ -1,0 +1,279 @@
+# CHG-2242: Promote Multi Phase Execution Contract SOP
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-06
+**Last reviewed:** 2026-05-06
+**Status:** In Progress
+**Date:** 2026-05-06
+**Requested by:** Frank
+**Priority:** Medium
+**Change Type:** Normal
+**Related:** BAB-2218, BAB-2219, BAB-2220, COR-1300, COR-1613, COR-1801, COR-1000, COR-1101, COR-1302, COR-1602, COR-1609, COR-1612, COR-1615
+**Tags:** promotion, multi-phase, execution-contract, pkg-governance
+
+---
+
+## What
+
+Promote the reusable parts of `BAB-2218: M3 Phase 7-12 Execution
+Contract` into a PKG-layer COR SOP:
+
+`COR-1614-SOP-Multi-Phase-Execution-Contract.md`
+
+The new SOP standardizes how an operator and agent turn an approved
+multi-phase plan into a bounded execution contract: authority references,
+operator defaults, reviewable slices, validation gates, review-loop caps,
+privacy/runtime-data rules, stop conditions, and after-merge continuation.
+
+## Why
+
+`BAB-2218` solved a repeatable governance problem: when a plan is already
+approved across several phases, the agent needs enough authorization to continue
+without repeatedly interrupting the operator, while still preserving small PRs,
+review gates, validation, and rollback boundaries.
+
+Without a COR-level SOP, other projects will either copy the Babs contract
+verbatim or improvise weaker variants. A promoted SOP gives them a reusable
+pattern while removing Babs-specific details such as M3, Ticket/Billboard,
+Citizen names, local paths, accounts, and phase numbers.
+
+## Impact Analysis
+
+- **Systems affected:**
+  - `src/fx_alfred/rules/COR-1614-SOP-Multi-Phase-Execution-Contract.md` -
+    new PKG SOP.
+  - `src/fx_alfred/rules/COR-0000-REF-Document-Index.md` - add COR-1614.
+  - `src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md` - add routing
+    discoverability for multi-phase execution contracts.
+  - `src/fx_alfred/rules/COR-1613-SOP-Council-Review.md` - release the
+    deferred `COR-1614-REF-Decision-Mechanism-Library` fallback ACID by changing
+    that future split plan to use the next open ACID at the time of the split.
+  - `rules/FXA-0000-REF-Document-Index.md` - add this CHG entry.
+  - `rules/FXA-2242-CHG-Promote-Multi-Phase-Execution-Contract-SOP.md` - this
+    promotion record.
+- **Not affected:** CLI behavior, package schema, templates, runtime code,
+  dependencies, and release version.
+- **Origin retention:** `BAB-2218` remains the evidence artifact. It should be
+  updated in the Babs repository with a pointer to COR-1614 when the Babs
+  worktree is ready for that project-level doc update.
+- **Rollback plan:** Revert the document-only implementation commit, including
+  COR-1614, COR-0000, COR-1103, COR-1613, FXA-0000, and this CHG closeout. If
+  implementation is split across multiple commits, revert all related commits
+  in reverse order. Then rerun `PYTHONPATH=src .venv/bin/af validate --root .`
+  and verify `af read COR-1614` no longer resolves.
+
+## Candidate Pattern Contract
+
+| Field | Value |
+|-------|-------|
+| Origin | `BAB-2218-CHG-M3-Phase-7-12-Execution-Contract.md` |
+| Trial status | Active trial with one completed slice and one active follow-on slice |
+| Pattern rule | For approved multi-phase work, create a contract that records the authority documents, operator defaults, non-negotiables, reviewable execution slices, validation matrix, external review policy, privacy/runtime-data rules, and hard stop conditions before continuous execution begins. |
+| Scope | Agents and operators executing already-approved multi-phase plans through multiple reviewable PRs. |
+| When to use | A plan spans multiple phases or PRs, directional decisions are already known, and the operator wants continuous delivery without repeated prompts for already-decided defaults. |
+| When not to use | Single-slice work, unresolved product design, emergency fixes, vague permission requests, or work where runtime/privacy boundaries are not yet understood. |
+| Evidence | `BAB-2218` approved after Trinity fast-review R2; PR #15 merged the PRP and contract; `BAB-2219` consumed PR A and PR #16 merged; `BAB-2220` is consuming PR B. |
+| Promotion criteria | Promote if the abstracted COR SOP preserves the BAB-2218 safety properties, removes project-specific assumptions, defines clear when-not-to-use and stop-condition rules, and local Trinity review finds no blockers. |
+| Retention plan | Keep `BAB-2218` as historical evidence. Add a pointer to COR-1614 later in Babs; do not delete or rewrite the originating CHG. |
+
+## Promotion Evaluation
+
+Per `COR-1801`, this is treated as a high-risk governance pattern because it
+creates a multi-project workflow contract. The high-risk bar is met by explicit
+maintainer endorsement plus risk rationale, rather than cross-project adoption:
+
+- **Use count:** two substantial uses in one project. `BAB-2218` governed
+  Phase 7 through `BAB-2219` and is governing Phase 8 through `BAB-2220`.
+- **Cross-project evidence:** not yet independent, but the operator/maintainer
+  explicitly asked to promote the pattern into COR. This satisfies the high-risk
+  maintainer-endorsement substitute in COR-1801 because waiting for a second
+  project would keep a known useful governance pattern local while active
+  multi-phase delivery work is already reusing it.
+- **Failure-mode demo:** known misuse cases are one unsafe mega-PR, contract
+  text that silently overrides higher-authority ADR/PRP documents, public PR
+  leakage of local paths/secrets, and agents continuing after a stop condition.
+- **Time in trial:** less than 14 days, but one complete PR slice/review/merge
+  cycle has completed. Maintainer explicitly accepts the lowered time-in-trial
+  bar because the pattern is actively governing live multi-phase delivery and
+  deferring promotion would leave the next similar contract without COR
+  governance.
+- **Counter-evidence:** no blocking review findings remain on `BAB-2218`.
+  `BAB-2219` review found implementation issues that the contract's review-loop
+  cap and external-review rules handled instead of bypassing.
+
+Failure-mode mitigations:
+
+- **Unsafe mega-PR:** COR-1614 must require reviewable slices and per-slice exit
+  conditions.
+- **Authority override:** COR-1614 must require subordinate authority references
+  and stop-on-conflict behavior.
+- **Public leakage:** COR-1614 must require privacy/runtime-data rules and
+  changed-file scans before PR text or comments.
+- **Continuation past blockers:** COR-1614 must define stop conditions and
+  review-loop caps before execution begins.
+
+Residual risk: early promotion means COR-1614 may need revision after the next
+one or two multi-phase projects use it. This is acceptable because the pattern is
+document-only, rollback is a document revert, and COR-1801 de-promotion or
+amendment remains available if evidence turns negative.
+
+Decision state requested: `promote`.
+
+PKG relationship classification: create a new COR SOP rather than amend an
+existing one. COR-1500 owns TDD for one implementation flow, COR-1602 owns
+multi-reviewer parallel review, COR-1202 owns session-plan composition, and
+COR-1103 owns routing. None of those documents owns the higher-level contract
+that authorizes continuous delivery across multiple reviewed PR slices.
+
+## Implementation Plan
+
+1. Review this CHG locally with Trinity fast-review using `~/.codex/trinity.json`
+   and the `fast-review` preset (`glm` + `deepseek`).
+2. Revise until both reviewers pass or only explicitly accepted non-blocking
+   advisories remain.
+3. Create `COR-1614` in the PKG rules directory with:
+   - COR-1000 conventions for new SOP metadata, ACID assignment, structure,
+     and index maintenance;
+   - standard SOP metadata and `Task tags`;
+   - `Authored from: BAB-2218-CHG-M3-Phase-7-12-Execution-Contract`;
+   - What/Why/When/When NOT sections;
+   - prerequisites and contract contents;
+   - positive rules, stop conditions, PR/merge policy, validation guidance,
+     privacy/runtime-data guidance, retention guidance, examples, and steps.
+4. Update `COR-0000` with the `1614 | SOP | Multi Phase Execution Contract`
+   row.
+5. Update `COR-1103` with routing and golden-rule pointers:
+   - route approved multi-phase continuous-execution work to COR-1614 before
+     implementation continues, either as a Route 4 execution-coordination
+     sub-branch or as an overlay when an approved plan already exists;
+   - add a golden rule that continuous multi-phase delivery requires an
+     explicit contract with reviewable slices, validation gates, and stop
+     conditions.
+6. Amend `COR-1613` Open Questions to release the hard-coded
+   `COR-1614-REF-Decision-Mechanism-Library` fallback. Future decision
+   mechanism library extraction must use the next open ACID at the time of that
+   future CHG, not the now-assigned COR-1614.
+7. Run local verification:
+   - `PYTHONPATH=src .venv/bin/af validate --root .`
+   - `PYTHONPATH=src .venv/bin/af read --root . COR-1614`
+   - `PYTHONPATH=src .venv/bin/af plan --root . COR-1614 --todo --graph-format=ascii --graph`
+   - `PYTHONPATH=src .venv/bin/af plan --root . --task "multi phase execution contract" --todo --graph-format=ascii --graph`
+   - `git diff --check`
+   - privacy/local-detail scan over changed files.
+8. Run Trinity fast-review on the implementation diff using
+   `~/.codex/trinity.json`.
+9. Iterate locally until GLM and DeepSeek approve.
+10. Mark this CHG completed, commit, push a branch, and open a PR.
+11. After PR creation, use COR-1615 to trigger/poll GitHub App review bot
+    results and COR-1612 to fetch, classify, fix, validate, and reply to
+    actionable findings until final review is clean.
+
+## Contract Preview
+
+The promoted SOP should abstract the BAB-2218 pattern into a reusable contract
+shape like this:
+
+```markdown
+## Contract Contents
+
+1. Authority documents: the approved PRP/ADR/PLN this contract is subordinate to.
+2. Operator defaults: what the executor may do without re-asking.
+3. Non-negotiables: product, privacy, runtime-data, and review-loop invariants.
+4. Execution slices: each PR-sized slice with scope, tests, validation, and exit condition.
+5. Review policy: local review before PR, GitHub review bot loop after PR, and cap rules.
+6. Stop conditions: when the executor must pause instead of continuing.
+7. Retention: how the originating plan and contract remain auditable.
+```
+
+The SOP body must make the core rule explicit: continuous execution authorizes
+continuity of already-decided defaults, not larger blast radius.
+
+## Acceptance Criteria
+
+- [x] `COR-1614-SOP-Multi-Phase-Execution-Contract.md` exists in the PKG
+  layer.
+- [x] COR-1614 defines when to use and when not to use a multi-phase execution
+  contract.
+- [x] COR-1614 defines required contract sections: authority, operator
+  defaults, execution slices, validation matrix, external review policy,
+  branch/PR/merge policy, runtime/privacy rules, stop conditions, and retention
+  guidance.
+- [x] COR-1614 makes clear that continuous execution does not authorize one
+  unsafe mega-PR or override higher-authority ADR/PRP documents.
+- [x] COR-0000 and COR-1103 are updated for discovery.
+- [x] COR-1613 Open Question 1 no longer hard-codes
+  `COR-1614-REF-Decision-Mechanism-Library.md` as a future ACID.
+- [x] Local validation and Trinity implementation fast-review pass before the PR
+  is opened.
+- [ ] PR feedback is completed through COR-1615 and COR-1612.
+
+## Open Questions / Defaults
+
+- **New SOP or amend existing SOP?** Default: new SOP. No existing COR SOP owns
+  the multi-phase execution-contract responsibility.
+- **ACID?** Default: COR-1614. It is absent from COR-0000 and sits between
+  Council Review (`COR-1613`) and GitHub App PR review bot loop (`COR-1615`).
+  COR-1613 currently mentions a deferred future `COR-1614-REF` extraction; this
+  CHG explicitly releases that hard-coded fallback and changes the future split
+  plan to use the next open ACID when that future CHG happens.
+- **Need PRP first?** Default: no. This promotion creates a document-only
+  governance SOP and does not change CLI behavior, schema, review thresholds, or
+  multiple COR workflows. If Trinity finds unresolved design trade-offs, route
+  to PRP before implementation.
+- **Babs origin update in this PR?** Default: no. Babs lives in a separate
+  repository with active unrelated work. Preserve the retention requirement in
+  this CHG and update `BAB-2218` separately when the Babs worktree is ready.
+
+## Testing / Verification
+
+Pre-implementation:
+
+- [x] CHG review R1: `trinity review --config ~/.codex/trinity.json --root . --preset fast-review --scope rules/FXA-2242-CHG-Promote-Multi-Phase-Execution-Contract-SOP.md`
+- [x] CHG review R2: same command after R1 advisories
+- [x] CHG review R3: same command after COR-1613 ACID-reservation blocker resolution
+
+Implementation:
+
+- [x] `PYTHONPATH=src .venv/bin/af validate --root .`
+- [x] `PYTHONPATH=src .venv/bin/af read --root . COR-1614`
+- [x] `PYTHONPATH=src .venv/bin/af plan --root . COR-1614 --todo --graph-format=ascii --graph`
+- [x] `PYTHONPATH=src .venv/bin/af plan --root . --task "multi phase execution contract" --todo --graph-format=ascii --graph`
+- [x] `git diff --check`
+- [x] Privacy/local-detail scan over changed files
+- [x] Implementation review, PKG docs: `trinity review --config ~/.codex/trinity.json --root . --preset fast-review --scope src/fx_alfred/rules`
+- [x] Implementation review, FXA docs: `trinity review --config ~/.codex/trinity.json --root . --preset fast-review --scope rules`
+
+## Approval
+
+- [x] CHG reviewed by Trinity fast-review
+- [x] Approved for COR-1614 implementation
+- [x] Implementation reviewed by Trinity fast-review before PR
+
+## Execution Log
+
+| Date | Action | Result |
+|------|--------|--------|
+| 2026-05-06 | Created promotion CHG. | Ready for Trinity fast-review before implementation. |
+| 2026-05-06 | Trinity fast-review R1. | GLM PASS and DeepSeek PASS 9.1/10 with advisories. Folded in acceptance criteria, open defaults, COR-1000 invocation, new-SOP rationale, concrete COR-1103 routing target, and root-relative commands. |
+| 2026-05-06 | Trinity fast-review R2. | DeepSeek PASS 9.0/10; GLM found a blocker that COR-1614 was hard-coded in COR-1613 as a possible future decision-mechanism-library REF. Expanded this CHG to release that deferred fallback by amending COR-1613 during implementation. |
+| 2026-05-06 | Trinity fast-review R3. | GLM PASS and DeepSeek PASS 9.1/10. Folded in advisories for explicit time-in-trial waiver, failure-mode mitigations, residual risk, COR-1613 acceptance criterion, and COR-1103 placement guidance. CHG approved for implementation. |
+| 2026-05-06 | Implemented COR-1614 and references. | Added COR-1614, COR-0000 row, COR-1103 routing and golden rule, and COR-1613 fallback release. Local validation, read/plan smoke checks, diff whitespace check, and privacy scan passed. |
+| 2026-05-06 | Trinity implementation review, PKG docs. | Scope `src/fx_alfred/rules`: GLM PASS and DeepSeek PASS. Folded in advisory fixes for COR-0000 Last updated date and COR-1801 body reference in COR-1614. |
+| 2026-05-06 | Trinity implementation review, FXA docs. | Scope `rules`: GLM PASS and DeepSeek PASS with non-blocking advisories only. Ready for PR creation. |
+
+## Post-Change Review
+
+- Pending until COR-1614 is implemented, locally reviewed, and PR feedback is
+  resolved.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-06 | Initial CHG for promoting the BAB-2218 execution contract pattern to COR-1614. | Codex |
+| 2026-05-06 | Fold in Trinity R1 advisories before implementation. | Codex |
+| 2026-05-06 | Address Trinity R2 ACID-reservation blocker by adding COR-1613 fallback-release scope. | Codex |
+| 2026-05-06 | Mark CHG approved after Trinity R3 PASS and advisory fold-in. | Codex |
+| 2026-05-06 | Record implementation verification and Trinity implementation review results. | Codex |

--- a/rules/FXA-2242-CHG-Promote-Multi-Phase-Execution-Contract-SOP.md
+++ b/rules/FXA-2242-CHG-Promote-Multi-Phase-Execution-Contract-SOP.md
@@ -3,7 +3,7 @@
 **Applies to:** FXA project
 **Last updated:** 2026-05-06
 **Last reviewed:** 2026-05-06
-**Status:** In Progress
+**Status:** Completed
 **Date:** 2026-05-06
 **Requested by:** Frank
 **Priority:** Medium
@@ -205,7 +205,7 @@ continuity of already-decided defaults, not larger blast radius.
   `COR-1614-REF-Decision-Mechanism-Library.md` as a future ACID.
 - [x] Local validation and Trinity implementation fast-review pass before the PR
   is opened.
-- [ ] PR feedback is completed through COR-1615 and COR-1612.
+- [x] PR feedback is completed through COR-1615 and COR-1612.
 
 ## Open Questions / Defaults
 
@@ -260,11 +260,17 @@ Implementation:
 | 2026-05-06 | Implemented COR-1614 and references. | Added COR-1614, COR-0000 row, COR-1103 routing and golden rule, and COR-1613 fallback release. Local validation, read/plan smoke checks, diff whitespace check, and privacy scan passed. |
 | 2026-05-06 | Trinity implementation review, PKG docs. | Scope `src/fx_alfred/rules`: GLM PASS and DeepSeek PASS. Folded in advisory fixes for COR-0000 Last updated date and COR-1801 body reference in COR-1614. |
 | 2026-05-06 | Trinity implementation review, FXA docs. | Scope `rules`: GLM PASS and DeepSeek PASS with non-blocking advisories only. Ready for PR creation. |
+| 2026-05-06 | Opened PR #101 and completed COR-1615/COR-1612 loop. | CI passed. Codex GitHub App review bot reported no major issues for current head `62dccca`; no inline review comments or review-summary findings were returned. |
 
 ## Post-Change Review
 
-- Pending until COR-1614 is implemented, locally reviewed, and PR feedback is
-  resolved.
+- COR-1614 was implemented and linked from COR-0000 and COR-1103.
+- COR-1613's deferred hard-coded COR-1614 fallback was released so the future
+  decision-mechanism-library split can use the next open ACID at that time.
+- Local validation, read/plan smoke checks, whitespace check, privacy scan, and
+  Trinity fast-review all passed before PR creation.
+- PR #101 CI passed, and the COR-1615 GitHub App review bot loop produced no
+  actionable findings to process through COR-1612.
 
 ---
 
@@ -277,3 +283,4 @@ Implementation:
 | 2026-05-06 | Address Trinity R2 ACID-reservation blocker by adding COR-1613 fallback-release scope. | Codex |
 | 2026-05-06 | Mark CHG approved after Trinity R3 PASS and advisory fold-in. | Codex |
 | 2026-05-06 | Record implementation verification and Trinity implementation review results. | Codex |
+| 2026-05-06 | Mark CHG completed after PR #101 CI and GitHub App review bot loop passed. | Codex |

--- a/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
+++ b/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
@@ -1,7 +1,7 @@
 # REF-0000: Document Index
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-05-05
+**Last updated:** 2026-05-06
 **Last reviewed:** 2026-05-05
 **Status:** Active
 
@@ -58,6 +58,7 @@ A reference index of all documents in the COR system.
 | 1611 | SOP | Reviewer Calibration Guide |
 | 1612 | SOP | Respond To PR Review Comments |
 | 1613 | SOP | Council Review |
+| 1614 | SOP | Multi Phase Execution Contract |
 | 1615 | SOP | GitHub App PR Review Bot Loop |
 | 1700 | SOP | Initialize Project |
 | 1701 | SOP | Archive Project |
@@ -84,3 +85,4 @@ A reference index of all documents in the COR system.
 | 2026-05-05 | Added COR-1615 (GitHub App PR Review Bot Loop). | Codex |
 | 2026-05-05 | Added COR-1801 (Pattern Promotion). | Codex |
 | 2026-05-06 | Added COR-1705–1709 (Code Review Checklists per FXA-2240). | Frank Xu |
+| 2026-05-06 | Added COR-1614 (Multi Phase Execution Contract). | Codex |

--- a/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
+++ b/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
@@ -1,10 +1,10 @@
 # SOP-1103: Workflow Routing
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-05-05
+**Last updated:** 2026-05-06
 **Last reviewed:** 2026-05-05
 **Status:** Active
-**Related:** COR-1607 (deprecated, replaced by this document)
+**Related:** COR-1607 (deprecated, replaced by this document), COR-1614
 **Workflow input:** proposal:draft
 **Workflow output:** task:routed
 **Always included:** true
@@ -103,6 +103,7 @@ like PRP, CHG, ADR, PLN, INC. Those match branches 2-6.
    └── PRP (COR-1102) → Review (COR-1602 strict) → CHG (COR-1101)
 
 4. Execution coordination needed for approved/in-progress work?
+   ├── Approved multi-phase continuous execution → COR-1614, then CHG/PLN/slice workflow as required
    └── PLN (af create pln) — use for roadmaps, phased plans, multi-team coordination
 
 5. Change to existing system/config/architecture?
@@ -136,6 +137,7 @@ like PRP, CHG, ADR, PLN, INC. Those match branches 2-6.
 • Review scoring rubric    → COR-1608 (PRP) / COR-1609 (CHG) / COR-1610 (Code) + COR-1611 (calibration)
 • Multi-reviewer decision  → COR-1613 (declare Review Unit: mechanism, threshold, reviewers)
 • GitHub App PR review bot loop → COR-1615 (trigger/poll/match current head), then COR-1612 for fetched findings
+• Approved multi-phase continuous execution → COR-1614 (write authority, defaults, reviewable slices, validation gates, privacy rules, and stop conditions before continuing)
 • Diagnose bug/perf regression → COR-1503 (Diagnose Feedback Loop: build feedback loop → reproduce → hypothesise → instrument → fix → regression-test)
 • Pre-task alignment       → COR-1203 (Socratic interview: 7-step loop before PRP/non-trivial code; challenge against glossary, stop when crisp or user-declined)
 • PRJ-to-PKG pattern promotion → COR-1801 (evaluate candidate evidence, decide promote/defer/reject/revise, then route to CHG/PRP)
@@ -163,6 +165,7 @@ COR-1608/1609/1610: Review scoring — PRP → 1608, CHG → 1609, Code → 1610
 COR-1611: Reviewer calibration — cite deductions, 10 = zero improvements, blocking vs advisory
 COR-1613: Multi-reviewer decision → declare Review Unit before reviewers begin (mechanism / rubric / threshold / reviewers); record per Step 6
 COR-1615: GitHub App PR review bot loop → request once per head, poll without spam, match result to current head, hand findings to COR-1612
+COR-1614: Multi-phase continuous execution → write an execution contract before continuing across reviewed PR slices
 COR-1503: Diagnose bug/perf regression → build feedback loop → reproduce → hypothesise (3-5 ranked) → instrument (one variable/round) → fix → regression-test (hand off to COR-1500)
 COR-1203: Pre-task alignment → before PRP/non-trivial code, offer 7-step Socratic interview; challenge against glossary (COR-1204 CTX), sharpen terms, stop when crisp or user-declined; record one-line outcome
 COR-1801: Pattern promotion → evaluate PRJ pattern contract and evidence before creating or amending PKG/COR documents
@@ -243,3 +246,4 @@ To create a routing document, follow **COR-1004** (Create Routing Document).
 | 2026-05-05 | Add COR-1615 routing entries for GitHub App PR review bot loops. | Codex |
 | 2026-05-03 | FXA-2122: add COR-1203 (Pre-Task Alignment) to Workflow Sequence diagram (after COR-1201, before af guide), OVERLAYS line, and Golden Rule line. | Frank Xu |
 | 2026-05-05 | Add COR-1801 routing entries for PRJ-to-PKG pattern promotion. | Codex |
+| 2026-05-06 | Add COR-1614 routing entries for approved multi-phase continuous execution contracts. | Codex |

--- a/src/fx_alfred/rules/COR-1613-SOP-Council-Review.md
+++ b/src/fx_alfred/rules/COR-1613-SOP-Council-Review.md
@@ -1,7 +1,7 @@
 # SOP-1613: Council Review
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-05-05
+**Last updated:** 2026-05-06
 **Last reviewed:** 2026-05-05
 **Status:** Active
 **Depends on:** COR-1402 (Declare Active Process), COR-0002 (Document Format Contract)
@@ -190,7 +190,7 @@ If a project's habits depend on such specifics (e.g., "in this project, the defa
 
 ## Open Questions
 
-1. **Mechanism library size (deferred).** A round-2 reviewer of FXA-2113 raised that 14 mechanisms may be overprovisioned for current usage, where only Decision Matrix is in active use. The Core+Advanced split is a readability concession but does not retire the question. **Plan:** revisit this question 90 days after this SOP becomes Active (≈ 2026-08-01). If fewer than 6 mechanisms have been invoked at least once in real reviews by then, demote the unused mechanisms to a separate `COR-1614-REF-Decision-Mechanism-Library.md` and trim this SOP body to the Core. Until then, the full library is documented here.
+1. **Mechanism library size (deferred).** A round-2 reviewer of FXA-2113 raised that 14 mechanisms may be overprovisioned for current usage, where only Decision Matrix is in active use. The Core+Advanced split is a readability concession but does not retire the question. **Plan:** revisit this question 90 days after this SOP becomes Active (≈ 2026-08-01). If fewer than 6 mechanisms have been invoked at least once in real reviews by then, demote the unused mechanisms to a separate `COR-16xx-REF-Decision-Mechanism-Library.md` using the next open COR ACID at that time, and trim this SOP body to the Core. Until then, the full library is documented here.
 
 2. **`af council` tooling.** No tooling exists today for declaring or aggregating Review Units — they live in conversation context, PR bodies, or session notes. If usage shows that manual declaration is error-prone, a future PRP may propose `af council declare/aggregate` commands. Out of scope for this SOP.
 
@@ -205,3 +205,4 @@ If a project's habits depend on such specifics (e.g., "in this project, the defa
 | 2026-05-03 | Initial version per FXA-2113 PRP. Round-1 review (4 reviewers) returned unanimous FIX (mean 8.0). Round-2 review returned 3-of-4 PASS (mean 9.03); one reviewer persistently raised mechanism-count and steelman-strength concerns. Chair cast the deciding vote PASS via mechanism #13 (Dictator/Single Reviewer) as tie-break. The dissent is captured as Open Question §1 with a 90-day revisit clause. | Frank Xu |
 | 2026-05-03 | FXA-2119: add half-diagnosed-fix prohibition to §When NOT to Use — a fix PR whose diagnosis was incomplete must complete COR-1503 Phase 1–5 before entering Council Review. | Frank Xu |
 | 2026-05-05 | Add COR-1615 relationship pointer for GitHub App PR review bot trigger/poll/current-head matching. | Codex |
+| 2026-05-06 | Release hard-coded COR-1614 fallback for the future decision-mechanism library split; future split must use the next open COR ACID. | Codex |

--- a/src/fx_alfred/rules/COR-1614-SOP-Multi-Phase-Execution-Contract.md
+++ b/src/fx_alfred/rules/COR-1614-SOP-Multi-Phase-Execution-Contract.md
@@ -1,0 +1,190 @@
+# SOP-1614: Multi Phase Execution Contract
+
+**Applies to:** All projects using the COR document system
+**Last updated:** 2026-05-06
+**Last reviewed:** 2026-05-06
+**Status:** Active
+**Related:** COR-1103, COR-1202, COR-1500, COR-1602, COR-1612, COR-1615, COR-1801
+**Task tags:** [multi-phase, execution-contract, phased-work, continuous-delivery, pr-slices, operator-defaults]
+**Authored from:** BAB-2218-CHG-M3-Phase-7-12-Execution-Contract
+
+---
+
+## What Is It?
+
+A workflow for creating a written execution contract before an agent continues
+through multiple approved implementation phases or PR slices.
+
+The contract records what is already authorized, what must remain true, how work
+will be split, what validation and review gates apply, and when the executor
+must stop instead of continuing automatically.
+
+## Why
+
+Approved multi-phase plans create a tension: stopping after every slice wastes
+operator attention by re-asking settled questions, but pushing ahead without a
+contract can turn a phased plan into an unsafe mega-change. A multi-phase
+execution contract preserves both continuity and control.
+
+The contract makes defaults explicit before implementation starts. It also gives
+reviewers a stable artifact to check when deciding whether later slices stayed
+inside the approved plan.
+
+## When to Use
+
+- An approved PRP, PLN, ADR set, or roadmap spans more than one implementation
+  slice.
+- The operator wants the executor to continue across slices without re-asking
+  already-decided defaults.
+- The work needs multiple PRs, review rounds, merge/pull/continue steps, or
+  long-running validation decisions.
+- The plan includes runtime data, privacy-sensitive outputs, credentials,
+  external accounts, generated artifacts, or public PR text that need explicit
+  guard rails.
+- The executor needs a clear stop list before beginning continuous delivery.
+
+## When NOT to Use
+
+- The task is a single small CHG or one obvious PR.
+- Product direction, architecture, schema, or ownership is still unsettled; use
+  COR-1102 or the project proposal route first.
+- The operator is only asking for a session plan; use COR-1202.
+- A production incident needs immediate containment; use the project incident
+  route and any emergency CHG process.
+- The contract would grant broad permission without concrete slices, validation
+  gates, and stop conditions.
+
+## Prerequisites
+
+- A higher-authority plan exists, such as an approved PRP, PLN, ADR, or
+  reviewed roadmap.
+- The operator has resolved the decisions that the contract will treat as
+  defaults.
+- The executor can name at least two slices and the exit condition for each.
+- Review and validation expectations are known enough to write down.
+- Privacy, runtime-data, credentials, and public-write constraints are known.
+
+## Contract Contents
+
+Every multi-phase execution contract should include these sections:
+
+1. **Authority documents** - the approved PRP, PLN, ADRs, issue, or prior CHG
+   that the contract is subordinate to.
+2. **Operator defaults and permissions** - actions the executor may take without
+   re-asking while the contract remains true.
+3. **Non-negotiable behavior** - product, architecture, privacy, runtime-data,
+   account, or review invariants that slices must not violate.
+4. **Execution slices** - reviewable PR-sized slices with scope, out-of-scope
+   boundaries, tests, validation, and exit conditions.
+5. **Validation matrix** - commands, coverage or quality gates, long-run
+   validations, and explicitly deferred checks.
+6. **External review policy** - local review before PR, PR review bot workflow,
+   round caps, and how actionable findings are handled.
+7. **Branch, PR, and merge policy** - branch naming, draft/non-draft default,
+   commit scope, merge/pull/continue sequence, and rollback expectations.
+8. **Runtime-data and privacy rules** - what must not be committed, logged, or
+   published in PR text or comments.
+9. **Stop conditions** - conflicts, missing credentials, failing gates, review
+   caps, destructive operations, or scope changes that require pausing.
+10. **Retention and closeout** - where the contract, slice outcomes, review
+    evidence, and deviations are recorded.
+
+## Rules
+
+- Continuous execution does not mean one large PR.
+- The contract cannot override higher-authority ADRs, PRPs, PLNs, or project
+  routing documents.
+- Every slice must stay independently reviewable, testable, and revertable.
+- Operator defaults are valid only while the contract remains true.
+- Open questions become explicit decisions before implementation proceeds.
+- Runtime data, credentials, private host details, and local-only paths must not
+  become public artifacts by accident.
+- External review caps must be explicit before the first PR opens.
+- After every merge, pull the updated base and verify the next slice still
+  matches the contract.
+- If a project-specific execution contract becomes a reusable cross-project
+  pattern, evaluate that follow-on promotion through COR-1801.
+
+## Stop Conditions
+
+Stop and report instead of continuing when:
+
+- a slice would violate an authority document or contract rule;
+- implementation requires a new product, architecture, schema, or ownership
+  decision;
+- required credentials, accounts, tools, or binaries are unavailable and no
+  deterministic fallback preserves the acceptance claim;
+- a validation gate fails for reasons that cannot be isolated safely;
+- a review-loop cap is reached while required findings remain;
+- continuing would require committing runtime data, transcripts, secrets,
+  private network details, local absolute paths, or host-specific state;
+- a destructive git or production operation would be needed;
+- the next slice is materially larger or riskier than the contract described.
+
+## Review And PR Policy
+
+- Run the selected local review workflow before opening each PR when the project
+  requires it.
+- After a PR opens, use COR-1615 for GitHub App review bot trigger/poll/current
+  head matching when such a bot is part of the gate.
+- Use COR-1612 for fetched PR review findings: classify, fix, validate, reply,
+  and push.
+- Do not treat acknowledgement reactions, queued states, or old-head reviews as
+  approval.
+- Record skipped long validations and the reason they were deferred.
+- If the contract defines a review cap, stop at that cap and summarize instead
+  of silently continuing.
+
+## Steps
+
+1. **Confirm authority** - name the higher-authority documents and verify the work is already approved for multi-phase execution.
+2. **Capture operator defaults** - write the permissions, account constraints, review caps, long-validation decisions, and continuation expectations.
+3. **List non-negotiables** - record product, architecture, runtime-data, privacy, and review invariants.
+4. **Define slices** - split the work into reviewable slices with scope, out-of-scope boundaries, tests, validation, and exit conditions.
+5. **Define validation** - list normal gates, slice-specific gates, coverage or quality expectations, long validations, and deferred checks.
+6. **Define review and PR flow** - specify local review, branch naming, PR default, GitHub App review loop, review-response route, merge policy, and continuation after merge.
+7. **Define stop conditions** - write the exact conflicts or failures that halt automatic continuation.
+8. **Review the contract** - run the appropriate review workflow before using the contract as execution authority.
+9. **Execute slice by slice** - follow the contract, validate each slice, open focused PRs, and resolve review findings.
+10. **Re-check after each merge** - pull the base branch, verify the next slice still matches the contract, then continue or stop.
+11. **Close out and retain evidence** - update the contract or tracker with review results, deviations, skipped checks, merge status, and follow-up work.
+
+## Completion Criteria
+
+- Authority documents are named and the contract is subordinate to them.
+- Operator defaults and permissions are explicit.
+- Every slice has scope, tests, validation, and exit conditions.
+- Privacy, runtime-data, and public-write rules are explicit.
+- Stop conditions are specific enough for an executor to halt without guessing.
+- Local and PR review loops are named with caps or escalation rules.
+- The contract and originating evidence remain traceable after the work
+  completes.
+
+## Examples
+
+### Example 1 - Promote an approved roadmap into continuous execution
+
+An approved roadmap has four remaining phases. The operator has already decided
+the implementation order, validation gates, and review cap. Create a contract
+that records those defaults, splits the work into four PR slices, and lets the
+executor continue after each merge while all stop conditions remain false.
+
+### Example 2 - Do not use for unresolved design
+
+A proposal says "build a new sync system" but the storage model and conflict
+rules are undecided. Do not write an execution contract yet. Route to PRP/design
+review first, then write a contract only after the design is approved.
+
+### Example 3 - Stop after review cap
+
+A slice reaches the contract's review cap while a required PR finding remains.
+The executor stops, reports the unresolved finding and validation state, and
+does not continue to the next slice until the operator resolves the conflict.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-06 | Initial version promoted from BAB-2218 per FXA-2242. | Codex |


### PR DESCRIPTION
## Summary

- Add COR-1614 Multi Phase Execution Contract SOP promoted from BAB-2218 via FXA-2242.
- Wire COR-1614 into COR-0000 and COR-1103 routing/golden rules.
- Release the deferred COR-1613 hard-coded COR-1614 decision-library fallback by changing it to next-open-ACID wording.

## Local validation

- `af validate --root .` -> 213 documents, 0 issues
- `af read COR-1614 --root .`
- `af plan COR-1614 --root . --todo --graph-format=ascii --graph`
- `af plan --root . --task "multi phase execution contract" --todo --graph-format=ascii --graph`
- `git diff --check`
- privacy/local-detail scan over changed files

## Trinity fast-review

- CHG review R3: `.trinity/reviews/20260506-131319-rules-FXA-2242-CHG-Promote-Multi-Phase-Execution-Contract-SOP.md` -> GLM PASS, DeepSeek PASS
- Implementation review, PKG docs: `.trinity/reviews/20260506-132330-src-fx_alfred-rules` -> GLM PASS, DeepSeek PASS
- Implementation review, FXA docs: `.trinity/reviews/20260506-132755-rules` -> GLM PASS, DeepSeek PASS

## Notes

- Babs origin update is intentionally left for the Babs repo so this PR stays scoped to Alfred PKG/FXA docs.
