### PR TITLE
docs(cor): add §Scoring weighted rubric to COR-1200 Session Retrospective

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -191,6 +191,7 @@
 | 2279 | CHG | Codify GitHub App PR Review Bot Scope Hint Technique In COR 1612 + COR 1615 |
 | 2280 | CHG | FXA 2276 Phase 10 Mergeable Trigger |
 | 2281 | CHG | Add COR 1802 Build Weighted Decision Matrix SOP |
+| 2282 | CHG | Add Scoring to COR 1200 Session Retrospective |
 
 ---
 

--- a/rules/FXA-2282-CHG-Add-Scoring-to-COR-1200-Session-Retrospective.md
+++ b/rules/FXA-2282-CHG-Add-Scoring-to-COR-1200-Session-Retrospective.md
@@ -90,7 +90,7 @@ Score 0–10 on each dimension. Composite = Σ(weight × score).
 
 **Example 1 — First codex catch, trinity missed** (`--repo` gap, PR #131 R1):
 Frequency=0, Actionability=8, Impact=5, Detection gap=10
-→ 0×0.35 + 8×0.30 + 5×0.20 + 10×0.15 = **4.9 → Discard** (first occurrence; if this class recurs next PR, Frequency rises to 5 and composite crosses into Log band at 6.95)
+→ 0×0.35 + 8×0.30 + 5×0.20 + 10×0.15 = **4.9 → Discard** (first occurrence; if this class recurs next PR, Frequency rises to 5 and composite crosses into Log band at 6.65)
 
 **Example 2 — Same class recurs in the next PR**:
 Frequency=5, Actionability=9, Impact=5, Detection gap=10

--- a/rules/FXA-2282-CHG-Add-Scoring-to-COR-1200-Session-Retrospective.md
+++ b/rules/FXA-2282-CHG-Add-Scoring-to-COR-1200-Session-Retrospective.md
@@ -1,0 +1,140 @@
+# CHG-2282: Add §Scoring to COR-1200 Session Retrospective
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-10
+**Last reviewed:** 2026-05-10
+**Status:** Proposed
+**Date:** 2026-05-10
+**Requested by:** Frank Xu (session 2026-05-10)
+**Priority:** Medium
+**Change Type:** Normal
+**Targets:** `src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md`
+**Closes:** #134
+
+---
+
+## What
+
+Add `## Scoring` section to COR-1200 (Session Retrospective) containing:
+
+1. Signal taxonomy — six named finding classes (five specific + one catch-all)
+2. Scoring rubric — four weighted dimensions (Frequency 35% / Actionability 30% / Impact 20% / Detection gap 15%), each scored 0–10 with anchor descriptions at 0, 5, 10
+3. Action thresholds — ≥7.5 → create GitHub issue; 5.0–7.4 → log only; <5.0 → discard
+4. Calibration examples — four worked examples with numeric composites
+
+Also add one-line §Scoring references to §Step 2, §Step 3, and §Step 4; add `### Scored Findings` subsection to §Step 5 template.
+
+## Why
+
+COR-1200 §Steps 2–4 identify patterns qualitatively but provide no scoring rubric and no objective criterion for when a finding should become a tracked GitHub issue. This leads to over-escalation of one-off noise and under-escalation of recurrent systematic gaps. Issue #133 (per-PR loop retrospective in COR-1617 §Phase 11) also needs a principled threshold rather than a hard-coded count rule.
+
+## Surfaces
+
+| File | Change |
+|------|--------|
+| `src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md` | Insert `## Scoring` section after `## Steps`; add one line to §Step 2, §Step 3, §Step 4; add `### Scored Findings` subsection to §Step 5 template; add Change History row |
+
+**Out of scope:** New document creation, changes to COR-1617, PRJ-layer override contract.
+
+**Soft dependency:** After issue #135 (COR-1802 SOP) merges, add one back-reference line in §Scoring rubric intro pointing to COR-1802. Ships independently — §Scoring is self-contained.
+
+## Implementation Plan
+
+1. Edit `COR-1200`: insert `## Scoring` section after `## Steps` (before `## Example`)
+2. Add "Score the finding per §Scoring; proceed with the indicated action" to §Step 2, §Step 3, §Step 4
+3. Add `### Scored Findings` subsection to §Step 5 template (after Key Learnings)
+4. Add Change History row
+5. `af validate --root /Users/frank/Projects/alfred` — must pass
+6. Push branch, open PR with `Closes #134`; verify `closingIssuesReferences`
+7. Trinity fast-review (glm + deepseek); iterate until both ≥ 9.0 and codex bot clean
+
+## §Scoring Draft Content
+
+> Inserted in COR-1200 as `## Scoring`, after `## Steps`.
+
+### Signal taxonomy
+
+Six finding classes. Classify each retro finding into the most specific matching class:
+
+| Class | Description |
+|-------|-------------|
+| **Recurrent finding** | Same finding type appeared in ≥2 distinct contexts (rounds, PRs, or sessions) |
+| **Detection gap** | Primary detector (trinity panel) missed what secondary caught (codex bot, human) |
+| **Late convergence** | Finding required R3+ rounds to resolve — not caught or prevented early |
+| **Process skip** | A mandatory SOP guard rail or step was not executed |
+| **Tooling gap** | Repeated manual step that could be scripted or added as an `af` command |
+| **Other** | Finding does not match any class above; describe in one sentence |
+
+### Scoring rubric
+
+Score 0–10 on each dimension. Composite = Σ(weight × score).
+
+| Dimension | Weight | 0 | 5 | 10 |
+|-----------|--------|---|---|-----|
+| **Frequency** | 35% | First time seen in any context | Appeared in 2 distinct contexts | ≥3 distinct PRs or sessions |
+| **Actionability** | 30% | Vague ("be more careful"); no concrete target | Has a target SOP/file but amendment wording unclear | Specific target section + one-sentence amendment drafted now |
+| **Impact** | 20% | No visible slowdown | Caused +1 review round or ~30 min lost | Caused R3+ or equivalent user rework / >1 h lost |
+| **Detection gap** | 15% | Caught by primary (trinity) on first pass | Caught by primary on re-review after initial miss | Missed by primary entirely; caught by secondary (codex) or human |
+
+### Action thresholds
+
+| Composite | Action |
+|-----------|--------|
+| **≥ 7.5** | **Create GitHub issue** — include the drafted amendment in the issue body (per COR-1501 §Step 3: gh issue create). Present score breakdown to user before creating. |
+| **5.0 – 7.4** | **Log only** — record in §Step 5 `### Scored Findings` with composite, dimension scores, and class. Re-evaluate on next iteration; Frequency score rises if the class recurs, potentially crossing the issue threshold. |
+| **< 5.0** | **Discard** — noise, one-off, or already covered by an existing MEMORY entry or open issue. |
+
+> **Threshold geometry note:** Reaching the Issue band (≥7.5) requires at least two dimensions to score strongly. Frequency=10 with all other dims at 5 yields only 6.75 (Log band) — intentional: a high-frequency but low-impact, vague, internally-caught finding warrants tracking, not an issue. Actionability is the second-strongest lever; Frequency=10 + Actionability=10 yields 6.5 at minimum (others at 0, Log band) and 8.25 with others at 5 (Issue band). Reaching the Issue band from Freq+Act=10 requires at least Impact=5 (composite = 7.5, exactly at threshold).
+
+### Calibration examples
+
+**Example 1 — First codex catch, trinity missed** (`--repo` gap, PR #131 R1):
+Frequency=0, Actionability=8, Impact=5, Detection gap=10
+→ 0×0.35 + 8×0.30 + 5×0.20 + 10×0.15 = **4.9 → Discard** (first occurrence; if this class recurs next PR, Frequency rises to 5 and composite crosses into Log band at 6.95)
+
+**Example 2 — Same class recurs in the next PR**:
+Frequency=5, Actionability=9, Impact=5, Detection gap=10
+→ 1.75 + 2.70 + 1.00 + 1.50 = **6.95 → Log and re-evaluate**
+
+**Example 3 — Third PR, same class** (pattern confirmed):
+Frequency=10, Actionability=9, Impact=5, Detection gap=8
+→ 3.50 + 2.70 + 1.00 + 1.20 = **8.40 → Create issue**
+
+**Example 4 — Single late-convergence, high impact, no recurrence**:
+Frequency=0, Actionability=9, Impact=10, Detection gap=5
+→ 0 + 2.70 + 2.00 + 0.75 = **5.45 → Log**
+
+### §Step 5 template addition
+
+> Add `### Scored Findings` as the last subsection in the §Step 5 template, after Key Learnings:
+
+```markdown
+### Scored Findings
+| Class | Frequency | Actionability | Impact | Detection gap | Composite | Action |
+|-------|-----------|---------------|--------|----------------|-----------|--------|
+| <class> | <0–10> | <0–10> | <0–10> | <0–10> | <n.n> | Log / Discard |
+```
+
+## Acceptance Criteria
+
+- [ ] `COR-1200` has `## Scoring` section with signal taxonomy, scoring rubric, action thresholds, and ≥4 calibration examples
+- [ ] Signal taxonomy has 6 rows including Other/Unclassified catch-all
+- [ ] Scoring rubric: 4 dimensions named Frequency/Actionability/Impact/Detection gap, weights sum to 100%, anchor descriptions at 0/5/10
+- [ ] Action thresholds: three bands; ≥7.5 band explicitly requires GitHub issue creation per COR-1501 §Step 3
+- [ ] "Log only" band references §Step 5 `### Scored Findings` table
+- [ ] ≥1 calibration example scores below the issue threshold
+- [ ] COR-1200 §Steps 2, 3, and 4 each add one line referencing §Scoring
+- [ ] COR-1200 §Step 5 template gains `### Scored Findings` subsection
+- [ ] No new document created; `af status` document count unchanged
+- [ ] `af validate --root /Users/frank/Projects/alfred` passes
+- [ ] Trinity fast-review (glm + deepseek) both ≥ 9.0
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-10 | Initial version per issue #134 | Claude Code |
+| 2026-05-10 | R1 fixes: geometry note arithmetic (B1); Log-only storage defined via §Step 5 Scored Findings (B2); Recurrence→Frequency rename (A2); Other catch-all row added (A1) | Claude Code |
+| 2026-05-10 | R2 advisories: Detection gap score=5 anchor clarified; template Action column "Deferred"→"Discard"; template placeholder `<0/5/10>`→`<0–10>` | Claude Code |

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -1,8 +1,8 @@
 # SOP-1200: Session Retrospective
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-03-17
-**Last reviewed:** 2026-03-17
+**Last updated:** 2026-05-10
+**Last reviewed:** 2026-05-10
 **Status:** Active
 **Last executed:** —
 

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -259,7 +259,7 @@ Score 0–10 on each dimension. Composite = Σ(weight × score).
 
 **Example 1 — First codex catch, trinity missed** (`--repo` gap, PR #131 R1):
 Frequency=0, Actionability=8, Impact=5, Detection gap=10
-→ 0×0.35 + 8×0.30 + 5×0.20 + 10×0.15 = **4.9 → Discard** (first occurrence; if this class recurs next PR, Frequency rises to 5 and composite crosses into Log band at 6.95)
+→ 0×0.35 + 8×0.30 + 5×0.20 + 10×0.15 = **4.9 → Discard** (first occurrence; if this class recurs next PR, Frequency rises to 5 and composite crosses into Log band at 6.65)
 
 **Example 2 — Same class recurs in the next PR**:
 Frequency=5, Actionability=9, Impact=5, Detection gap=10

--- a/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
+++ b/src/fx_alfred/rules/COR-1200-SOP-Session-Retrospective.md
@@ -148,7 +148,7 @@ Ask yourself:
 - Did I copy-paste similar commands or configs?
 - Did I manually do something that could be scripted?
 
-**If yes** → Candidate for a new command, Makefile target, or script.
+**If yes** → Candidate for a new command, Makefile target, or script. Score the finding per §Scoring below; proceed with the indicated action.
 
 ### 3. Identify undocumented processes
 
@@ -157,7 +157,7 @@ Ask yourself:
 - Did I have to figure something out from scratch that should be documented?
 - Did I teach someone (or get taught) a workflow?
 
-**If yes** → Candidate for a new SOP.
+**If yes** → Candidate for a new SOP. Score the finding per §Scoring below; proceed with the indicated action.
 
 ### 4. Identify improvements to existing SOPs
 
@@ -165,7 +165,7 @@ Ask yourself:
 - Did I follow an existing SOP but hit a gap or error in it?
 - Is there a step missing or outdated?
 
-**If yes** → Update the relevant SOP and add a Change History entry.
+**If yes** → Update the relevant SOP and add a Change History entry. Score the finding per §Scoring below; proceed with the indicated action.
 
 ### 5. Record findings
 
@@ -202,6 +202,11 @@ Fill in the template with the sections below. The document is automatically inde
 
 ### Key Learnings
 - <numbered list of insights worth remembering for future sessions>
+
+### Scored Findings
+| Class | Frequency | Actionability | Impact | Detection gap | Composite | Action |
+|-------|-----------|---------------|--------|----------------|-----------|--------|
+| <class> | <0–10> | <0–10> | <0–10> | <0–10> | <n.n> | Log / Discard |
 ```
 
 ### 6. Execute improvements
@@ -209,6 +214,64 @@ Fill in the template with the sections below. The document is automatically inde
 - Create new SOPs immediately if they're small
 - File larger improvements as TODOs for the next session
 - Update existing SOPs before ending the session
+
+---
+
+## Scoring
+
+Use this rubric to decide whether a retro finding warrants a tracked GitHub issue, a log entry, or discard.
+
+### Signal taxonomy
+
+Six finding classes. Classify each retro finding into the most specific matching class:
+
+| Class | Description |
+|-------|-------------|
+| **Recurrent finding** | Same finding type appeared in ≥2 distinct contexts (rounds, PRs, or sessions) |
+| **Detection gap** | Primary detector (trinity panel) missed what secondary caught (codex bot, human) |
+| **Late convergence** | Finding required R3+ rounds to resolve — not caught or prevented early |
+| **Process skip** | A mandatory SOP guard rail or step was not executed |
+| **Tooling gap** | Repeated manual step that could be scripted or added as an `af` command |
+| **Other** | Finding does not match any class above; describe in one sentence |
+
+### Scoring rubric
+
+Score 0–10 on each dimension. Composite = Σ(weight × score).
+
+| Dimension | Weight | 0 | 5 | 10 |
+|-----------|--------|---|---|-----|
+| **Frequency** | 35% | First time seen in any context | Appeared in 2 distinct contexts | ≥3 distinct PRs or sessions |
+| **Actionability** | 30% | Vague ("be more careful"); no concrete target | Has a target SOP/file but amendment wording unclear | Specific target section + one-sentence amendment drafted now |
+| **Impact** | 20% | No visible slowdown | Caused +1 review round or ~30 min lost | Caused R3+ or equivalent user rework / >1 h lost |
+| **Detection gap** | 15% | Caught by primary (trinity) on first pass | Caught by primary on re-review after initial miss | Missed by primary entirely; caught by secondary (codex) or human |
+
+### Action thresholds
+
+| Composite | Action |
+|-----------|--------|
+| **≥ 7.5** | **Create GitHub issue** — include the drafted amendment in the issue body (per COR-1501 §Step 3: gh issue create). Present score breakdown to user before creating. |
+| **5.0 – 7.4** | **Log only** — record in §Step 5 `### Scored Findings` with composite, dimension scores, and class. Re-evaluate on next iteration; Frequency score rises if the class recurs, potentially crossing the issue threshold. |
+| **< 5.0** | **Discard** — noise, one-off, or already covered by an existing MEMORY entry or open issue. |
+
+> **Threshold geometry note:** Reaching the Issue band (≥7.5) requires at least two dimensions to score strongly. Frequency=10 with all other dims at 5 yields only 6.75 (Log band) — intentional: a high-frequency but low-impact, vague, internally-caught finding warrants tracking, not an issue. Actionability is the second-strongest lever; Frequency=10 + Actionability=10 yields 6.5 at minimum (others at 0, Log band) and 8.25 with others at 5 (Issue band). Reaching the Issue band from Freq+Act=10 requires at least Impact=5 (composite = 7.5, exactly at threshold).
+
+### Calibration examples
+
+**Example 1 — First codex catch, trinity missed** (`--repo` gap, PR #131 R1):
+Frequency=0, Actionability=8, Impact=5, Detection gap=10
+→ 0×0.35 + 8×0.30 + 5×0.20 + 10×0.15 = **4.9 → Discard** (first occurrence; if this class recurs next PR, Frequency rises to 5 and composite crosses into Log band at 6.95)
+
+**Example 2 — Same class recurs in the next PR**:
+Frequency=5, Actionability=9, Impact=5, Detection gap=10
+→ 1.75 + 2.70 + 1.00 + 1.50 = **6.95 → Log and re-evaluate**
+
+**Example 3 — Third PR, same class** (pattern confirmed):
+Frequency=10, Actionability=9, Impact=5, Detection gap=8
+→ 3.50 + 2.70 + 1.00 + 1.20 = **8.40 → Create issue**
+
+**Example 4 — Single late-convergence, high impact, no recurrence**:
+Frequency=0, Actionability=9, Impact=10, Detection gap=5
+→ 0 + 2.70 + 2.00 + 0.75 = **5.45 → Log**
 
 ---
 
@@ -247,3 +310,4 @@ af create ref --prefix ALF --area 12 --title "Session Retrospective 2026-03-17-D
 | 2026-03-17 | Step 5: add explicit af create ref command, add Key Learnings section, add example save command, use YYYY-MM-DD-DN title format for multiple sessions per day | Claude Code |
 | 2026-03-19 | Added Step 0: close all D items before retrospective (references COR-1201) | Claude Code |
 | 2026-03-20 | Added Why/When to Use/When NOT to Use sections per FXA-2223 | Claude Code |
+| 2026-05-10 | Added §Scoring (signal taxonomy, 4-dim rubric, action thresholds, 4 calibration examples); §Step 5 template: added Scored Findings subsection; §Steps 2/3/4: added §Scoring reference per FXA-2282 / issue #134 | Claude Code |


### PR DESCRIPTION
## Summary

- Add `## Scoring` section to `COR-1200` with signal taxonomy (6 classes), 4-dimension weighted rubric (Frequency 35% / Actionability 30% / Impact 20% / Detection gap 15%), action thresholds (≥7.5 → issue / 5.0–7.4 → log / <5.0 → discard), and 4 calibration examples
- Update §Steps 2, 3, and 4 with one-line §Scoring references
- Add `### Scored Findings` subsection to §Step 5 template for logging scored findings pending re-evaluation
- Add CHG document FXA-2282 (plan-review PASS: GLM 9.5/10, DeepSeek 9.3/10)

## Scope hints

Single PKG-layer document edit (`COR-1200-SOP-Session-Retrospective.md`). Review focus: §Scoring section correctness (arithmetic, anchor descriptions, action threshold bands, calibration example math). No code changes.

## Test plan

- [x] `af validate --root /Users/frank/Projects/alfred` passes (265 docs, 0 issues)
- [x] Scoring rubric weights sum to 100% (35+30+20+15)
- [x] All 4 calibration example arithmetic verified by fast-review panel
- [x] Threshold geometry note verified correct (Freq=10+Act=10+Impact=5 = 7.5 exactly at threshold)
- [x] §Steps 2/3/4 each reference §Scoring
- [x] §Step 5 template includes Scored Findings subsection
- [x] No new documents created

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)