### PR TITLE
docs(cor): align COR-1501 with current alfred conventions (#127)

### DIFF
--- a/src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md
+++ b/src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md
@@ -123,6 +123,8 @@ This repo uses paired `stack-type-*` + `stack-area-*` labels (the `iterwheel-sta
 | `stack-area-tests` | Test infrastructure |
 | `stack-area-backend` | Server / library code |
 | `stack-area-frontend` | UI / client code |
+| `stack-area-infra` | Hosting, runtime, deployment, environments |
+| `stack-area-unknown` | Area cannot be determined yet — `iterwheel-stack[bot]` may rewrite this on intake |
 
 If you mis-pair, `iterwheel-stack[bot]` may swap one label after intake (observed on issue #127: hand-applied `stack-area-docs` was replaced with `stack-area-github`). Treat that as confirmation, not a rejection.
 
@@ -195,7 +197,7 @@ The `--repo` flag is required when the working directory is not the target repo'
 gh issue view <number> --repo <owner>/<repo>
 ```
 
-`gh issue list` only confirms the issue exists; `gh issue view` confirms the body rendered correctly and lets you inspect intake-bot signals — look for `blueprint-ready` (intake passed) or `blueprint-requests-revision` (a required H2 section is missing or `- [ ]` is absent under `## Acceptance Criteria`). If revision is requested, edit the body via `gh issue edit <number> --body-file <path>` and re-verify.
+`gh issue list` only confirms the issue exists; `gh issue view` confirms the body rendered correctly and lets you inspect intake-bot signals — look for `blueprint-ready` (intake passed) or `blueprint-requests-revision` (a required H2 section is missing or `- [ ]` is absent under `## Acceptance Criteria`). If revision is requested, edit the body via `gh issue edit <number> --repo <owner>/<repo> --body-file <path>` and re-verify (the same `--repo` rule from Step 3 applies — without it, `gh` falls back to the current working directory's repo).
 
 ---
 

--- a/src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md
+++ b/src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md
@@ -1,10 +1,10 @@
 # SOP-1501: Create GitHub Issue
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-03-14
-**Last reviewed:** 2026-03-14
+**Last updated:** 2026-05-10
+**Last reviewed:** 2026-05-10
 **Status:** Active
-**Last executed:** —
+**Last executed:** 2026-05-10 (issue #126)
 
 ---
 
@@ -43,85 +43,159 @@ Consistent issue structure makes triage faster, reduces back-and-forth clarifica
 
 ## Issue Template
 
-```markdown
-## Summary
+This SOP defers to each repo's `.github/ISSUE_TEMPLATE/blueprint.md` (the Iterwheel Blueprint template) as the source of truth. Repos that have the `iterwheel-blueprint[bot]` installed require the H2 sections below; the bot applies the `blueprint-ready` label + 🚀 reaction only when every section is present and at least one concrete `- [ ]` item appears under `## Acceptance Criteria`.
 
-<1-2 sentences describing what needs to be done and why.>
+```markdown
+## Work Type
+
+<short paragraph: code / docs / refactor / repo hygiene / governance / SOP / infra>
+
+## Problem / Goal
+
+<what is broken / missing / desired — user-visible outcome, not implementation>
 
 ## Context
 
-- **Source:** <SOP number, session retrospective, or user request>
+- **Source:** <SOP number, session retrospective, prior PR, or user request>
 - **Related files:** <list of relevant files or paths>
-- **Depends on:** <other issue numbers, if any>
+- **Related issue:** <other issue numbers, if any>
+- **Depends on:** <blocker issue numbers, if any>
+
+## Expected Outcome
+
+<one paragraph describing the end state a future reader could verify against>
 
 ## Acceptance Criteria
 
-- [ ] Criterion 1
-- [ ] Criterion 2
-- [ ] Criterion 3
+- [ ] First concrete, verifiable criterion
+- [ ] Add more as needed
 
-## Technical Notes
+## Reproduction Steps / Task Plan
 
-<Optional: implementation hints, constraints, or relevant code references.>
+1.
+2.
+3.
+
+## Priority
+
+P2 — <one-line justification>
+
+## Requester / Owner
+
+- **Requester**: @<github-handle>
+- **Owner**: TBD
+
+## Out of Scope (optional)
+
+<explicit non-goals; delete the section if not applicable>
 ```
 
 ---
 
 ## Steps
 
-### 1. Determine issue type
+### 1. Determine issue type and area
+
+This repo uses paired `stack-type-*` + `stack-area-*` labels (the `iterwheel-stack[bot]` may auto-classify, but pre-applying the correct pair speeds intake). The pair replaces older single-label conventions like `sop` / `automation` / `bug` / `enhancement` / `docs` — do not use those.
+
+**Type labels** (`stack-type-*` — pick exactly one):
 
 | Label | Use when |
 |-------|----------|
-| `sop` | New or updated SOP needed |
-| `automation` | Script, Makefile target, or command to create |
-| `bug` | Something broken |
-| `enhancement` | Improvement to existing feature |
-| `docs` | Documentation only |
+| `stack-type-task` | General work item or governance ticket (default for SOP-driven work) |
+| `stack-type-bug` | Something is broken |
+| `stack-type-feature` | New capability |
+| `stack-type-docs` | Documentation-only change |
+| `stack-type-refactor` | Internal restructuring with no behavior change |
+| `stack-type-chore` | Repo hygiene / housekeeping |
+| `stack-type-ci` | CI / build pipeline change |
+| `stack-type-test` | Test-only change |
+| `stack-type-spike` | Investigation / time-boxed prototype |
+
+**Area labels** (`stack-area-*` — pick exactly one):
+
+| Label | Use when |
+|-------|----------|
+| `stack-area-github` | GitHub-side surface (Actions, issues, repo config) |
+| `stack-area-automation` | Scripts, Makefile targets, agents |
+| `stack-area-docs` | Documentation surfaces (`docs/`, `rules/`, governance) |
+| `stack-area-ci` | CI workflows, build / publish |
+| `stack-area-tests` | Test infrastructure |
+| `stack-area-backend` | Server / library code |
+| `stack-area-frontend` | UI / client code |
+
+If you mis-pair, `iterwheel-stack[bot]` may swap one label after intake (observed on issue #127: hand-applied `stack-area-docs` was replaced with `stack-area-github`). Treat that as confirmation, not a rejection.
 
 ### 2. Write the issue
 
-Use the template above. Keep the title short (<70 chars), put details in the body.
+Use the blueprint template under §Issue Template above. Keep the title short (<70 chars); put details in the body.
 
-Title format: `[<label>] <short description>`
+Title format: `[Task]: <one-line summary>` (matches `.github/ISSUE_TEMPLATE/blueprint.md`'s `title:` field).
 
 Examples:
-- `[automation] Add make add-channel command`
-- `[sop] Create SOP for launchd plist management`
-- `[bug] Codex relay 401 when started via nohup`
+- `[Task]: Add make add-channel command`
+- `[Task]: Codex relay 401 when started via nohup`
+- `[Docs]: Add COR-1501 route to FXA-2125 decision tree`
+
+The leading `[<Type>]` chip should align with the `stack-type-*` label (e.g. `[Task]` ↔ `stack-type-task`, `[Docs]` ↔ `stack-type-docs`).
 
 ### 3. Create via CLI
 
 ```bash
 gh issue create \
-  --title "[<label>] <title>" \
+  --repo <owner>/<repo> \
+  --title "[Task]: <one-line summary>" \
   --body "$(cat <<'EOF'
-## Summary
+## Work Type
 
-<description>
+<short paragraph>
+
+## Problem / Goal
+
+<user-visible outcome>
 
 ## Context
 
-- **Source:** ALF-NNNN / session retrospective / user request
+- **Source:** <SOP-NNNN / session retrospective / user request>
 - **Related files:** <paths>
+- **Related issue:** <#NNN>
+- **Depends on:** <#NNN or None>
+
+## Expected Outcome
+
+<one paragraph end-state>
 
 ## Acceptance Criteria
 
-- [ ] ...
+- [ ] <first concrete criterion>
 
-## Technical Notes
+## Reproduction Steps / Task Plan
 
-<notes>
+1.
+2.
+
+## Priority
+
+P2 — <justification>
+
+## Requester / Owner
+
+- **Requester**: @<github-handle>
+- **Owner**: TBD
 EOF
 )" \
-  --label "<label>"
+  --label "stack-type-task,stack-area-docs"
 ```
+
+The `--repo` flag is required when the working directory is not the target repo's clone (common when following an SOP from a different project).
 
 ### 4. Verify
 
 ```bash
-gh issue list
+gh issue view <number> --repo <owner>/<repo>
 ```
+
+`gh issue list` only confirms the issue exists; `gh issue view` confirms the body rendered correctly and lets you inspect intake-bot signals — look for `blueprint-ready` (intake passed) or `blueprint-requests-revision` (a required H2 section is missing or `- [ ]` is absent under `## Acceptance Criteria`). If revision is requested, edit the body via `gh issue edit <number> --body-file <path>` and re-verify.
 
 ---
 
@@ -129,8 +203,9 @@ gh issue list
 
 | Field | Convention |
 |-------|-----------|
-| Title prefix | `[sop]`, `[automation]`, `[bug]`, `[enhancement]`, `[docs]` |
-| Assignee | Channel/session that will work on it |
+| Title prefix chip | `[Task]:`, `[Bug]:`, `[Feature]:`, `[Docs]:`, etc. (matches `stack-type-*` family) |
+| Labels | One `stack-type-*` + one `stack-area-*` (paired) |
+| Assignee | Owner of the work, or unassigned with `Owner: TBD` |
 | Milestone | Optional, for grouping related work |
 
 ---
@@ -150,3 +225,4 @@ gh issue list
 | 2026-03-08 | Initial version | Claude Code |
 | 2026-03-14 | PDCA + Johnny Decimal migration: renamed from ALF-1003 to ALF-2101 | Claude Code |
 | 2026-03-20 | Added Why/When to Use/When NOT to Use sections per FXA-2223 | Claude Code |
+| 2026-05-10 | issue #127: align with current alfred repo conventions — stack-type-* + stack-area-* label pair (replaces old `sop`/`automation`/etc. taxonomy), Iterwheel Blueprint template (replaces Summary/Context template), `[Task]:` title chip, `--repo` flag in CLI example, `gh issue view` verify with intake-bot label check | Claude Opus 4.7 |

--- a/src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md
+++ b/src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md
@@ -1,6 +1,6 @@
 # SOP-1501: Create GitHub Issue
 
-**Applies to:** All projects using the COR document system
+**Applies to:** Repos using the Iterwheel intake bots (`iterwheel-blueprint[bot]` for body intake, `iterwheel-stack[bot]` for `stack-*` label pairs). The procedure (template, CLI, verify) generalizes; the label tables below reflect alfred's labels and must be substituted for repos with a different label set.
 **Last updated:** 2026-05-10
 **Last reviewed:** 2026-05-10
 **Status:** Active
@@ -96,7 +96,9 @@ P2 — <one-line justification>
 
 ### 1. Determine issue type and area
 
-This repo uses paired `stack-type-*` + `stack-area-*` labels (the `iterwheel-stack[bot]` may auto-classify, but pre-applying the correct pair speeds intake). The pair replaces older single-label conventions like `sop` / `automation` / `bug` / `enhancement` / `docs` — do not use those.
+This repo (alfred) uses paired `stack-type-*` + `stack-area-*` labels (the `iterwheel-stack[bot]` may auto-classify, but pre-applying the correct pair speeds intake). The pair replaces older single-label conventions like `sop` / `automation` / `bug` / `enhancement` / `docs` — do not use those on alfred.
+
+If you are following this SOP from a non-alfred repo, run `gh label list --repo <owner>/<repo>` first to enumerate the actual labels there, and substitute the correct pair into Step 3's `--label` argument; the framework (`stack-type-*` + `stack-area-*` pair model, blueprint template, `[Type]:` title chip, `--repo` flag, `gh issue view` verify) is portable, but the specific label values below are not.
 
 **Type labels** (`stack-type-*` — pick exactly one):
 


### PR DESCRIPTION
## Summary

Closes issue #127. Updates COR-1501 (Create GitHub Issue SOP) so an agent following it step-by-step produces a valid, bot-intakeable issue on this repo: correct stack-* label pair, blueprint-compatible body template, `[Task]:` title chip, `--repo` flag, and a `gh issue view` verify that surfaces intake-bot signals.

Live execution of COR-1501 during the 2026-05-10 session (issue #126) surfaced five concrete gaps; this PR closes all five.

## Changes

- **Step 1 — label taxonomy.** Replace `sop`/`automation`/`bug`/`enhancement`/`docs` with paired `stack-type-*` (9 values) + `stack-area-*` (7 values), mirroring the labels actually applied by `iterwheel-stack[bot]`. Note that mis-pairs may be silently rebalanced by the bot (observed on issue #127).
- **§Issue Template.** Replace `Summary / Context / Acceptance Criteria / Technical Notes` with the Iterwheel Blueprint sections (`Work Type / Problem · Goal / Context / Expected Outcome / Acceptance Criteria / Reproduction Steps · Task Plan / Priority / Requester · Owner / Out of Scope`). Required for `iterwheel-blueprint[bot]` to apply `blueprint-ready`.
- **Step 2 — title format.** `[Task]: <one-line summary>` (or `[Bug]:`, `[Docs]:`, etc., aligned with the `stack-type-*` label).
- **Step 3 — CLI.** Add `--repo` flag (required when working dir != repo clone). Use multi-label syntax `--label \"stack-type-task,stack-area-docs\"`. Body uses the blueprint template via heredoc.
- **Step 4 — verify.** `gh issue view <number> --repo <owner>/<repo>` (vs old `gh issue list`) — confirms body rendered, lets the agent inspect `blueprint-ready` vs `blueprint-requests-revision` to know whether intake passed.
- **Frontmatter.** Bump `Last updated` / `Last reviewed` to 2026-05-10. Record `Last executed: 2026-05-10 (issue #126)`.

## Acceptance criteria (from #127)

- [x] Step 1 label table replaced with `stack-type-*` / `stack-area-*` taxonomy (with note that the combination replaces the old single-label system)
- [x] Step 2 template updated to match \`.github/ISSUE_TEMPLATE/blueprint.md\` sections
- [x] Step 3 CLI example updated with `--repo` flag and correct multi-label syntax
- [x] Step 4 verify updated to `gh issue view <number>` (confirm body + bot intake label)
- [x] Title convention reconciled with blueprint template title format
- [x] `af validate --root /Users/frank/Projects/alfred` passes (264 docs, 0 issues)
- [x] Change recorded in COR-1501 Change History

## Scope hints

- **In scope:** the single-file edit to `src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md` listed above. PR is +110/-34 lines, all in one PKG document.
- **Out of scope (intentional):**
  - The companion routing add to FXA-2125 (issue #126) is in PR #130, not bundled here. Reviewers: do **not** flag the absence of an FXA-2125 update — it's tracked separately.
  - Auto-generated `docs/` mirror is gitignored and rebuilt on push to main by `.github/workflows/docs.yml`. Not in this diff.
  - Other COR SOPs that may also reference the old label taxonomy are out of scope for #127; surface follow-ups as separate issues.

## Test plan

- [x] `.venv/bin/pytest -v --tb=short` → 900 passed
- [x] `.venv/bin/ruff check .` → clean
- [x] `af validate --root /Users/frank/Projects/alfred` → 264 docs checked, 0 issues
- [x] `.venv/bin/python scripts/build_docs.py` runs cleanly (regenerated docs/ — gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)