### PR TITLE
feat: add af tag star/unstar/list + af list --starred (FXA-2273)

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -182,6 +182,7 @@
 | 2270 | CHG | COR 1103 Add Pre Task Alignment Routing |
 | 2271 | CTX | Alfred Glossary |
 | 2272 | CHG | Merge fx_alfredrules Into Top Level rules |
+| 2273 | PRP | AF Tag Star Command And List Filter |
 
 ---
 

--- a/rules/FXA-2273-PRP-AF-Tag-Star-Command-And-List-Filter.md
+++ b/rules/FXA-2273-PRP-AF-Tag-Star-Command-And-List-Filter.md
@@ -1,0 +1,137 @@
+# PRP-2273: AF Tag Star Command And List Filter
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-07
+**Last reviewed:** 2026-05-07
+**Status:** Draft
+
+---
+
+## What Is It?
+
+A user-preference layer for marking commonly-used `Tags:` values as **starred**, plus a complementary `--starred` flag on `af list` that filters documents whose `Tags:` includes any starred tag. Starred tags are stored in a new per-user file `~/.alfred/preferences.yaml`, kept out of git and out of the document layer. Concretely:
+
+- `af tag star <name>` — add `<name>` to the user's starred list (idempotent)
+- `af tag unstar <name>` — remove `<name>` from the starred list (idempotent)
+- `af tag list` — show the user's starred tags (one per line, or JSON with `--json`)
+- `af list --starred` — filter docs whose `Tags:` metadata contains *any* starred tag
+
+The feature does not modify any document — `Tags:` metadata is read-only as far as this feature is concerned. Only the user's `preferences.yaml` is mutated.
+
+---
+
+## Problem
+
+`af list --tag <name>` exists today, but the user has to remember the exact tag string and pass it explicitly every time. For a small set of tags they retrieve frequently (e.g., `release`, `review`, `pr-review`, `bdd`), this is friction. There is no per-user preference layer to express *"these are the tags I care about most often"*.
+
+Embedding "starred" semantics in document `Tags:` metadata is the wrong place — it's a personal preference, not a property of the document, and would pollute shared docs across users.
+
+## Scope
+
+**In scope:**
+
+- New CLI command group `af tag` with subcommands `star`, `unstar`, `list`.
+- New flag `af list --starred`.
+- New file format: `~/.alfred/preferences.yaml` with at least the key `starred_tags` (a list of strings). All tag names normalised to lowercase on write to match the existing `parse_tags()` lowercasing in `core/parser.py`.
+- Atomic writes (tempfile + `os.replace`) for `preferences.yaml`, matching the pattern used by `update_cmd`.
+- Read returns `[]` and never errors when the file is missing or empty.
+- JSON output for `af tag list --json`.
+- Tests: minimum 6 (star/unstar idempotency, list when empty, list when populated, `af list --starred` filter behaviour, missing file = empty starred set, atomic write doesn't leave `.tmp` artifacts).
+- Help text and `af --help` discoverability for the new command group.
+
+**Out of scope:**
+
+- Cross-machine sync of starred tags. The `~/.alfred/preferences.yaml` file is local-only by design.
+- Server-side preferences or any network call.
+- Combinator changes to existing `--tag` flag (it stays case-insensitive exact-match against any single tag).
+- `af tag suggest` or analytics ("which of my tags do I use most"). Pure manual star/unstar.
+- Migrating existing `Tags:` metadata. No document is touched.
+- Tags governance / canonicalisation. The user can star any string; if it doesn't match any doc's `Tags:`, `--starred` simply returns nothing.
+- Any change to PKG (bundled COR docs). PKG layer is read-only.
+
+## Proposed Solution
+
+### Architecture
+
+| Component | Path | Purpose |
+|---|---|---|
+| Preferences I/O | `src/fx_alfred/core/preferences.py` (new) | Atomic read/write of `~/.alfred/preferences.yaml`; framework-agnostic (no Click) |
+| Tag command group | `src/fx_alfred/commands/tag_cmd.py` (new) | Click group with `star`, `unstar`, `list` subcommands |
+| List filter | extend `src/fx_alfred/commands/list_cmd.py` | New `--starred` Click option; logic delegates to `core.preferences` |
+| CLI registration | `src/fx_alfred/cli.py` | Add `"tag": "fx_alfred.commands.tag_cmd:tag_cmd"` to `lazy_subcommands` |
+
+Logic stays in `core/preferences.py`; command modules stay thin (matches the existing `commands/` ↔ `core/` boundary and the LazyGroup convention).
+
+### Preferences file schema (`~/.alfred/preferences.yaml`)
+
+```yaml
+# Created/managed by `af tag star`; safe to edit by hand.
+starred_tags:
+  - release
+  - review
+  - pr-review
+```
+
+Behaviour rules:
+
+- File missing → treated as `{starred_tags: []}`. No error, no auto-create on read.
+- `~/.alfred/` directory missing → created with `os.makedirs(..., exist_ok=True)` on first write (`af tag star`). Read paths never create the directory.
+- File present but malformed YAML → `core/preferences.py` raises a custom `PreferencesError`; `commands/tag_cmd.py` and `commands/list_cmd.py` convert it to `click.ClickException` with a path-bearing message at the command boundary. `core/` stays Click-free.
+- On `tag star <name>` write, the YAML output includes a header comment warning hand-editors that YAML may coerce certain bare strings (`yes`/`no`/`on`/`off`/numeric literals) — quote tag names that look like booleans or numbers.
+- File present, valid YAML, missing `starred_tags` key → empty list, no error.
+- File present, valid YAML, `starred_tags` not a list → `ClickException`.
+- On write, only re-serialise the `starred_tags` key; preserve any other top-level keys the file may have (forward-compat with future preference keys).
+- All tag names lowercased on `star`/`unstar` write; matches `parse_tags()` lowercasing on read in `core/parser.py`.
+
+### Command behaviours
+
+- `af tag star <name>` — lowercase + strip `<name>`; if empty/whitespace-only after normalisation, exit non-zero with `ClickException("tag name cannot be empty")`. Otherwise load preferences; if `<name>` already in `starred_tags`, exit 0 with `"already starred: <name>"`; else append, atomic-write, exit 0 with `"starred: <name>"`.
+- `af tag unstar <name>` — same empty-string guard as `star`. Otherwise load preferences; if not in list, exit 0 with `"not starred: <name>"`; else remove, atomic-write, exit 0 with `"unstarred: <name>"`.
+- `af tag list` — print starred tags one per line (sorted), or nothing when empty. `--json` emits `{"schema_version": "1", "starred_tags": [...]}`.
+- `af list --starred` — filter docs to those whose `Document.tags` intersects with `starred_tags` (set intersection, case-insensitive — already lowercase on both sides). Composes with `--type`, `--prefix`, `--source`, `--tag` via the same AND logic as today. **When `starred_tags` is empty (no preferences file or nothing starred yet), `--starred` matches zero documents** — this is intentional ("star at least one tag first") rather than a bug; the command exits 0 with `"No documents found."` (or `[]` in JSON) just like any other empty filter result. `af tag list` returning empty is the diagnostic.
+
+### Backward compatibility
+
+- Existing `af list` behaviour unchanged when `--starred` is not passed.
+- Existing `--tag` flag unchanged. `--tag` and `--starred` may be combined (AND).
+- No document is modified; `af validate` results unchanged.
+- No new dependency; `pyyaml` is already a project dependency.
+
+### Validation commands (FXA-2102 readiness gate)
+
+```bash
+.venv/bin/pytest -q                          # all tests pass, ≥6 new
+.venv/bin/ruff check . && .venv/bin/ruff format --check .
+.venv/bin/pyright src/                       # 0 errors
+.venv/bin/af validate --root .               # 0 issues
+.venv/bin/af tag --help                      # group registered, subcommands listed
+.venv/bin/af list --help                     # --starred listed
+```
+
+### Acceptance Criteria
+
+1. `af tag star release` creates `~/.alfred/preferences.yaml` with `starred_tags: [release]`; running it again exits 0 without duplicating.
+2. `af tag unstar release` removes `release`; running it again on the now-empty list exits 0 ("not starred").
+3. `af tag list` prints `release` after step 1; prints nothing (or `[]` in JSON) after step 2.
+4. `af list --starred` returns only docs whose `Tags:` contains at least one starred tag (after `af tag star release`, returns docs tagged `release`).
+5. Deleting the preferences file mid-session and running `af list --starred` returns the empty set with no error.
+6. Concurrent writes (simulated in tests by writing twice in succession) leave no `.tmp` or partial files.
+7. Existing `af list` (no `--starred`) output and `af list --tag <name>` output are semantically identical to v1.12.0 — same documents, same order, same labels (whitespace tolerance allowed for any incidental refactor of the print loop).
+
+## Open Questions
+
+1. **YAML vs JSON for the preferences file?** Proposed YAML for human-edit friendliness (matches `--spec` convention). Alternatively JSON (smaller, no YAML edge cases). Defaulting to YAML; flagged for review.
+2. **`--starred` shortform `-s`?** No clash with existing flags. Defaulting to long-form only for safety; can add later.
+3. **Should `af tag list` show all tags in use across docs (not just starred), with a star marker on starred ones?** That would unify `af tag list` and "list all tags discovered in PRJ docs". Defer — out of this PRP's scope, separate PRP if useful.
+4. **AND vs OR for `--starred` + `--tag`?** AND keeps consistency with all other `af list` filters. Documented as AND in §Proposed Solution; flagged for confirmation.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-07 | Initial version | Claude Code |
+| 2026-05-07 | Trinity fast-review (round 1): GLM 9.08 PASS, DeepSeek 9.30 PASS — 2/2 PASS, zero blocking. Folded convergent advisory (empty-string guard, empty-starred UX) and craft items (~/.alfred/ dir creation, `PreferencesError` at core boundary, AC #7 softened to semantic equivalence, YAML coercion warning). | Claude Code |
+| 2026-05-07 | Implementation complete on branch `af-tag-star`. Validation: pytest 888 passing (+19 new), ruff/pyright clean, af validate 247 docs / 0 issues, `af tag --help` surfaces star/unstar/list, `af list --starred` works. Files: core/preferences.py + commands/tag_cmd.py (new); list_cmd.py + cli.py (modified). | Claude Code |
+| 2026-05-07 | Trinity fast-review code review: GLM 9.13 PASS, DeepSeek 9.30 PASS — 2/2 PASS, zero blocking. Folded convergent advisory (`af list --starred` malformed-YAML test) and single-reviewer items (dedup-on-read in `get_starred_tags`, defensive `.strip().lower()` in `add_starred_tag`/`remove_starred_tag`, `--starred --json` test, `--starred --tag` combo test). Final: pytest 891 passing (+22 new). | Claude Code |

--- a/src/fx_alfred/cli.py
+++ b/src/fx_alfred/cli.py
@@ -44,6 +44,7 @@ Quick Start:
         "search": "fx_alfred.commands.search_cmd:search_cmd",
         "skill": "fx_alfred.commands.skill_cmd:skill_cmd",
         "status": "fx_alfred.commands.status_cmd:status_cmd",
+        "tag": "fx_alfred.commands.tag_cmd:tag_cmd",
         "update": "fx_alfred.commands.update_cmd:update_cmd",
         "validate": "fx_alfred.commands.validate_cmd:validate_cmd",
         "where": "fx_alfred.commands.where_cmd:where_cmd",

--- a/src/fx_alfred/commands/list_cmd.py
+++ b/src/fx_alfred/commands/list_cmd.py
@@ -4,6 +4,7 @@ import click
 
 from fx_alfred.commands._helpers import scan_or_fail
 from fx_alfred.context import root_option
+from fx_alfred.core.preferences import PreferencesError, get_starred_tags
 from fx_alfred.core.source import SOURCE_LABELS
 
 
@@ -39,6 +40,11 @@ Filters use exact case-insensitive matching (AND logic).
 @click.option(
     "--tag", default=None, help="Filter by tag (case-insensitive exact match)."
 )
+@click.option(
+    "--starred",
+    is_flag=True,
+    help="Filter by starred tags from ~/.alfred/preferences.yaml (af tag star).",
+)
 @click.pass_context
 def list_cmd(
     ctx: click.Context,
@@ -47,6 +53,7 @@ def list_cmd(
     source_filter: str | None,
     json_output: bool,
     tag: str | None,
+    starred: bool,
 ):
     """List all documents across PKG, USR, and PRJ layers."""
     docs = scan_or_fail(ctx)
@@ -60,6 +67,12 @@ def list_cmd(
         docs = [d for d in docs if d.source.lower() == source_filter.lower()]
     if tag is not None:
         docs = [d for d in docs if tag.lower() in d.tags]
+    if starred:
+        try:
+            starred_set = set(get_starred_tags())
+        except PreferencesError as exc:
+            raise click.ClickException(str(exc)) from exc
+        docs = [d for d in docs if starred_set.intersection(d.tags)]
 
     if not docs:
         if json_output:

--- a/src/fx_alfred/commands/tag_cmd.py
+++ b/src/fx_alfred/commands/tag_cmd.py
@@ -1,0 +1,72 @@
+"""af tag command group — manage starred tags (FXA-2273)."""
+
+from __future__ import annotations
+
+import json
+
+import click
+
+from fx_alfred.core.preferences import (
+    PreferencesError,
+    add_starred_tag,
+    get_starred_tags,
+    remove_starred_tag,
+)
+
+
+SCHEMA_VERSION = "1"
+
+
+def _normalise(name: str) -> str:
+    cleaned = name.strip().lower()
+    if not cleaned:
+        raise click.ClickException("tag name cannot be empty")
+    return cleaned
+
+
+@click.group("tag")
+def tag_cmd() -> None:
+    """Manage starred tags (per-user, persisted in ~/.alfred/preferences.yaml)."""
+
+
+@tag_cmd.command("star")
+@click.argument("name")
+def tag_star_cmd(name: str) -> None:
+    """Mark <name> as a starred tag."""
+    norm = _normalise(name)
+    try:
+        added, _ = add_starred_tag(norm)
+    except PreferencesError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"{'starred' if added else 'already starred'}: {norm}")
+
+
+@tag_cmd.command("unstar")
+@click.argument("name")
+def tag_unstar_cmd(name: str) -> None:
+    """Remove <name> from starred tags."""
+    norm = _normalise(name)
+    try:
+        removed, _ = remove_starred_tag(norm)
+    except PreferencesError as exc:
+        raise click.ClickException(str(exc)) from exc
+    click.echo(f"{'unstarred' if removed else 'not starred'}: {norm}")
+
+
+@tag_cmd.command("list")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON object.")
+def tag_list_cmd(json_output: bool) -> None:
+    """List the user's starred tags (sorted)."""
+    try:
+        starred = get_starred_tags()
+    except PreferencesError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if json_output:
+        click.echo(
+            json.dumps({"schema_version": SCHEMA_VERSION, "starred_tags": starred})
+        )
+        return
+
+    for tag in starred:
+        click.echo(tag)

--- a/src/fx_alfred/core/preferences.py
+++ b/src/fx_alfred/core/preferences.py
@@ -1,0 +1,147 @@
+"""User preferences I/O for ~/.alfred/preferences.yaml (FXA-2273).
+
+Framework-agnostic: raises PreferencesError on schema/parse failures.
+The command layer (commands/tag_cmd.py, commands/list_cmd.py) converts
+PreferencesError to click.ClickException at the CLI boundary.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_HEADER_COMMENT = (
+    "# Managed by `af tag star`; safe to edit by hand.\n"
+    "# Quote tag names that look like booleans or numbers (yes/no/on/off/1.0)\n"
+    "# — YAML coerces unquoted bare strings of those shapes.\n"
+)
+
+
+class PreferencesError(ValueError):
+    """Raised when ~/.alfred/preferences.yaml is malformed or has wrong shape."""
+
+
+def preferences_path() -> Path:
+    """Path to the user's preferences file (depends on Path.home())."""
+    return Path.home() / ".alfred" / "preferences.yaml"
+
+
+def load_preferences() -> dict[str, Any]:
+    """Read preferences.yaml. Returns {} when file is missing.
+
+    Raises PreferencesError on parse failure or wrong top-level shape.
+    """
+    path = preferences_path()
+    if not path.exists():
+        return {}
+    raw = path.read_text()
+    if not raw.strip():
+        return {}
+    try:
+        data = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise PreferencesError(f"malformed YAML in {path}: {exc}") from exc
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise PreferencesError(
+            f"{path}: top-level must be a mapping, got {type(data).__name__}"
+        )
+    return data
+
+
+def get_starred_tags() -> list[str]:
+    """Return the user's starred tags (sorted list).
+
+    Returns [] when the file is missing or starred_tags key is absent.
+    Raises PreferencesError when the key exists but is not a list.
+    """
+    data = load_preferences()
+    if "starred_tags" not in data:
+        return []
+    value = data["starred_tags"]
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise PreferencesError(
+            f"{preferences_path()}: 'starred_tags' must be a list, got "
+            f"{type(value).__name__}"
+        )
+    return sorted({str(v).lower() for v in value})
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    """Write content to path via tempfile + os.replace (no .tmp leftover)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        prefix=".preferences.", suffix=".tmp", dir=str(path.parent)
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        os.replace(tmp_path, path)
+    except Exception:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+        raise
+
+
+def _serialise(data: dict[str, Any]) -> str:
+    body = yaml.safe_dump(data, sort_keys=True, default_flow_style=False)
+    return _HEADER_COMMENT + body
+
+
+def add_starred_tag(name: str) -> tuple[bool, list[str]]:
+    """Add `name` to starred_tags. Returns (added, sorted_starred_tags).
+
+    `added` is False when name was already starred (idempotent).
+    Preserves any other top-level keys in preferences.yaml.
+    """
+    name = name.strip().lower()
+    data = load_preferences()
+    existing_raw = data.get("starred_tags")
+    if existing_raw is None:
+        existing: list[str] = []
+    elif isinstance(existing_raw, list):
+        existing = [str(v).lower() for v in existing_raw]
+    else:
+        raise PreferencesError(
+            f"{preferences_path()}: 'starred_tags' must be a list, got "
+            f"{type(existing_raw).__name__}"
+        )
+
+    if name in existing:
+        return False, sorted(existing)
+    new_list = sorted(existing + [name])
+    data["starred_tags"] = new_list
+    _atomic_write(preferences_path(), _serialise(data))
+    return True, new_list
+
+
+def remove_starred_tag(name: str) -> tuple[bool, list[str]]:
+    """Remove `name` from starred_tags. Returns (removed, sorted_starred_tags).
+
+    `removed` is False when name was not starred (idempotent).
+    """
+    name = name.strip().lower()
+    data = load_preferences()
+    existing_raw = data.get("starred_tags")
+    if existing_raw is None:
+        return False, []
+    if not isinstance(existing_raw, list):
+        raise PreferencesError(
+            f"{preferences_path()}: 'starred_tags' must be a list, got "
+            f"{type(existing_raw).__name__}"
+        )
+    existing = [str(v).lower() for v in existing_raw]
+    if name not in existing:
+        return False, sorted(existing)
+    new_list = sorted(t for t in existing if t != name)
+    data["starred_tags"] = new_list
+    _atomic_write(preferences_path(), _serialise(data))
+    return True, new_list

--- a/tests/test_list_cmd.py
+++ b/tests/test_list_cmd.py
@@ -225,3 +225,139 @@ def test_list_json_empty_result(sample_project, monkeypatch):
     assert result.exit_code == 0
     assert result.output == "[]\n"
     assert json.loads(result.output) == []
+
+
+# ---------- FXA-2273: --starred filter ----------
+
+
+def _doc_with_tags(
+    root: Path, prefix: str, acid: str, type_code: str, title: str, tags: str
+) -> None:
+    path = root / "rules" / f"{prefix}-{acid}-{type_code}-{title}.md"
+    body = (
+        f"# {type_code}-{acid}: {title.replace('-', ' ')}\n\n"
+        "**Applies to:** TST project\n"
+        "**Last updated:** 2026-05-07\n"
+        "**Last reviewed:** 2026-05-07\n"
+        "**Status:** Active\n"
+        f"**Tags:** {tags}\n\n"
+        "---\n\n## What Is It?\n\nDoc.\n"
+    )
+    path.write_text(body)
+
+
+def test_list_starred_filters_by_starred_tags(sample_project, monkeypatch):
+    """`af list --starred` returns only docs whose Tags intersect starred set."""
+    from pathlib import Path
+
+    monkeypatch.chdir(sample_project)
+    _doc_with_tags(
+        sample_project, "TST", "5001", "REF", "Release-Notes", "release, docs"
+    )
+    _doc_with_tags(sample_project, "TST", "5002", "SOP", "Build-Process", "build, ci")
+
+    # Star "release" only
+    Path.home().joinpath(".alfred").mkdir(parents=True, exist_ok=True)
+    Path.home().joinpath(".alfred", "preferences.yaml").write_text(
+        "starred_tags:\n  - release\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--starred"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "TST-5001" in result.output
+    assert "TST-5002" not in result.output
+
+
+def test_list_starred_empty_returns_no_docs(sample_project, monkeypatch):
+    """No starred tags → --starred matches zero docs (intentional)."""
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--starred"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "No documents found." in result.output
+
+
+def test_list_starred_combines_with_other_filters(sample_project, monkeypatch):
+    """--starred AND --type SOP → only starred SOPs."""
+    from pathlib import Path
+
+    monkeypatch.chdir(sample_project)
+    _doc_with_tags(sample_project, "TST", "5001", "REF", "Release-Notes", "release")
+    _doc_with_tags(sample_project, "TST", "5002", "SOP", "Release-SOP", "release")
+
+    Path.home().joinpath(".alfred").mkdir(parents=True, exist_ok=True)
+    Path.home().joinpath(".alfred", "preferences.yaml").write_text(
+        "starred_tags:\n  - release\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["list", "--starred", "--type", "SOP"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert "TST-5002" in result.output
+    assert "TST-5001" not in result.output
+
+
+def test_list_starred_json_output(sample_project, monkeypatch):
+    """`af list --starred --json` returns only starred-tag-matching docs."""
+    import json as _json
+    from pathlib import Path as _Path
+
+    monkeypatch.chdir(sample_project)
+    _doc_with_tags(sample_project, "TST", "5001", "REF", "Release-Notes", "release")
+    _doc_with_tags(sample_project, "TST", "5002", "SOP", "Build-Process", "build")
+
+    _Path.home().joinpath(".alfred").mkdir(parents=True, exist_ok=True)
+    _Path.home().joinpath(".alfred", "preferences.yaml").write_text(
+        "starred_tags:\n  - release\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--starred", "--json"], catch_exceptions=False)
+    assert result.exit_code == 0
+    data = _json.loads(result.output)
+    acids = [d["acid"] for d in data]
+    assert "5001" in acids
+    assert "5002" not in acids
+
+
+def test_list_starred_with_tag_combination(sample_project, monkeypatch):
+    """--starred AND --tag are combined via AND (intersection)."""
+    from pathlib import Path as _Path
+
+    monkeypatch.chdir(sample_project)
+    _doc_with_tags(sample_project, "TST", "5001", "REF", "Release-A", "release, urgent")
+    _doc_with_tags(
+        sample_project, "TST", "5002", "SOP", "Release-B", "release, deferred"
+    )
+
+    _Path.home().joinpath(".alfred").mkdir(parents=True, exist_ok=True)
+    _Path.home().joinpath(".alfred", "preferences.yaml").write_text(
+        "starred_tags:\n  - release\n"
+    )
+
+    runner = CliRunner()
+    # Both docs are starred (have "release"); only 5001 also has "urgent"
+    result = runner.invoke(
+        cli, ["list", "--starred", "--tag", "urgent"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert "TST-5001" in result.output
+    assert "TST-5002" not in result.output
+
+
+def test_list_starred_against_malformed_yaml(sample_project, monkeypatch):
+    """Malformed preferences.yaml raises ClickException via list_cmd boundary."""
+    from pathlib import Path as _Path
+
+    monkeypatch.chdir(sample_project)
+    prefs_dir = _Path.home() / ".alfred"
+    prefs_dir.mkdir(parents=True, exist_ok=True)
+    (prefs_dir / "preferences.yaml").write_text("starred_tags: [unclosed")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--starred"])
+    assert result.exit_code != 0
+    assert "preferences.yaml" in result.output

--- a/tests/test_tag_cmd.py
+++ b/tests/test_tag_cmd.py
@@ -1,0 +1,198 @@
+"""Tests for af tag command (FXA-2273)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from fx_alfred.cli import cli
+
+
+pytestmark = pytest.mark.cli
+
+
+def _prefs_path() -> Path:
+    return Path.home() / ".alfred" / "preferences.yaml"
+
+
+def test_tag_star_creates_preferences_file_and_starred_tags_key():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "star", "release"])
+
+    assert result.exit_code == 0
+    assert "starred: release" in result.output
+    assert _prefs_path().exists()
+    data = yaml.safe_load(_prefs_path().read_text())
+    assert data["starred_tags"] == ["release"]
+
+
+def test_tag_star_is_idempotent():
+    runner = CliRunner()
+    runner.invoke(cli, ["tag", "star", "release"])
+    result = runner.invoke(cli, ["tag", "star", "release"])
+
+    assert result.exit_code == 0
+    assert "already starred: release" in result.output
+    data = yaml.safe_load(_prefs_path().read_text())
+    assert data["starred_tags"] == ["release"]
+
+
+def test_tag_star_lowercases_name():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "star", "Release"])
+
+    assert result.exit_code == 0
+    data = yaml.safe_load(_prefs_path().read_text())
+    assert data["starred_tags"] == ["release"]
+
+
+def test_tag_star_rejects_empty_name():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "star", "  "])
+
+    assert result.exit_code != 0
+    assert "tag name cannot be empty" in result.output
+    assert not _prefs_path().exists()
+
+
+def test_tag_unstar_removes_tag():
+    runner = CliRunner()
+    runner.invoke(cli, ["tag", "star", "release"])
+    runner.invoke(cli, ["tag", "star", "review"])
+    result = runner.invoke(cli, ["tag", "unstar", "release"])
+
+    assert result.exit_code == 0
+    assert "unstarred: release" in result.output
+    data = yaml.safe_load(_prefs_path().read_text())
+    assert data["starred_tags"] == ["review"]
+
+
+def test_tag_unstar_is_idempotent_when_not_starred():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "unstar", "nonexistent"])
+
+    assert result.exit_code == 0
+    assert "not starred: nonexistent" in result.output
+
+
+def test_tag_list_when_empty():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "list"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_tag_list_when_populated_sorted():
+    runner = CliRunner()
+    runner.invoke(cli, ["tag", "star", "review"])
+    runner.invoke(cli, ["tag", "star", "release"])
+    runner.invoke(cli, ["tag", "star", "bdd"])
+    result = runner.invoke(cli, ["tag", "list"])
+
+    assert result.exit_code == 0
+    assert result.output.strip().splitlines() == ["bdd", "release", "review"]
+
+
+def test_tag_list_json_output():
+    runner = CliRunner()
+    runner.invoke(cli, ["tag", "star", "release"])
+    runner.invoke(cli, ["tag", "star", "review"])
+    result = runner.invoke(cli, ["tag", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["schema_version"] == "1"
+    assert sorted(data["starred_tags"]) == ["release", "review"]
+
+
+def test_tag_list_json_when_empty():
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "list", "--json"])
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data == {"schema_version": "1", "starred_tags": []}
+
+
+def test_preferences_file_missing_treated_as_empty():
+    """No file → no error, empty starred set."""
+    runner = CliRunner()
+    assert not _prefs_path().exists()
+    result = runner.invoke(cli, ["tag", "list"])
+
+    assert result.exit_code == 0
+    assert result.output.strip() == ""
+
+
+def test_malformed_yaml_raises_click_exception():
+    prefs = _prefs_path()
+    prefs.parent.mkdir(parents=True, exist_ok=True)
+    prefs.write_text("starred_tags: [unclosed")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "list"])
+
+    assert result.exit_code != 0
+    assert str(prefs) in result.output
+
+
+def test_starred_tags_not_a_list_raises():
+    prefs = _prefs_path()
+    prefs.parent.mkdir(parents=True, exist_ok=True)
+    prefs.write_text("starred_tags: 'not-a-list'")
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "list"])
+
+    assert result.exit_code != 0
+
+
+def test_preferences_file_preserves_unknown_keys():
+    """Forward-compat: future preference keys must survive a star/unstar write."""
+    prefs = _prefs_path()
+    prefs.parent.mkdir(parents=True, exist_ok=True)
+    prefs.write_text("future_key: keep-me\nstarred_tags:\n  - existing\n")
+
+    runner = CliRunner()
+    runner.invoke(cli, ["tag", "star", "release"])
+
+    data = yaml.safe_load(prefs.read_text())
+    assert data["future_key"] == "keep-me"
+    assert sorted(data["starred_tags"]) == ["existing", "release"]
+
+
+def test_atomic_write_no_tmp_artifacts_after_two_writes():
+    runner = CliRunner()
+    runner.invoke(cli, ["tag", "star", "release"])
+    runner.invoke(cli, ["tag", "star", "review"])
+
+    alfred_dir = _prefs_path().parent
+    leftover = [
+        p.name
+        for p in alfred_dir.iterdir()
+        if p.name.startswith(".") or "tmp" in p.name.lower()
+    ]
+    assert leftover == []
+
+
+def test_alfred_dir_created_on_first_write():
+    """If ~/.alfred/ does not exist, first `af tag star` creates it."""
+    alfred_dir = Path.home() / ".alfred"
+    if alfred_dir.exists():
+        # The conftest isolate_home should have left this absent
+        for p in alfred_dir.iterdir():
+            p.unlink()
+        alfred_dir.rmdir()
+
+    assert not alfred_dir.exists()
+    runner = CliRunner()
+    result = runner.invoke(cli, ["tag", "star", "release"])
+
+    assert result.exit_code == 0
+    assert alfred_dir.exists()
+    assert _prefs_path().exists()


### PR DESCRIPTION
## Summary

User-preference layer for marking commonly-used `Tags:` values as **starred**, plus an `af list --starred` filter that returns docs whose `Tags:` contains any starred tag. Starred tags persist in a new per-user file `~/.alfred/preferences.yaml`. **Documents are not modified.**

Closes the workflow gap where users had to type `af list --tag <name>` repeatedly for a small set of frequently-retrieved tags.

## New API

| Command | Behaviour |
|---------|-----------|
| `af tag star <name>` | Mark `<name>` as starred (idempotent, lowercase, rejects empty) |
| `af tag unstar <name>` | Remove (idempotent) |
| `af tag list [--json]` | Sorted list of starred tags |
| `af list --starred` | Filter docs by intersection with starred set; composes with `--type/--prefix/--source/--tag` (AND) |

`~/.alfred/preferences.yaml` schema:

```yaml
# Managed by `af tag star`; safe to edit by hand.
# Quote tag names that look like booleans or numbers (yes/no/on/off/1.0)
# — YAML coerces unquoted bare strings of those shapes.
starred_tags:
  - release
  - review
```

## Architecture

| Layer | File | Purpose |
|---|---|---|
| Core (framework-agnostic) | `src/fx_alfred/core/preferences.py` (new) | Atomic YAML I/O, `PreferencesError`, dedup-on-read, defensive `.strip().lower()` |
| Command layer | `src/fx_alfred/commands/tag_cmd.py` (new) | Click group; converts `PreferencesError` → `click.ClickException` at boundary |
| List filter | `src/fx_alfred/commands/list_cmd.py` (modified) | New `--starred` flag |
| CLI registration | `src/fx_alfred/cli.py` (modified) | LazyGroup entry |

Atomic writes via `tempfile.mkstemp()` + `os.replace()` (matches `update_cmd` pattern). `~/.alfred/` directory created on first write only. Forward-compatible with future preference keys (preserved on round-trip).

## Trinity multi-model review (fast-review preset)

**Plan review (COR-1608 PRP rubric)**:

| Reviewer | Composite | Verdict |
|---|---|---|
| GLM | 9.08 | PASS |
| DeepSeek | 9.30 | PASS |

**Code review (COR-1610 Code rubric)**:

| Reviewer | Composite | Verdict |
|---|---|---|
| GLM | 9.13 | PASS |
| DeepSeek | 9.30 | PASS |

Zero blocking findings across both rounds. Convergent advisory items (≥ 2/2) folded; single-reviewer craft items also folded (cheap improvements):

- Empty-string `<name>` guard
- Empty-starred UX explicit in PRP
- `~/.alfred/` directory creation on first write
- `PreferencesError` → `ClickException` at command boundary (core stays Click-free)
- Dedup on read in `get_starred_tags()` (defensive against hand-edited YAML)
- `.strip().lower()` defensively in `add_starred_tag`/`remove_starred_tag`
- Missing tests added: `--starred --json`, `--starred + --tag` combo, malformed-YAML through `--starred`

## Validation (FXA-2102 readiness gate)

- [x] `pytest -q` — **891 passing** (was 869 on main; +22 new: 16 in `test_tag_cmd.py`, 6 in `test_list_cmd.py`)
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 94 files formatted
- [x] `pyright src/` — 0 errors, 0 warnings
- [x] `af validate --root .` — **247 docs, 0 issues**
- [x] `af tag --help` — group registered, subcommands listed
- [x] `af list --help` — `--starred` listed
- [x] PRP records all review rounds + final validation facts

## Backward compatibility

- Existing `af list` (no `--starred`) output is semantically identical to v1.12.0
- Existing `--tag` flag unchanged
- No new dependencies (`pyyaml` already present)
- No document is modified; PKG layer untouched
- USR layer untouched except for the new `~/.alfred/preferences.yaml` (created on first `af tag star`)

## Test plan

- [ ] CI passes
- [ ] `af tag star release` creates `~/.alfred/preferences.yaml`
- [ ] `af list --starred` returns docs tagged `release`
- [ ] `af tag list --json` returns `{"schema_version": "1", "starred_tags": [...]}`
- [ ] Codex bot review (will auto-trigger on PR open)

PRP: `rules/FXA-2273-PRP-AF-Tag-Star-Command-And-List-Filter.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)