### PR TITLE
release: v1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 
 Alfred is a CLI-based agent runbook (`af`) that manages SOPs, workflows, and structured documents across three layers (PKG, USR, PRJ). It provides:
 
-- **NEW in v1.12.0** — [Contract-First Delivery Workflow (COR-1616)](src/fx_alfred/rules/COR-1616-SOP-Contract-First-Delivery-Workflow.md) — project-neutral reviewed-delivery loop (contract → plan review → TDD/BDD/E2E → impl review → identity-correct PR → PR review loop → close out), promoted from Babs `BAB-1503`. Also: pytest test-marker governance gate, skills-absorption round 5 (COR-1207, COR-1208, FXA-2248).
+- **NEW in v1.13.0** — Starred-tags personal-preference layer: `af tag star/unstar/list` + `af list --starred` filter. Starred tags persist in `~/.alfred/preferences.yaml`; documents are not modified.
+- **v1.12.0** — [Contract-First Delivery Workflow (COR-1616)](src/fx_alfred/rules/COR-1616-SOP-Contract-First-Delivery-Workflow.md) — project-neutral reviewed-delivery loop (contract → plan review → TDD/BDD/E2E → impl review → identity-correct PR → PR review loop → close out), promoted from Babs `BAB-1503`. Also: pytest test-marker governance gate, skills-absorption round 5 (COR-1207, COR-1208, FXA-2248).
 - **v1.10.0** — Agent-editable helpers and skill documents: `af agent call/run`, `af skill list/read`, and `af plan --with-skills`
 - **v1.9.1** — [GitHub App PR Review Bot Loop (COR-1615)](src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md) for Codex Connector / Copilot PR review loops; v1.9.0 added [Council Review (COR-1613)](src/fx_alfred/rules/COR-1613-SOP-Council-Review.md) and [Diagnose Feedback Loop (COR-1503)](src/fx_alfred/rules/COR-1503-SOP-Diagnose-Feedback-Loop.md)
 - **Workflow Routing** — `af guide` tells AI agents which SOP to follow for any task
@@ -206,7 +207,17 @@ af search "validation" --json       # JSON output
 # List & Filter
 af list --type SOP                  # filter by type
 af list --tag release               # filter by tag
+af list --starred                   # filter by your starred tags (~/.alfred/preferences.yaml)
 af list --prefix FXA --json         # filter + JSON output
+
+# Starred tags (per-user preferences, ~/.alfred/preferences.yaml)
+af tag star release                 # mark "release" as starred
+af tag star review                  # add another
+af tag list                         # show your starred tags (sorted)
+af tag list --json                  # JSON output: {schema_version, starred_tags}
+af tag unstar review                # remove from starred
+af list --starred                   # filter docs by intersection with your starred set
+af list --starred --type SOP        # combine: starred SOPs only (AND)
 
 # Other
 af guide --json                     # routing guide as JSON

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.12.0"
+version = "1.13.0"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,51 @@
 # Changelog
 
+## v1.13.0 (2026-05-07)
+
+Minor release: starred-tags personal-preference layer and `af tag` command group.
+
+### Added
+
+- **`af tag star/unstar/list`** — new command group for managing per-user
+  starred tags. Starred tags persist in `~/.alfred/preferences.yaml` (created
+  on first `af tag star`; not stored in any document). All names are
+  lowercased and de-duplicated; empty names are rejected.
+- **`af list --starred`** — filter documents whose `Tags:` metadata
+  intersects the starred set. Composes with `--type / --prefix / --source / --tag`
+  via the same AND logic as existing filters.
+- **`af tag list --json`** — schema-versioned JSON output:
+  `{"schema_version": "1", "starred_tags": [...]}`.
+- **`src/fx_alfred/core/preferences.py`** — new framework-agnostic atomic
+  YAML I/O layer with `PreferencesError`, dedup-on-read, and forward-compat
+  preservation of unknown top-level keys. Command layer converts
+  `PreferencesError` → `click.ClickException` at the boundary. (FXA-2273)
+
+### Changed
+
+- **`rules/` and `fx_alfred/rules/` PRJ trees merged** into a single top-level
+  `rules/` tree. 23 docs renumbered to FXA-2249–2271; FXA-2248 moved as-is.
+  PKG provenance pointers (`Authored from:` / history rows) in COR-1103,
+  COR-1203, COR-1204, COR-1503, COR-1504, COR-1602, COR-1613 updated to the
+  new ACIDs. PKG layer (`src/fx_alfred/rules/`) and USR layer (`~/.alfred/`)
+  untouched. (FXA-2272)
+
+### Docs
+
+- README — new "NEW in v1.13.0" highlight + COR-1616 entry retained;
+  `af tag` and `af list --starred` now appear in the Commands table.
+
+### Stats
+
+- 891 tests passing (+22 new for FXA-2273), 0 breaking changes.
+
+### Install / Upgrade
+
+```bash
+pip install fx-alfred==1.13.0       # install specific version
+pipx install fx-alfred              # first install
+pipx upgrade fx-alfred              # upgrade existing
+```
+
 ## v1.12.0 (2026-05-07)
 
 Minor release: new Contract-First Delivery Workflow SOP, pytest test

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "fx-alfred"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Minor release bumping fx-alfred from v1.12.0 → v1.13.0.

## Highlights

- **NEW**: `af tag star/unstar/list` command group + `af list --starred` filter (FXA-2273, PR #110). User-preference layer for marking commonly-used `Tags:` values as starred; persists in `~/.alfred/preferences.yaml`. Documents are not modified. Trinity fast-review: GLM 9.13 + DeepSeek 9.30 PASS on code review; Codex bot clean.
- **STRUCTURAL**: rules-tree merge (FXA-2272, PR #109). The orphan `fx_alfred/rules/` PRJ tree was merged into top-level `rules/`. 23 docs renumbered to FXA-2249–2271; FXA-2248 moved as-is. PKG provenance pointers updated. `fx_alfred/` directory removed.

## Readiness gates (FXA-2102 + FXA-2136)

- [x] `pytest -q` — **891 passing**
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 94 files formatted
- [x] `pyright src/` — 0 errors, 0 warnings
- [x] `af validate --root .` — 247 docs, 0 issues
- [x] CHANGELOG entry added (v1.13.0)
- [x] README updated per FXA-2136 (`NEW in v1.13.0` highlight + new `af tag` and `af list --starred` examples in Document Management section)
- [x] uv.lock regenerated to 1.13.0

## Files

- `pyproject.toml` — version 1.12.0 → 1.13.0
- `uv.lock` — refreshed to 1.13.0
- `src/fx_alfred/CHANGELOG.md` — v1.13.0 entry
- `README.md` — `NEW in v1.13.0` line + Document Management examples

## Test plan

- [ ] CI passes
- [ ] After merge: `gh release create v1.13.0` triggers GitHub Actions → PyPI Trusted Publisher
- [ ] Post-publish: `pipx upgrade fx-alfred` and verify `af --version` reports `1.13.0`
- [ ] `af tag star release && af list --starred` returns docs tagged `release`

🤖 Generated with [Claude Code](https://claude.com/claude-code)