### PR TITLE
release: v1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 
 Alfred is a CLI-based agent runbook (`af`) that manages SOPs, workflows, and structured documents across three layers (PKG, USR, PRJ). It provides:
 
-- **NEW in v1.10.0** — Agent-editable helpers and skill documents: `af agent call/run`, `af skill list/read`, and `af plan --with-skills`
+- **NEW in v1.12.0** — [Contract-First Delivery Workflow (COR-1616)](src/fx_alfred/rules/COR-1616-SOP-Contract-First-Delivery-Workflow.md) — project-neutral reviewed-delivery loop (contract → plan review → TDD/BDD/E2E → impl review → identity-correct PR → PR review loop → close out), promoted from Babs `BAB-1503`. Also: pytest test-marker governance gate, skills-absorption round 5 (COR-1207, COR-1208, FXA-2248).
+- **v1.10.0** — Agent-editable helpers and skill documents: `af agent call/run`, `af skill list/read`, and `af plan --with-skills`
 - **v1.9.1** — [GitHub App PR Review Bot Loop (COR-1615)](src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md) for Codex Connector / Copilot PR review loops; v1.9.0 added [Council Review (COR-1613)](src/fx_alfred/rules/COR-1613-SOP-Council-Review.md) and [Diagnose Feedback Loop (COR-1503)](src/fx_alfred/rules/COR-1503-SOP-Diagnose-Feedback-Loop.md)
 - **Workflow Routing** — `af guide` tells AI agents which SOP to follow for any task
 - **Workflow Checklists** — `af plan` generates step-by-step checklists from SOPs. With `--task "<description>"` auto-composes the SOP set from tags; `--todo` flattens into a unified checklist; `--graph` renders ASCII + Mermaid flowcharts with intra-SOP loops and gates; `--with-skills` recommends matching skill docs
@@ -344,6 +345,7 @@ graph TD
 | COR-1602 | Multi-Model Parallel Review |
 | COR-1612 | Respond to PR review comments on GitHub |
 | COR-1615 | GitHub App PR Review Bot Loop — trigger/poll/match-head loop for Codex Connector, Copilot, and other GitHub App reviewers |
+| COR-1616 | Contract-First Delivery Workflow — project-neutral reviewed delivery loop (contract → plan review → TDD/BDD/E2E → impl review → identity-correct PR → PR review loop → close out) |
 | COR-1608 | PRP Review Scoring rubric |
 | COR-1611 | Reviewer Calibration Guide |
 | COR-1613 | Council Review — multi-reviewer decision mechanism (14 voting rules) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.11.0"
+version = "1.12.0"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -45,7 +45,7 @@ governance enforcement, and skills-absorption round 5.
 ### Install / Upgrade
 
 ```bash
-pip install fx-alfred==1.11.1       # install specific version
+pip install fx-alfred==1.12.0       # install specific version
 pipx install fx-alfred              # first install
 pipx upgrade fx-alfred              # upgrade existing
 ```

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## v1.12.0 (2026-05-07)
+
+Minor release: new Contract-First Delivery Workflow SOP, pytest test
+governance enforcement, and skills-absorption round 5.
+
+### Added
+
+- **COR-1616 Contract-First Delivery Workflow** — PKG SOP promoted from
+  Babs `BAB-1503` per issue #106 into a project-neutral, reusable
+  reviewed-delivery loop covering plan review, TDD/BDD/E2E pressure,
+  implementation review, privacy/artifact cleanup, identity-correct PR,
+  PR review loop, and post-merge reconciliation. Includes Browser-Harness
+  BDD Policy, Pitfalls section, and an Adapter SOP example so projects
+  can rebase existing SOPs onto `Inherits from: COR-1616`.
+  Reviewed via Trinity multi-model parallel review (Gemini, GLM, Codex,
+  DeepSeek) — 4/4 PASS in round 2 against the COR-1608 PRP rubric.
+  (PR #107)
+
+### Changed
+
+- **COR-1103 Workflow Routing** now surfaces COR-1616 in OVERLAYS and
+  Golden Rules so `af guide` routes reviewed delivery slices through the
+  new SOP. (PR #107)
+- **COR-0000 Document Index** updated to list COR-1616. (PR #107)
+
+### Tests
+
+- **Pytest test governance** enforced: every test file now declares an
+  explicit pytest marker, with a CI gate (`tests/test_pytest_markers.py`)
+  that fails the build if a new test file lands without one. Reduces
+  silent-skip risk and drift in test classification. (PR #103, PR #104)
+
+### Docs
+
+- **Skills-absorption round 5** — COR-1207 (Working in Unfamiliar Code:
+  Zoom-Out), COR-1208 (Session Startup Sanity Check), and FXA-2248 SOP
+  Outcome Notebook absorbed into the Alfred SOP graph. (PR #105)
+
+### Stats
+
+- 869 tests passing, 0 breaking changes.
+
+### Install / Upgrade
+
+```bash
+pip install fx-alfred==1.11.1       # install specific version
+pipx install fx-alfred              # first install
+pipx upgrade fx-alfred              # upgrade existing
+```
+
 ## v1.11.0 (2026-05-06)
 
 Feature release: new governance, review, and execution-contract SOPs.

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "fx-alfred"
-version = "1.11.0"
+version = "1.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Minor release bumping fx-alfred from v1.11.0 → v1.12.0.

## Highlights

- **NEW**: `COR-1616 Contract-First Delivery Workflow` PKG SOP, promoted from Babs `BAB-1503` per issue #106. Project-neutral reviewed-delivery loop covering plan review, TDD/BDD/E2E, implementation review, privacy/artifact cleanup, identity-correct PR, PR review loop, and post-merge reconciliation. Trinity multi-model review (Gemini, GLM, Codex, DeepSeek) — 4/4 PASS in round 2 against COR-1608 PRP rubric. (PR #107)
- **NEW**: pytest test governance — every test file now declares an explicit pytest marker, with a CI gate that fails the build if a new test file lands without one. (PR #103, PR #104)
- **NEW**: skills-absorption round 5 — COR-1207, COR-1208, FXA-2248. (PR #105)
- **CHANGED**: COR-1103 routing surfaces COR-1616 in OVERLAYS + Golden Rules. COR-0000 index lists COR-1616. README v1.12.0 highlight + Key SOPs table updated.

## Readiness gates (FXA-2102 + FXA-2136)

- [x] `pytest -v` — 869 tests passing
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 91 files already formatted
- [x] `pyright src/` — 0 errors, 0 warnings
- [x] All upstream PRs merged into main (#103, #104, #105, #107)
- [x] CHANGELOG entry added (v1.12.0)
- [x] README updated per FXA-2136 (NEW-in line + Key SOPs table)
- [x] Version bumped 1.11.0 → 1.12.0

## Files

- `pyproject.toml` — version 1.11.0 → 1.12.0
- `src/fx_alfred/CHANGELOG.md` — v1.12.0 entry
- `README.md` — NEW-in-v1.12.0 highlight + COR-1616 in Key SOPs table

## Test plan

- [ ] CI checks pass on this PR
- [ ] After merge: `gh release create v1.12.0` triggers GitHub Actions → PyPI Trusted Publisher
- [ ] Post-publish: `pipx upgrade fx-alfred` and verify `af --version` reports `1.12.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)