### PR TITLE
release: v1.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 
 Alfred is a CLI-based agent runbook (`af`) that manages SOPs, workflows, and structured documents across three layers (PKG, USR, PRJ). It provides:
 
-- **NEW in v1.13.0** — Per-user document bookmarking: `af star <ID>`, `af unstar <ID>`, `af starred`. Bookmark any doc directly by ACID; persists in `~/.alfred/preferences.yaml`; documents are not modified.
+- **NEW in v1.14.0** — [Multi-Agent Workflow Loop (COR-1617 cluster)](src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md) — umbrella SOP for consensus-driven multi-agent task execution with consent gates, worker dispatch, and loop primitives. Ships COR-1617/1618/1619/1620/1621/1622. Also: COR-1612 §Scoping bot reviews via PR body; COR-1615 pointer; new `.github/ISSUE_TEMPLATE/blueprint.md` for iterwheel intake.
+- **v1.13.0** — Per-user document bookmarking: `af star <ID>`, `af unstar <ID>`, `af starred`. Bookmark any doc directly by ACID; persists in `~/.alfred/preferences.yaml`; documents are not modified.
 - **v1.12.0** — [Contract-First Delivery Workflow (COR-1616)](src/fx_alfred/rules/COR-1616-SOP-Contract-First-Delivery-Workflow.md) — project-neutral reviewed-delivery loop (contract → plan review → TDD/BDD/E2E → impl review → identity-correct PR → PR review loop → close out), promoted from Babs `BAB-1503`. Also: pytest test-marker governance gate, skills-absorption round 5 (COR-1207, COR-1208, FXA-2248).
 - **v1.10.0** — Agent-editable helpers and skill documents: `af agent call/run`, `af skill list/read`, and `af plan --with-skills`
 - **v1.9.1** — [GitHub App PR Review Bot Loop (COR-1615)](src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md) for Codex Connector / Copilot PR review loops; v1.9.0 added [Council Review (COR-1613)](src/fx_alfred/rules/COR-1613-SOP-Council-Review.md) and [Diagnose Feedback Loop (COR-1503)](src/fx_alfred/rules/COR-1503-SOP-Diagnose-Feedback-Loop.md)
@@ -354,6 +355,7 @@ graph TD
 | COR-1612 | Respond to PR review comments on GitHub |
 | COR-1615 | GitHub App PR Review Bot Loop — trigger/poll/match-head loop for Codex Connector, Copilot, and other GitHub App reviewers |
 | COR-1616 | Contract-First Delivery Workflow — project-neutral reviewed delivery loop (contract → plan review → TDD/BDD/E2E → impl review → identity-correct PR → PR review loop → close out) |
+| COR-1617 | Multi-Agent Workflow Loop — consensus-driven task execution with consent gates, worker dispatch, and structured loop primitives |
 | COR-1608 | PRP Review Scoring rubric |
 | COR-1611 | Reviewer Calibration Guide |
 | COR-1613 | Council Review — multi-reviewer decision mechanism (14 voting rules) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.13.0"
+version = "1.14.0"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,42 @@
 # Changelog
 
+## v1.14.0 (2026-05-09)
+
+Docs-shipped-as-PKG-SOPs release. No CLI / behavior changes; new bundled COR documents.
+
+### Added
+
+- **COR-1617 Multi-Agent Workflow Loop cluster** — promoted from trinity
+  TRN-1008 (alfred#115, PRs #117 + #119). Eleven-phase umbrella SOP
+  composing existing PKG SOPs, plus the supporting cluster:
+  - `COR-1617` — Multi-Agent Workflow Loop (umbrella).
+  - `COR-1618` — Auto-pick consent gate.
+  - `COR-1619` — Worker dispatch contract.
+  - `COR-1620` — Loop primitives (wakeup, idle-with-retry,
+    merge-watch, stop-marker).
+  - `COR-1621` — Triage tree + severity vocabulary (P0–P3).
+  - `COR-1622` — Parameter schema (instantiated per-project).
+- **COR-1612 §Scoping bot reviews via PR body (optional, GitHub App
+  review bots only)** — codifies the PR-body scope-hint technique
+  observed empirically on alfred PR #117 R11–R12 + PR #119 R1–R5
+  (FXA-2279, PR #122). Includes recommended template, when-most-useful
+  / when-NOT-useful heuristics, the non-substitution caveat, and the
+  evidence table.
+- **COR-1615 §Operator Checklist pointer** to COR-1612 §Scoping for
+  operators on long iteration loops (FXA-2279, PR #122).
+- **`.github/ISSUE_TEMPLATE/blueprint.md`** — Iterwheel Blueprint
+  intake template (alfred#116, PR #121). Markdown form (not Issue
+  Forms YAML) so the rendered body uses the H2 section headings the
+  `iterwheel-blueprint[bot]` intake check detects.
+
+### Changed
+
+- `pyproject.toml` version bump 1.13.0 → 1.14.0.
+
+### Removed
+
+- None.
+
 ## v1.13.0 (2026-05-07)
 
 Minor release: per-user document bookmarking via `af star`.

--- a/uv.lock
+++ b/uv.lock
@@ -291,7 +291,7 @@ wheels = [
 
 [[package]]
 name = "fx-alfred"
-version = "1.13.0"
+version = "1.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

Version bump to v1.14.0. Ships PKG SOPs added since v1.13.0.

## What ships

- **COR-1617 cluster** (PRs #117 + #119): Multi-Agent Workflow Loop umbrella SOP + COR-1618 (consent gate), COR-1619 (worker dispatch), COR-1620 (loop primitives), COR-1621 (triage), COR-1622 (parameter schema).
- **COR-1612 §Scoping bot reviews via PR body** (PR #122): codifies the PR-body scope-hint technique observed empirically on alfred PR #117 R11–R12 + PR #119 R1–R5.
- **COR-1615 §Operator Checklist pointer** (PR #122) to COR-1612 §Scoping.
- **`.github/ISSUE_TEMPLATE/blueprint.md`** (PR #121) for iterwheel-blueprint intake.

## Test plan

- [x] \`pytest -v\` — all passing
- [x] \`ruff check .\` — clean
- [x] \`ruff format --check .\` — clean
- [x] \`pyright src/\` — clean
- [x] \`af --version\` shows 1.14.0
- [x] README updated with v1.14.0 highlight

## Release flow

After merge, operator runs \`gh release create v1.14.0 ...\` which triggers the publish workflow (Trusted Publisher → PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code) using Haiku 4.5