### PR TITLE
release: v1.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 
 Alfred is a CLI-based agent runbook (`af`) that manages SOPs, workflows, and structured documents across three layers (PKG, USR, PRJ). It provides:
 
-- **NEW in v1.12.0** — [Contract-First Delivery Workflow (COR-1616)](src/fx_alfred/rules/COR-1616-SOP-Contract-First-Delivery-Workflow.md) — project-neutral reviewed-delivery loop (contract → plan review → TDD/BDD/E2E → impl review → identity-correct PR → PR review loop → close out), promoted from Babs `BAB-1503`. Also: pytest test-marker governance gate, skills-absorption round 5 (COR-1207, COR-1208, FXA-2248).
+- **NEW in v1.13.0** — Per-user document bookmarking: `af star <ID>`, `af unstar <ID>`, `af starred`. Bookmark any doc directly by ACID; persists in `~/.alfred/preferences.yaml`; documents are not modified.
+- **v1.12.0** — [Contract-First Delivery Workflow (COR-1616)](src/fx_alfred/rules/COR-1616-SOP-Contract-First-Delivery-Workflow.md) — project-neutral reviewed-delivery loop (contract → plan review → TDD/BDD/E2E → impl review → identity-correct PR → PR review loop → close out), promoted from Babs `BAB-1503`. Also: pytest test-marker governance gate, skills-absorption round 5 (COR-1207, COR-1208, FXA-2248).
 - **v1.10.0** — Agent-editable helpers and skill documents: `af agent call/run`, `af skill list/read`, and `af plan --with-skills`
 - **v1.9.1** — [GitHub App PR Review Bot Loop (COR-1615)](src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md) for Codex Connector / Copilot PR review loops; v1.9.0 added [Council Review (COR-1613)](src/fx_alfred/rules/COR-1613-SOP-Council-Review.md) and [Diagnose Feedback Loop (COR-1503)](src/fx_alfred/rules/COR-1503-SOP-Diagnose-Feedback-Loop.md)
 - **Workflow Routing** — `af guide` tells AI agents which SOP to follow for any task
@@ -207,6 +208,13 @@ af search "validation" --json       # JSON output
 af list --type SOP                  # filter by type
 af list --tag release               # filter by tag
 af list --prefix FXA --json         # filter + JSON output
+
+# Star (per-user bookmarks, ~/.alfred/preferences.yaml)
+af star COR-1202                    # bookmark a doc (PREFIX-ACID, prefix-case-insensitive, or ACID-only)
+af star 1202                        # ACID-only when unambiguous
+af starred                          # list bookmarks; (missing) marks deleted docs
+af starred --json                   # {schema_version, starred_docs, missing}
+af unstar COR-1202                  # remove bookmark (works on stale entries too)
 
 # Other
 af guide --json                     # routing guide as JSON

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.12.0"
+version = "1.13.0"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,57 @@
 # Changelog
 
+## v1.13.0 (2026-05-07)
+
+Minor release: per-user document bookmarking via `af star`.
+
+### Added
+
+- **`af star <ID>`** — bookmark a document by its identifier. Accepts
+  `PREFIX-ACID` (e.g. `COR-1202`), case-insensitive prefix
+  (`cor-1202`), or ACID-only (`1202`). Idempotent. Errors on no-match
+  or ambiguous-ACID inputs. (FXA-2274)
+- **`af unstar <ID>`** — remove a bookmark. Best-effort resolution:
+  works on stale bookmarks (doc deleted), errors on ambiguous
+  ACID-only when multiple stored entries match, prefers stale starred
+  entries over a different live doc with the same ACID.
+- **`af starred [--json]`** — sorted list of bookmarked docs. Marks
+  entries that no longer resolve as `(missing)` in text mode and as
+  `"missing": [...]` alongside `"starred_docs"` in JSON mode (schema
+  version `"1"`).
+- **`~/.alfred/preferences.yaml`** — new per-user preferences file
+  with a `starred_docs:` key. Created on first `af star`. Atomic
+  writes via `tempfile.mkstemp()` + `os.replace()`. Forward-compat:
+  unknown top-level keys survive `star`/`unstar` round-trips.
+
+### Internal
+
+- New `src/fx_alfred/core/preferences.py` — framework-agnostic atomic
+  YAML I/O with `PreferencesError`, dedup-on-read, and unknown-key
+  preservation. Reusable by future per-user-preference features.
+
+### Removed
+
+- The `af tag star/unstar/list` commands and `af list --starred` flag
+  introduced briefly on `main` (FXA-2273) were **deleted before
+  reaching PyPI**. They starred tag *values* rather than documents,
+  which proved overengineered for the actual `Tags:` coverage in real
+  document bases (5 of 238 docs in this repo). `af star` is the
+  simpler primitive that matches operator intent: bookmark the doc
+  itself, no `Tags:` dependency.
+
+### Stats
+
+- 899 tests passing, coverage 95.01%, 0 breaking changes for PyPI
+  users (v1.12.0 had neither `af tag` nor `af star`).
+
+### Install / Upgrade
+
+```bash
+pip install fx-alfred==1.13.0       # install specific version
+pipx install fx-alfred              # first install
+pipx upgrade fx-alfred              # upgrade existing
+```
+
 ## v1.12.0 (2026-05-07)
 
 Minor release: new Contract-First Delivery Workflow SOP, pytest test

--- a/src/fx_alfred/core/preferences.py
+++ b/src/fx_alfred/core/preferences.py
@@ -15,9 +15,7 @@ from typing import Any
 import yaml
 
 
-_HEADER_COMMENT = (
-    "# Managed by `af star`; safe to edit by hand.\n"
-)
+_HEADER_COMMENT = "# Managed by `af star`; safe to edit by hand.\n"
 
 
 class PreferencesError(ValueError):

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "fx-alfred"
-version = "1.12.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Minor release bumping fx-alfred from v1.12.0 → v1.13.0.

## Highlight

- **NEW**: `af star <ID>`, `af unstar <ID>`, `af starred [--json]` — per-user document bookmarking. Persists in `~/.alfred/preferences.yaml` under a new `starred_docs:` key. Documents are not modified. (FXA-2274, PR #112)

## Note about the previous v1.13.0

A prior v1.13.0 release PR (#111) was opened but closed unmerged. It would have shipped `af tag star/unstar/list` and `af list --starred` (FXA-2273) — those commands were determined to be overengineered for actual `Tags:` coverage in real document bases (5 of 238 docs in this repo) and were deleted from `main` in PR #112 before reaching PyPI. **PyPI users see a clean v1.12.0 → v1.13.0 upgrade with `af star` only.**

## Readiness gates (FXA-2102 + FXA-2136)

- [x] `pytest -q` — **899 passing**, coverage **95.01%** (gate ≥ 95%)
- [x] `ruff check .` — All checks passed
- [x] `ruff format --check .` — 94 files formatted (also includes a stray format pass on `src/fx_alfred/core/preferences.py` that slipped through main)
- [x] `pyright src/` — 0 errors, 0 warnings
- [x] `af validate --root .` — 248 docs, 0 issues
- [x] `pyproject.toml` bumped 1.12.0 → 1.13.0
- [x] `uv.lock` regenerated to 1.13.0
- [x] CHANGELOG entry added (v1.13.0)
- [x] README updated per FXA-2136 (`NEW in v1.13.0` highlight + `af star/unstar/starred` examples)

## Files

- `pyproject.toml` — version 1.12.0 → 1.13.0
- `uv.lock` — refreshed to 1.13.0
- `src/fx_alfred/CHANGELOG.md` — v1.13.0 entry
- `README.md` — `NEW in v1.13.0` line + Star (per-user bookmarks) section
- `src/fx_alfred/core/preferences.py` — incidental ruff format pass

## Test plan

- [ ] CI passes
- [ ] After merge: `gh release create v1.13.0` triggers GitHub Actions → PyPI Trusted Publisher
- [ ] Post-publish: `pipx upgrade fx-alfred && af --version` → `1.13.0`
- [ ] `af star COR-1202 && af starred` round-trips correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)