### PR TITLE
docs(fxa): route COR-1501 in FXA-2125 decision tree (#126)

### DIFF
--- a/rules/FXA-2125-SOP-Workflow-Routing-PRJ.md
+++ b/rules/FXA-2125-SOP-Workflow-Routing-PRJ.md
@@ -81,6 +81,10 @@ What do you need to do in the FXA project?
    └── .venv/bin/pytest tests/ -v --tb=short      (tests)
        .venv/bin/ruff check .                       (lint)
        af validate --root fx_alfred                (document validation)
+
+9. Create a task ticket / GitHub issue?
+   └── COR-1501 (Create GitHub Issue)
+       Determine type → write with blueprint template → gh issue create --repo <repo> → gh issue view <number>
 ```
 
 ## Project Context
@@ -106,6 +110,7 @@ COR-1500: Any code change → TDD: failing test first, then green, then refactor
 af create: Never manually create .md files, always af create --prefix FXA --area 21
 af validate: Run after document migrations to confirm 0 issues
 fx_alfred: Documents live in rules/ (PRJ layer), document changes committed with code
+COR-1501: GitHub issue = blueprint template + stack-type-* / stack-area-* label pair
 ```
 
 ## Steps
@@ -124,3 +129,4 @@ This is a routing SOP — no procedural steps. The Project Decision Tree above i
 | 2026-03-21 | Added Steps section (routing SOP, no procedural steps) | Claude Code |
 | 2026-03-30 | CHG FXA-2153: Translated decision tree from Chinese to English (COR-0002/COR-1401 compliance) | Claude Code |
 | 2026-04-04 | CHG FXA-2190: Remove deprecated FXA-2127 ref from decision tree, fix stale "no remote" golden rule | Claude Code |
+| 2026-05-10 | issue #126: add branch 9 (Create GitHub issue → COR-1501) to decision tree; add COR-1501 traceability line to Golden Rules | Claude Opus 4.7 |


### PR DESCRIPTION
## Summary

Closes routing gap from issue #126: COR-1501 (Create GitHub Issue) existed in the PKG layer but was unreachable via `af guide`. After this PR, branch 9 of FXA-2125's decision tree surfaces it as the canonical step for creating task tickets.

- Add branch 9 ("Create a task ticket / GitHub issue?") to FXA-2125's Project Decision Tree, with the inline note: `Determine type → write with blueprint template → gh issue create --repo <repo> → gh issue view <number>`
- Add Golden Rules traceability line: `COR-1501: GitHub issue = blueprint template + stack-type-* / stack-area-* label pair`
- Record the change in FXA-2125 Change History

## Acceptance criteria (from #126)

- [x] FXA-2125 decision tree gains a new branch for "Create a task ticket / GitHub issue" routing to COR-1501
- [x] Branch includes a brief inline note (determine type → write with template → `gh issue create` → verify), analogous to other branches
- [x] Golden Rules section updated with a COR-1501 traceability line
- [x] `af validate --root /Users/frank/Projects/alfred` passes with 0 issues (264 docs, 0 issues)
- [x] Change recorded in FXA-2125 Change History

## Scope hints

- **In scope:** the three edits in `rules/FXA-2125-SOP-Workflow-Routing-PRJ.md` listed above. PR is single-file, +6/-0 lines.
- **Out of scope (tracked separately):** the inline note references "blueprint template", which is the *target* convention COR-1501 itself is being updated to align with under issue #127. #126 is intentionally decoupled per its issue body ("that work is tracked separately"); the note describes the end-state COR-1501 will be authoritative for, even though COR-1501's own update has not landed yet. Reviewers: do **not** flag the route note as inconsistent with current COR-1501 content — that mismatch is expected and resolved by #127.
- **Out of scope:** any edits to COR-1501, the blueprint template, or `af guide`/`af plan` code paths.

## Test plan

- [x] `af validate --root /Users/frank/Projects/alfred` → 264 docs checked, 0 issues
- [ ] `af guide --root /Users/frank/Projects/alfred/fx_alfred` surfaces branch 9 (manual verification by reviewer if desired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)