### PR TITLE
chore(repo): add Iterwheel Blueprint issue template (#116)

### DIFF
--- a/.github/ISSUE_TEMPLATE/blueprint.md
+++ b/.github/ISSUE_TEMPLATE/blueprint.md
@@ -1,0 +1,79 @@
+---
+name: Iterwheel Blueprint
+about: File a task / feature / docs request that the iterwheel-blueprint bot can intake automatically.
+title: "[Task]: <one-line summary>"
+labels: []
+assignees: []
+---
+
+<!--
+Iterwheel Blueprint intake template.
+
+The iterwheel-blueprint bot watches new issues filed against this repository
+and applies the `blueprint-ready` label + 🚀 reaction when the body contains
+the required H2 sections AND at least one concrete acceptance criterion
+(a `- [ ]` checkbox item under ## Acceptance Criteria).
+
+Keep the H2 section headings (## Work Type, ## Problem / Goal, etc.) so the
+bot can detect them. Sections with placeholder values (e.g. "TBD") will not
+satisfy the intake check — fill each one with a concrete answer before submit.
+-->
+
+## Work Type
+
+<!-- One short paragraph: what kind of work is this? Code, docs, refactor,
+     repo hygiene, governance / SOP, infra, etc. -->
+
+## Problem / Goal
+
+<!-- What is broken / missing / desired? State the user-visible outcome,
+     not the implementation. -->
+
+## Context
+
+<!-- Background a maintainer needs to understand the request: prior PRs,
+     related issues, governance docs, constraints, deadlines. -->
+
+## Expected Outcome
+
+<!-- What does "done" look like? One paragraph describing the end state
+     a future reader could verify against. -->
+
+## Acceptance Criteria
+
+<!-- At least one concrete checkbox item is REQUIRED for blueprint-ready
+     intake. Each item should be independently verifiable. -->
+
+- [ ] <first concrete, verifiable acceptance criterion>
+- [ ] <add more as needed>
+
+## Reproduction Steps / Task Plan
+
+<!-- For bugs: minimal reproduction. For tasks: numbered task plan
+     (the agent will refine, not execute verbatim). -->
+
+1.
+2.
+3.
+
+## Priority
+
+<!-- One of P0 (incident / blocker), P1 (important, schedule soon),
+     P2 (normal), P3 (nice-to-have). Add a one-line justification. -->
+
+P2 - <one-line justification>
+
+## Requester / Owner
+
+<!-- Requester: who is asking for this. Owner: who will do or coordinate
+     the work (TBD is fine; the maintainer will assign). -->
+
+- **Requester**: @<github-handle>
+- **Owner**: TBD
+
+## Out of Scope (optional)
+
+<!-- Explicit non-goals to prevent scope creep. Delete this section if
+     not applicable. -->
+
+-


### PR DESCRIPTION
## Summary

Adds `.github/ISSUE_TEMPLATE/blueprint.md` so future issues filed against this repository start from the Iterwheel Blueprint intake template that `iterwheel-blueprint[bot]` recognizes.

## Why

Closes #116. The repo is already installed for `iterwheel-blueprint[bot]` and has the Wukong webhook configured (verified by the bot labeling issue #116 itself + #117–#120 as `blueprint-ready` with the 🚀 reaction). What's missing is the **template chooser entry** — without a template under `.github/ISSUE_TEMPLATE/`, every new issue starts from a blank editor and the requester has to remember the H2 section structure manually.

## Scope

- **Adds** one file: `.github/ISSUE_TEMPLATE/blueprint.md`
- **Touches no other surfaces** — does not edit `config.yml` (no chooser config exists yet, and the issue does not ask to disable blank issues), does not add labels, does not modify any workflow.

## Choice of template format — markdown vs Issue Forms YAML

Two compatible formats:

| Format | H1/H2 control | Bot detection compatibility |
|---|---|---|
| **Markdown** (`.md`, frontmatter + body) | full — author writes raw markdown | ✅ matches `iterwheel-blueprint`'s observed H2-section detection |
| **Issue Forms** (`.yml`, structured fields) | none — labels render as `### H3` | ⚠ may or may not match — bot has only been verified against H2-bodied issues |

Picked the markdown form because:
1. Every existing `blueprint-ready` issue in this repo (`#116` / `#117` / `#118` / `#119` / `#120`) uses **H2** section headings, and that is the only structure the bot's intake check has been observed to accept.
2. Issue Forms would force H3 (no override), creating risk of bot-detection drift on the very first templated issue.
3. The acceptance criteria specify section *names*, not field validation — markdown body is sufficient.

## Acceptance Criteria (from #116)

- [x] The repository contains a Blueprint issue template under `.github/ISSUE_TEMPLATE/`.
- [x] The template includes Work Type, Problem / Goal, Context, Expected Outcome, Acceptance Criteria, Reproduction Steps / Task Plan, Priority, and Requester / Owner.
- [ ] A new issue filed with the template is marked `blueprint-ready` by `iterwheel-blueprint`. *(post-merge verification — not testable from this PR)*
- [ ] `iterwheel-blueprint` adds its ready-state comment, label, and rocket reaction when the issue is complete. *(post-merge verification)*
- [x] Existing issue workflows in this repository still work after the template is added. *(additive change; nothing removed or modified)*

## Test plan

- [x] `af validate --root .` passes (253 documents, 0 issues).
- [x] YAML frontmatter parses cleanly (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [x] All 8 required H2 sections present in body.
- [ ] After merge: file a fresh issue from the template chooser, confirm `iterwheel-blueprint[bot]` applies `blueprint-ready` + 🚀.

## SOP-loop notes

This PR is being shipped under `follow FXA-2276` (COR-1617 multi-agent loop), iteration 1.

- **Phase 1** — auto-pick: live-chat invocation; #116 selected over #118 (Rank 3 single-file beats Rank 4 multi-surface).
- **Phase 3** — sized as **inline-PR-body**; the issue body is the spec. No separate CHG document filed (single config-file addition; not a CHG/SOP/PRP edit).
- **Phase 4** — plan-review **skipped**; the change is config-file addition with the spec fully captured by the issue body and acceptance criteria. Per COR-1617 §When NOT to Use, lightweight config additions don't require panel review. Bot review on this PR will catch any defects.

## Scope hints for automated reviewers

**In-scope (please flag):**
- P0/P1 — would the template body actually trigger `iterwheel-blueprint`'s `blueprint-ready` detection? Any heading typo or missing required section.
- P2 — frontmatter correctness (template chooser display, default title, label set).
- Cross-doc drift between the template's H2 headings and what existing `blueprint-ready` issues use (the bot's de-facto contract).

**Out-of-scope (please skip or batch into a follow-up):**
- P3 cosmetic — comment phrasing inside HTML comments, placeholder example wording.
- Suggestions to switch to Issue Forms YAML (covered in PR body §Choice of template format).
- Suggestions to add `config.yml` chooser config or disable blank issues (out of scope for #116).

🤖 Generated with [Claude Code](https://claude.com/claude-code)