### PR TITLE
docs(sop): promote README check to a numbered Step in FXA-2102 (FXA-2275)

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -184,6 +184,7 @@
 | 2272 | CHG | Merge fx_alfredrules Into Top Level rules |
 | 2273 | PRP | AF Tag Star Command And List Filter |
 | 2274 | PRP | AF Star Command Bookmark Documents |
+| 2275 | CHG | FXA 2102 Promote README Check To Numbered Step |
 
 ---
 

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -1,7 +1,7 @@
 # SOP-2102: Release To PyPI
 
 **Applies to:** FXA project
-**Last updated:** 2026-04-18
+**Last updated:** 2026-05-07
 **Last reviewed:** 2026-03-17
 **Status:** Active
 
@@ -42,7 +42,7 @@ A defined release process ensures consistent, verifiable deployments. Using GitH
 - Ruff format clean (`.venv/bin/ruff format --check .`) — if files need formatting, format + commit first
 - Pyright clean (`.venv/bin/pyright src/`) — catches type errors that the publish CI also runs
 - Dual code review passed (Codex + Gemini both ≥ 9/10)
-- README up to date (FXA-2136 Update README SOP)
+- README updated per **Step 2** below (FXA-2136 Update README SOP)
 - Version bumped in `pyproject.toml`
 - All changes committed and pushed to `main`
 
@@ -59,7 +59,16 @@ A defined release process ensures consistent, verifiable deployments. Using GitH
    .venv/bin/af --version             # confirm version matches
    ```
 
-2. **Create GitHub Release** using the release notes template below
+2. **Update README per FXA-2136** (skip only when the release contains zero user-facing changes)
+   Run the FXA-2136 Update README SOP. At minimum:
+   - Bump or add the "NEW in v\<VERSION\>" highlight line for any new feature/command
+   - Add new commands to the Commands Reference / Document Management section
+   - Confirm Quick Start commands still work
+   - Update the Key SOPs table if a new COR SOP shipped
+   - Commit the README change with the version bump (or as a separate commit on the release branch) **before** running Step 3
+   - Verification: `git diff main -- README.md` shows the intended changes; nothing stale referencing the prior version remains
+
+3. **Create GitHub Release** using the release notes template below
    ```bash
    gh release create v<VERSION> --title "v<VERSION>" --notes "$(cat <<'NOTES'
    <release notes from template>
@@ -107,20 +116,20 @@ Categories (use only what applies):
 - **Docs** — documentation-only changes
 - **Stats** — test count, breaking changes
 
-3. **Wait for CI** — GitHub Actions runs test → build → publish automatically
+4. **Wait for CI** — GitHub Actions runs test → build → publish automatically
 
-4. **Verify CI passed**
+5. **Verify CI passed**
    ```bash
    gh run list --repo frankyxhl/alfred --limit 1
    ```
 
-5. **Verify on PyPI**
+6. **Verify on PyPI**
    ```bash
    pipx install fx-alfred --force
    af --version  # should show new version
    ```
 
-6. **Update CHG document** — mark status as Completed in the related CHG doc
+7. **Update CHG document** — mark status as Completed in the related CHG doc
 
 ---
 
@@ -152,7 +161,8 @@ pipx upgrade fx-alfred                        # verify on PyPI
 
 | Date       | Change                                                                                 | By                  |
 |------------|----------------------------------------------------------------------------------------|---------------------|
-| 2026-03-17 | Initial version                                                                        | Claude Code         |
-| 2026-03-20 | FXA-2133: Add Why, When to Use, When NOT to Use sections (5W1H migration)              | Claude Code         |
-| 2026-03-21 | Added Examples section + release notes template                                        | Claude Code         |
+| 2026-03-17 | Initial version | Claude Code |
+| 2026-03-20 | FXA-2133: Add Why, When to Use, When NOT to Use sections (5W1H migration) | Claude Code |
+| 2026-03-21 | Added Examples section + release notes template | Claude Code |
 | 2026-04-18 | Add pyright to Prerequisites + Step 1 per CHG-FXA-2208 (post v1.6.0 publish incident). | Frank + Claude Code |
+| 2026-05-07 | FXA-2275: promote README check from Prerequisites to a numbered Step (new Step 2). Renumbered subsequent steps 3-7. Reason: README updates were silently skipped twice during v1.12.0 and v1.13.0 release work because the check sat in Prerequisites and was easy to miss when reading top-down. | Claude Code |

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -66,7 +66,7 @@ A defined release process ensures consistent, verifiable deployments. Using GitH
    - Confirm Quick Start commands still work
    - Update the Key SOPs table if a new COR SOP shipped
    - Commit the README change with the version bump (or as a separate commit on the release branch) **before** running Step 3
-   - Verification: `git diff main -- README.md` shows the intended changes; nothing stale referencing the prior version remains
+   - Verification: `grep -F "v<NEW_VERSION>" README.md` returns at least one match (confirms the new version is referenced) AND a manual scan finds no stale references to the prior version. This works regardless of whether the release commit lives on a branch or on `main`.
 
 3. **Create GitHub Release** using the release notes template below
    ```bash

--- a/rules/FXA-2275-CHG-FXA-2102-Promote-README-Check-To-Numbered-Step.md
+++ b/rules/FXA-2275-CHG-FXA-2102-Promote-README-Check-To-Numbered-Step.md
@@ -1,0 +1,65 @@
+# CHG-2275: FXA-2102 Promote README Check To Numbered Step
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-07
+**Last reviewed:** 2026-05-07
+**Status:** Proposed
+**Date:** 2026-05-07
+**Requested by:** —
+**Priority:** Medium
+**Change Type:** Normal
+
+---
+
+## What
+
+Promote the README check in `FXA-2102 Release To PyPI` from a Prerequisites bullet to a numbered, fully-described Step (new Step 2). Renumber the remaining steps 3-7 accordingly. Update the Prerequisites bullet to point at the new Step 2 for clarity.
+
+
+## Why
+
+During this session's release work for v1.12.0 and v1.13.0, the README update was silently skipped twice. The operator had to remind the agent ("pls don't forget to update README as well") during v1.12.0 and again ask "we have a release gate SOP for this?" during v1.13.0. Root cause: the check sat in Prerequisites and was never referenced in the Steps section, so a top-down read of the SOP missed it.
+
+Promoting the check to a numbered Step makes it impossible to skip when working through the SOP linearly, and adds a concrete verification command (`git diff main -- README.md`) so the operator can confirm the change actually landed.
+
+
+## Impact Analysis
+
+**Files changed**
+
+- `rules/FXA-2102-SOP-Release-To-PyPI.md` — single file; insert new Step 2; renumber Steps 3-7; tweak Prerequisites bullet to reference Step 2; add Change History row.
+
+**Behavioural impact**
+
+- Future release runs follow an explicit README step instead of relying on the operator to remember the Prerequisites bullet.
+- Existing release work (v1.13.0 already shipped) is unaffected — this is an SOP wording change, not a code change.
+
+**Out of scope** (explicitly deferred per operator decision)
+
+- Versioning guidance (patch vs minor vs major) — not added.
+- Branch policy clarification (release commits via feature-branch PR vs direct push) — not added.
+- `gh auth status` identity gate as a Prerequisite — not added.
+- Step 7 wording about "related CHG" — not clarified.
+
+These four items were considered and explicitly de-scoped.
+
+
+## Implementation Plan
+
+1. Edit the Prerequisites bullet from `README up to date (FXA-2136 Update README SOP)` to `README updated per Step 2 below (FXA-2136 Update README SOP)`.
+2. Insert new Step 2 between current Step 1 (Verify readiness) and current Step 2 (Create GitHub Release):
+   - Title: "Update README per FXA-2136 (skip only when the release contains zero user-facing changes)"
+   - Body: short bulleted list — bump NEW-in line, add new commands, confirm Quick Start, update Key SOPs table if applicable, commit before tagging, verification command.
+3. Renumber the original Steps 2-6 to 3-7. (Specifically: "Create GitHub Release" → 3; "Wait for CI" → 4; "Verify CI passed" → 5; "Verify on PyPI" → 6; "Update CHG document" → 7.)
+4. Add Change History row dated 2026-05-07 referencing FXA-2275.
+5. Run `af validate --root .` to confirm no structural issues.
+6. Commit + push + open PR; tag-style review (Codex bot only — no Trinity since change is below the trivial threshold per operator decision).
+
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-07 | Initial version | — |

--- a/rules/FXA-2275-CHG-FXA-2102-Promote-README-Check-To-Numbered-Step.md
+++ b/rules/FXA-2275-CHG-FXA-2102-Promote-README-Check-To-Numbered-Step.md
@@ -20,7 +20,7 @@ Promote the README check in `FXA-2102 Release To PyPI` from a Prerequisites bull
 
 During this session's release work for v1.12.0 and v1.13.0, the README update was silently skipped twice. The operator had to remind the agent ("pls don't forget to update README as well") during v1.12.0 and again ask "we have a release gate SOP for this?" during v1.13.0. Root cause: the check sat in Prerequisites and was never referenced in the Steps section, so a top-down read of the SOP missed it.
 
-Promoting the check to a numbered Step makes it impossible to skip when working through the SOP linearly, and adds a concrete verification command (`git diff main -- README.md`) so the operator can confirm the change actually landed.
+Promoting the check to a numbered Step makes it impossible to skip when working through the SOP linearly, and adds a concrete verification — `grep -F "v<NEW_VERSION>" README.md` plus a manual stale-reference scan — so the operator can confirm the change actually landed. (An earlier draft used `git diff main -- README.md`; that variant was rejected during PR review because it produces an empty diff once the release commit lands on `main`, defeating the whole point of the gate.)
 
 
 ## Impact Analysis


### PR DESCRIPTION
## Summary

The README update has lived in `FXA-2102` Prerequisites since v1.6.x but was silently skipped twice in this session (v1.12.0 and v1.13.0 releases) because top-down readers naturally focus on the Steps section. Promoting the check to a numbered Step (new **Step 2**) makes it impossible to skip linearly and adds a concrete verification command.

## Changes

- **`rules/FXA-2102-SOP-Release-To-PyPI.md`**:
  - Prerequisites bullet `README up to date` → `README updated per Step 2 below`
  - **New Step 2** "Update README per FXA-2136" with concrete sub-bullets (bump NEW-in line, add new commands, confirm Quick Start, update Key SOPs table, commit before tagging, `git diff main -- README.md` verification)
  - Renumbered original Steps 2-6 to **3-7**: Create GitHub Release → 3, Wait for CI → 4, Verify CI → 5, Verify on PyPI → 6, Update CHG → 7
  - Change History row dated 2026-05-07

- **`rules/FXA-2275-CHG-FXA-2102-Promote-README-Check-To-Numbered-Step.md`** (new):
  - Records what changed, why, impact analysis, implementation plan
  - Explicitly lists 4 deferred items per operator decision (versioning guidance, branch policy, `gh auth status` Prerequisite, "related CHG" wording)

## Out of scope (deferred per operator decision)

- Versioning guidance (patch / minor / major heuristic)
- Branch policy clarification (release commits via feature-branch PR vs direct push)
- `gh auth status` identity gate as a Prerequisite
- Step 7 "related CHG" wording

## Validation

- [x] `af validate --root .` — **249 documents, 0 issues**
- No code changes; only SOP wording + new CHG document
- No tests affected; no version bump needed

## Test plan

- [ ] CI passes (lint/format/typecheck on the doc changes only)
- [ ] Codex bot review on PR open
- [ ] Next release run uses the new Step 2 explicitly

🤖 Generated with [Claude Code](https://claude.com/claude-code)