### PR TITLE
feat(cor): add §Resilience parameters to COR-1622 loop-config schema

### DIFF
--- a/src/fx_alfred/rules/COR-1622-REF-Multi-Agent-Loop-Project-Configuration.md
+++ b/src/fx_alfred/rules/COR-1622-REF-Multi-Agent-Loop-Project-Configuration.md
@@ -1,8 +1,8 @@
 # REF-1622: Multi-Agent Loop Project Configuration
 
 **Applies to:** All projects adopting the COR-1617 Multi-Agent Workflow Loop
-**Last updated:** 2026-05-09
-**Last reviewed:** 2026-05-09
+**Last updated:** 2026-05-10
+**Last reviewed:** 2026-05-10
 **Status:** Active
 **Related:** COR-1617 (umbrella SOP), COR-1618 (consent auto-pick), COR-1619 (worker dispatch), COR-1620 (loop primitives), COR-1621 (triage)
 
@@ -81,6 +81,14 @@ When a doc uses `<X>`, look it up here first. If absent, treat as a runtime vari
 | `<worker-agent>` | string | yes | — | The coding worker identifier the orchestrator delegates substantial implementation to (e.g. `trinity-glm via droid exec`). |
 | `<worker-min-loc>` | integer | yes | `30` | Lines-of-change threshold for the single-function trivial-fix branch. **At or below** this count: orchestrator edits directly. **Above**: dispatch to `<worker-agent>`. (Boundary alignment with COR-1619 §Decision Tree node C — both docs treat the threshold value itself as the orchestrator-direct ceiling.) |
 
+### Resilience (CLI retry / failure escalation)
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `<cli-retry-attempts>` | integer | yes | `3` | Maximum retry attempts when a panel-provider CLI fails (timeout, non-zero exit, or missing binary). `0` = fail-fast: surface the failure immediately without retrying. |
+| `<cli-retry-backoff-seconds>` | integer | yes | `600` | Seconds to wait between retry attempts. |
+| `<cli-retry-on-failure>` | enum | yes | `pause-and-ask` | Action when all retry attempts are exhausted. One of: `pause-and-ask` — surface the failure to the operator and wait for instruction; `mark-non-viable` — treat the provider as non-viable for this run and continue if the panel retains ≥3 viable verdicts (see §Review panel `<panel-providers>`); `abort-loop` — stop the run entirely. |
+
 ### Bot polling (COR-1615 binding)
 
 | Key | Type | Required | Default | Description |
@@ -122,6 +130,9 @@ Trinity instantiates this schema as `TRN-1209-REF-Multi-Agent-Loop-Config.md` (i
 | `<wakeup-tool>` | `ScheduleWakeup` |
 | `<idle-cap>` | `12` |
 | `<merge-watch-cap>` | `24` |
+| `<cli-retry-attempts>` | `3` (default) |
+| `<cli-retry-backoff-seconds>` | `600` (default) |
+| `<cli-retry-on-failure>` | `pause-and-ask` (default) |
 
 ---
 
@@ -130,6 +141,7 @@ Trinity instantiates this schema as `TRN-1209-REF-Multi-Agent-Loop-Config.md` (i
 - A project that adopts COR-1617 MUST instantiate this schema before any orchestrator session runs the loop. Missing or `unset` required keys is a hard error — orchestrator aborts and surfaces.
 - Substituting `<weights-doc>` with a foreign project's weights doc is a guard-rail violation. Each project's panel-review uses the project's own weights table.
 - `<intake-quality-mode>` may not silently change between sessions. If a project moves from `1FA` to `2FA` mid-flight, every previously-rocket-eligible issue must be re-checked against the new mode.
+- `<cli-retry-on-failure>` = `mark-non-viable` interacts with the `<panel-providers>` 3-viable-minimum rule: after marking a provider non-viable, verify the remaining panel still meets the 3-viable gate before continuing. If it does not, escalate to the operator regardless of this setting.
 
 ---
 
@@ -143,3 +155,4 @@ Trinity instantiates this schema as `TRN-1209-REF-Multi-Agent-Loop-Config.md` (i
 | 2026-05-09 | R9: `<worker-min-loc>` boundary semantics aligned with COR-1619 §Decision Tree — was "at or above → worker" (so the value 30 went to worker); now "at or below → orchestrator, above → worker" (so 30 stays with orchestrator). COR-1619 was the operative dispatch SOP and already used "at or below"; this fixes the contract divergence. Codex bot R8 P2 boundary finding. | Claude Opus 4.7 |
 | 2026-05-09 | FXA-2277: two schema refinements surfaced when alfred attempted to instantiate. (1) `<fork-remote>` renamed to `<pr-push-remote>` — original name presupposed a forked-fork workflow that not all adopters use; alfred pushes feature branches to `origin` directly. The invariant ("never push to `origin/main`") is preserved; only the name changed. (2) `<weights-doc>` type widened from `string` to `string \| map<<spec-format>, string>` — adopters with one rubric across artifact types use the scalar form (trinity's `TRN-1800`); adopters keying off `<spec-format>` use the map form. Trinity's existing instantiation continues working unchanged. | Claude Opus 4.7 |
 | 2026-05-09 | R3 (PR #119): codex bot R2 P2 — `<weights-doc>` schema-row description showed an example with invalid map keys (`code`, `PRP` — not in the `<spec-format>` enum). Same class of bug fixed in FXA-2276 R2 but not propagated to COR-1622 itself. Replaced with valid enum keys (alfred's actual map: `{CHG: COR-1609, ADR: COR-1609, RFC: COR-1608, inline-PR-body: COR-1609}`); added explicit note that `code` is not a valid key (code review uses COR-1610 by phase per COR-1617 §Phase 4). Adopters copying the schema row now get a valid instantiation. | Claude Opus 4.7 |
+| 2026-05-10 | FXA-146: add §Resilience parameter group (`<cli-retry-attempts>`, `<cli-retry-backoff-seconds>`, `<cli-retry-on-failure>`) covering CLI/provider-failure retry behavior. Defaults (3 attempts / 600 s / pause-and-ask) match Babs operator policy. Guard rail added for `mark-non-viable` interaction with 3-viable-minimum. Worked Example updated with trinity's effective defaults (all three keys inherit schema defaults; no behavior change). | Claude Sonnet 4.6 |


### PR DESCRIPTION
## Summary

- Add `§Resilience` subsection to COR-1622 between `§Worker dispatch` and `§Bot polling`
- Three new required keys with conservative defaults: `<cli-retry-attempts>` (3), `<cli-retry-backoff-seconds>` (600 s), `<cli-retry-on-failure>` (pause-and-ask)
- Guard rail added: `mark-non-viable` must re-verify 3-viable-minimum before continuing
- `§Worked Example` (Trinity) extended with effective defaults — no behavior change to existing adopters
- `af validate` passes (267 docs, 0 issues)

## Scope hints

Documentation-only. Single file changed: `src/fx_alfred/rules/COR-1622-REF-Multi-Agent-Loop-Project-Configuration.md`. No code changes. Review for: schema row correctness, enum completeness, guard rail cross-reference accuracy, worked example consistency.

Closes #146