### PR TITLE
feat(cor): add R-count cap with adaptive extension to COR-1617 §Phase 8

### DIFF
--- a/rules/FXA-2276-REF-Multi-Agent-Loop-Configuration.md
+++ b/rules/FXA-2276-REF-Multi-Agent-Loop-Configuration.md
@@ -73,6 +73,14 @@ PR #117 promoted trinity's TRN-1008 into the COR-1617 PKG cluster. Alfred is the
 | `<idle-cap>` | `12` | default — 6 h @ 1800 s |
 | `<merge-watch-cap>` | `24` | default — 12 h @ 1800 s |
 
+### R-count cap (COR-1617 §Phase 8)
+
+| Key | Alfred value | Notes |
+|-----|--------------|-------|
+| `<max-r-count>` | `10` | default |
+| `<max-r-count-extension>` | `3` | default — hard stop at R13 |
+| `<convergence-severity>` | `advisory` | default — P0/P1/P2 open blocks extension; advisory-only triggers convergence |
+
 ---
 
 ## Invocation
@@ -170,3 +178,4 @@ These project-specific deviations are intentional and not gaps in the SOP:
 | 2026-05-10 | FXA-2283 R2: renumber 11-phase → 12-phase; Phase 11 = Retrospective (new synchronous phase); Phase 12 = Loop restart (formerly Phase 11); update all §11 references to §12; add Phase 11 Retrospective row to §Adoption Status; update §Invocation `follow FXA-2276 once` to stop after phase 11; update Known Risk §11 → §12. | Claude Code |
 | 2026-05-10 | FXA-2283 R3: Phase 11 row — add alfred deviation note (git-pull no-op pre-merge under FXA-2280 mergeable trigger; update COR-1615 endpoint reference to §Commands); `follow FXA-2276 for #N` — fix phases 2–10 → 2–11, add "no §12 wake" clause. | Claude Code |
 | 2026-05-10 | FXA-2283 R6: Phase 11 row — add Alfred deviation note for Trinity-miss/codex-catch: alfred dispatches the panel via Skill(trinity) in-session; findings not GitHub-re-fetchable; output `n/a — panel findings not GitHub-accessible`. | Claude Code |
+| 2026-05-10 | Issue #144: add §R-count cap section instantiating `<max-r-count>` = 10, `<max-r-count-extension>` = 3, `<convergence-severity>` = advisory (all defaults). | Claude Sonnet 4.6 |

--- a/rules/FXA-2276-REF-Multi-Agent-Loop-Configuration.md
+++ b/rules/FXA-2276-REF-Multi-Agent-Loop-Configuration.md
@@ -79,7 +79,7 @@ PR #117 promoted trinity's TRN-1008 into the COR-1617 PKG cluster. Alfred is the
 |-----|--------------|-------|
 | `<max-r-count>` | `10` | default |
 | `<max-r-count-extension>` | `3` | default — hard stop at R13 |
-| `<convergence-severity>` | `advisory` | default — P0/P1/P2 open blocks extension; advisory-only triggers convergence |
+| `<convergence-severity>` | `advisory` | default — advisory-only findings → converge (Case A); P0/P1/P2 open → self-authorized extension (Case B) until hard stop at R13 |
 
 ---
 

--- a/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
+++ b/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
@@ -221,15 +221,15 @@ Code-review panel runs once per HEAD when CI is green AND bot has reviewed the c
 
 ### Round-count cap
 
-Cap check fires on every round where R-number ≥ `<max-r-count>` (default 10 per COR-1622 §R-count cap). Evaluate in order:
+Cap check fires on every round where R-number ≥ `<max-r-count>` (default 10 per COR-1622 §R-count cap). Cases are evaluated in the order listed:
 
 | Case | Condition | Action |
 |------|-----------|--------|
+| **C — Hard stop** | R-number ≥ `<max-r-count>` + `<max-r-count-extension>` | Halt. Surface to user: "PR #\<N\> reached R\<count\> (soft cap `<max-r-count>` + `<max-r-count-extension>` extension rounds). Remaining: P0=\<n\> P1=\<n\> P2=\<n\> advisory=\<n\>. Trend: \<converging / flat / diverging\>. Recommend: [merge as-is / address manually / close]. Awaiting decision." |
 | **A — Converged** | All remaining findings are at or below `<convergence-severity>` (default `advisory` — no P0/P1/P2 open) | Declare convergence. Proceed to Phase 10. No user alert. |
 | **B — Extension** | P0/P1/P2 still open AND R-number < `<max-r-count>` + `<max-r-count-extension>` | Log: "R\<N\>: unresolved P\<k\> findings; self-authorizing extension round \<ext#\>." Continue Phase 8. |
-| **C — Hard stop** | R-number == `<max-r-count>` + `<max-r-count-extension>` | Halt. Surface to user: "PR #\<N\> reached R\<count\> (soft cap `<max-r-count>` + `<max-r-count-extension>` extension rounds). Remaining: P0=\<n\> P1=\<n\> P2=\<n\> advisory=\<n\>. Trend: \<converging / flat / diverging\>. Recommend: [merge as-is / address manually / close]. Awaiting decision." |
 
-Case C check takes priority: evaluate C first, then A, then B. If C fires, do NOT proceed to Phase 10 — await operator decision.
+Case C is evaluated first: reaching the extended hard-stop round requires operator sign-off even when all findings have converged, to prevent silent auto-merge after an unusually long iteration cycle. If C fires, halt — do NOT proceed to Phase 10.
 
 ### Phase 9 — Triage
 
@@ -360,3 +360,4 @@ This SOP is the PKG-layer generalization of trinity's `TRN-1008-SOP-Multi-Agent-
 | 2026-05-10 | FXA-148 R3: §Failure Modes — add `<cli-retry-backoff-seconds>` (default 600 s) between retry attempts; codex bot P2 Thread 2 on PR #149 R2. | Claude Sonnet 4.6 |
 | 2026-05-10 | FXA-148 R4: §Failure Modes — expand failure-condition list to include "exits non-zero" and "uses a missing binary" (matching COR-1622 §Resilience trigger list); previously only timeout/non-2xx/malformed-JSON were listed, leaving CLI-specific failure modes outside the retry path. | Claude Sonnet 4.6 |
 | 2026-05-10 | Issue #144: §Phase 8 — add §Round-count cap: three-tier logic (Case A converged / Case B extension / Case C hard stop) with parameters `<max-r-count>` (default 10), `<max-r-count-extension>` (default 3), `<convergence-severity>` (default advisory) defined in COR-1622 §R-count cap. Prevents unbounded iteration loops. | Claude Sonnet 4.6 |
+| 2026-05-10 | Issue #144 R2: §Round-count cap — (1) Case C condition `==` → `≥` (GLM P0/DeepSeek P2: equality left R>hard-stop with no case firing); (2) reorder table to C→A→B to match evaluation priority; (3) update trailing note to include rationale for C-first ordering. | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
+++ b/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
@@ -219,6 +219,18 @@ CI status splits four ways:
 
 Code-review panel runs once per HEAD when CI is green AND bot has reviewed the current HEAD. Panel gate per phase 4. If gate met → phase 10. If gate not met → triage per phase 9 → push R<n+1> → loop back.
 
+### Round-count cap
+
+Cap check fires on every round where R-number ≥ `<max-r-count>` (default 10 per COR-1622 §R-count cap). Evaluate in order:
+
+| Case | Condition | Action |
+|------|-----------|--------|
+| **A — Converged** | All remaining findings are at or below `<convergence-severity>` (default `advisory` — no P0/P1/P2 open) | Declare convergence. Proceed to Phase 10. No user alert. |
+| **B — Extension** | P0/P1/P2 still open AND R-number < `<max-r-count>` + `<max-r-count-extension>` | Log: "R\<N\>: unresolved P\<k\> findings; self-authorizing extension round \<ext#\>." Continue Phase 8. |
+| **C — Hard stop** | R-number == `<max-r-count>` + `<max-r-count-extension>` | Halt. Surface to user: "PR #\<N\> reached R\<count\> (soft cap `<max-r-count>` + `<max-r-count-extension>` extension rounds). Remaining: P0=\<n\> P1=\<n\> P2=\<n\> advisory=\<n\>. Trend: \<converging / flat / diverging\>. Recommend: [merge as-is / address manually / close]. Awaiting decision." |
+
+Case C check takes priority: evaluate C first, then A, then B. If C fires, do NOT proceed to Phase 10 — await operator decision.
+
 ### Phase 9 — Triage
 
 Apply COR-1621 to every finding. Plan-review architectural blockers go back to phase 4 (re-dispatch panel after CHG fix); code-review and bot findings flow through the severity tree. Re-dispatch the panel only when blockers (or convergent advisories) were addressed.
@@ -347,3 +359,4 @@ This SOP is the PKG-layer generalization of trinity's `TRN-1008-SOP-Multi-Agent-
 | 2026-05-10 | FXA-148 R2: §Failure Modes — also parameterize exhaustion action: "mark the provider unavailable for this round" → "apply `<cli-retry-on-failure>` (default `pause-and-ask`)"; N-1/dissenter guard-rail conditionalized to `mark-non-viable` branch only. GLM P1-B1 on PR #149 R1. | Claude Sonnet 4.6 |
 | 2026-05-10 | FXA-148 R3: §Failure Modes — add `<cli-retry-backoff-seconds>` (default 600 s) between retry attempts; codex bot P2 Thread 2 on PR #149 R2. | Claude Sonnet 4.6 |
 | 2026-05-10 | FXA-148 R4: §Failure Modes — expand failure-condition list to include "exits non-zero" and "uses a missing binary" (matching COR-1622 §Resilience trigger list); previously only timeout/non-2xx/malformed-JSON were listed, leaving CLI-specific failure modes outside the retry path. | Claude Sonnet 4.6 |
+| 2026-05-10 | Issue #144: §Phase 8 — add §Round-count cap: three-tier logic (Case A converged / Case B extension / Case C hard stop) with parameters `<max-r-count>` (default 10), `<max-r-count-extension>` (default 3), `<convergence-severity>` (default advisory) defined in COR-1622 §R-count cap. Prevents unbounded iteration loops. | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1622-REF-Multi-Agent-Loop-Project-Configuration.md
+++ b/src/fx_alfred/rules/COR-1622-REF-Multi-Agent-Loop-Project-Configuration.md
@@ -81,6 +81,14 @@ When a doc uses `<X>`, look it up here first. If absent, treat as a runtime vari
 | `<worker-agent>` | string | yes | — | The coding worker identifier the orchestrator delegates substantial implementation to (e.g. `trinity-glm via droid exec`). |
 | `<worker-min-loc>` | integer | yes | `30` | Lines-of-change threshold for the single-function trivial-fix branch. **At or below** this count: orchestrator edits directly. **Above**: dispatch to `<worker-agent>`. (Boundary alignment with COR-1619 §Decision Tree node C — both docs treat the threshold value itself as the orchestrator-direct ceiling.) |
 
+### R-count cap (COR-1617 §Phase 8)
+
+| Key | Type | Required | Default | Description |
+|-----|------|----------|---------|-------------|
+| `<max-r-count>` | integer | yes | `10` | Soft cap — round at which the cap check first fires. On this round and every round thereafter, the orchestrator evaluates Case C / A / B before continuing. |
+| `<max-r-count-extension>` | integer | yes | `3` | Additional rounds auto-authorized when P0/P1/P2 findings remain open. Hard stop (Case C) triggers at `<max-r-count>` + `<max-r-count-extension>`. |
+| `<convergence-severity>` | enum | yes | `advisory` | Finding severity at or below which the PR is considered converged (Case A). One of: `advisory` (no P0/P1/P2 open), `p2` (no P0/P1 open), `p1` (no P0 open). |
+
 ### Resilience (CLI retry / failure escalation)
 
 | Key | Type | Required | Default | Description |
@@ -126,6 +134,9 @@ Trinity instantiates this schema as `TRN-1209-REF-Multi-Agent-Loop-Config.md` (i
 | `<panel-pass-threshold>` | `9.0` |
 | `<worker-agent>` | `trinity-glm via droid exec` |
 | `<worker-min-loc>` | `30` |
+| `<max-r-count>` | `10` (default) |
+| `<max-r-count-extension>` | `3` (default) |
+| `<convergence-severity>` | `advisory` (default) |
 | `<cli-retry-attempts>` | `3` (default) |
 | `<cli-retry-backoff-seconds>` | `600` (default) |
 | `<cli-retry-on-failure>` | `pause-and-ask` (default) |
@@ -157,3 +168,4 @@ Trinity instantiates this schema as `TRN-1209-REF-Multi-Agent-Loop-Config.md` (i
 | 2026-05-09 | R3 (PR #119): codex bot R2 P2 — `<weights-doc>` schema-row description showed an example with invalid map keys (`code`, `PRP` — not in the `<spec-format>` enum). Same class of bug fixed in FXA-2276 R2 but not propagated to COR-1622 itself. Replaced with valid enum keys (alfred's actual map: `{CHG: COR-1609, ADR: COR-1609, RFC: COR-1608, inline-PR-body: COR-1609}`); added explicit note that `code` is not a valid key (code review uses COR-1610 by phase per COR-1617 §Phase 4). Adopters copying the schema row now get a valid instantiation. | Claude Opus 4.7 |
 | 2026-05-10 | FXA-146: add §Resilience parameter group (`<cli-retry-attempts>`, `<cli-retry-backoff-seconds>`, `<cli-retry-on-failure>`) covering CLI/provider-failure retry behavior. Defaults (3 attempts / 600 s / pause-and-ask) match Babs operator policy. Guard rail added for `mark-non-viable` interaction with 3-viable-minimum. Worked Example updated with trinity's effective defaults (all three keys inherit schema defaults; no behavior change). | Claude Sonnet 4.6 |
 | 2026-05-10 | DeepSeek R1 advisory fixes: `<cli-retry-attempts>` — added per-provider-per-round scope and explicit COR-1617 §Failure Modes override note; guard rail — added dissenter exception condition; Worked Example — moved three resilience rows to match schema section order (after §Worker dispatch, before §Bot polling). | Claude Sonnet 4.6 |
+| 2026-05-10 | Issue #144: add §R-count cap parameter group (`<max-r-count>`, `<max-r-count-extension>`, `<convergence-severity>`) for COR-1617 §Phase 8 round-count guard. Defaults (10 / 3 / advisory) define soft cap R10, hard stop R13. Worked Example updated with trinity's effective defaults (all three inherit schema defaults). | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1622-REF-Multi-Agent-Loop-Project-Configuration.md
+++ b/src/fx_alfred/rules/COR-1622-REF-Multi-Agent-Loop-Project-Configuration.md
@@ -87,7 +87,7 @@ When a doc uses `<X>`, look it up here first. If absent, treat as a runtime vari
 |-----|------|----------|---------|-------------|
 | `<max-r-count>` | integer | yes | `10` | Soft cap — round at which the cap check first fires. On this round and every round thereafter, the orchestrator evaluates Case C / A / B before continuing. |
 | `<max-r-count-extension>` | integer | yes | `3` | Additional rounds auto-authorized when P0/P1/P2 findings remain open. Hard stop (Case C) triggers at `<max-r-count>` + `<max-r-count-extension>`. |
-| `<convergence-severity>` | enum | yes | `advisory` | Finding severity at or below which the PR is considered converged (Case A). One of: `advisory` (no P0/P1/P2 open), `p2` (no P0/P1 open), `p1` (no P0 open). |
+| `<convergence-severity>` | enum | yes | `advisory` | Finding severity at or below which the PR is considered converged (Case A). Enum values in ascending severity order: `advisory` (no P0/P1/P2 open) < `p2` (no P0/P1 open) < `p1` (no P0 open). Note: `advisory` here is a threshold label, not COR-1621's "advisory" finding class. |
 
 ### Resilience (CLI retry / failure escalation)
 
@@ -169,3 +169,4 @@ Trinity instantiates this schema as `TRN-1209-REF-Multi-Agent-Loop-Config.md` (i
 | 2026-05-10 | FXA-146: add §Resilience parameter group (`<cli-retry-attempts>`, `<cli-retry-backoff-seconds>`, `<cli-retry-on-failure>`) covering CLI/provider-failure retry behavior. Defaults (3 attempts / 600 s / pause-and-ask) match Babs operator policy. Guard rail added for `mark-non-viable` interaction with 3-viable-minimum. Worked Example updated with trinity's effective defaults (all three keys inherit schema defaults; no behavior change). | Claude Sonnet 4.6 |
 | 2026-05-10 | DeepSeek R1 advisory fixes: `<cli-retry-attempts>` — added per-provider-per-round scope and explicit COR-1617 §Failure Modes override note; guard rail — added dissenter exception condition; Worked Example — moved three resilience rows to match schema section order (after §Worker dispatch, before §Bot polling). | Claude Sonnet 4.6 |
 | 2026-05-10 | Issue #144: add §R-count cap parameter group (`<max-r-count>`, `<max-r-count-extension>`, `<convergence-severity>`) for COR-1617 §Phase 8 round-count guard. Defaults (10 / 3 / advisory) define soft cap R10, hard stop R13. Worked Example updated with trinity's effective defaults (all three inherit schema defaults). | Claude Sonnet 4.6 |
+| 2026-05-10 | Issue #144 R2: `<convergence-severity>` — add enum ordering note (advisory < p2 < p1) and clarify that `advisory` is a threshold label, not COR-1621's "advisory" finding class (GLM P1 / DeepSeek P3). | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1802-SOP-Build-Weighted-Decision-Matrix.md
+++ b/src/fx_alfred/rules/COR-1802-SOP-Build-Weighted-Decision-Matrix.md
@@ -110,11 +110,11 @@ Run at least:
 
 ### Step 8 — Document
 
-Use the COR-1800 table format. Required consuming-document sections:
+Use COR-1800's table format for the scoring rubric and action thresholds tables. Required consuming-document sections:
 
-- **Scoring rubric** table (Steps 3–4 output)
-- **Action thresholds** table (Step 6 output)
-- **Calibration examples** section with ≥3 worked cases (Step 5 output)
+- **Scoring rubric** table (Steps 3–4 output) — use COR-1800 table style
+- **Action thresholds** table (Step 6 output) — use COR-1800 table style
+- **Calibration examples** section with ≥3 worked cases (Step 5 output) — additional COR-1802 requirement; COR-1800 does not include this section
 
 ---
 
@@ -225,3 +225,4 @@ Composite: 0.25×9 + 0.25×10 + 0.15×8 + 0.15×10 + 0.20×9 = 2.25 + 2.5 + 1.2 
 | 2026-05-10 | R4: (1) fix CHG §SOP Draft Step 6 to match corrected SOP wording (codex bot P2 on CHG line 109); (2) break tied-rank notation in §Worked Example (codex bot P2 on line 141) — now strict ordering with equal-weight clarification added to Step 3 rule 6. | Claude Sonnet 4.6 |
 | 2026-05-10 | R5: fix COR-1800 back-reference (codex bot P2). Changed "Built per COR-1802" → "See COR-1802 for the meta-framework" to avoid false compliance claim — COR-1800 pre-dates COR-1802 and lacks the required 0/5/10 anchors and calibration examples sections. | Claude Sonnet 4.6 |
 | 2026-05-10 | R6: (1) remove Step 4 "interpolate linearly" exception — contradicts anchor-testability requirement from Step 2; replaced with guidance to return to Step 2 if midpoint anchor is hard (codex bot P2); (2) sync CHG Step 3 to include equal-weight rule 6 (codex bot P2 on CHG line 84). | Claude Sonnet 4.6 |
+| 2026-05-10 | Issue #139: §Step 8 — clarify "COR-1800 table format" applies to scoring rubric and action thresholds only; calibration examples is an additional COR-1802 requirement not present in COR-1800. Codex bot finding on PR #137. | Claude Sonnet 4.6 |


### PR DESCRIPTION
## Summary

- **COR-1617 §Phase 8**: adds §Round-count cap — three-tier logic: Case A (all findings ≤ `<convergence-severity>` → converge to Phase 10), Case B (P0/P1/P2 open + extension rounds remain → self-authorize extension), Case C (hard stop at cap + extension → surface severity summary to operator)
- **COR-1622**: new §R-count cap parameter group: `<max-r-count>` (default 10), `<max-r-count-extension>` (default 3), `<convergence-severity>` (default `advisory`)
- **FXA-2276**: instantiates all three keys (inheriting schema defaults — soft cap R10, hard stop R13)

Prevents unbounded iteration loops: PR #117 ran 12 rounds, PR #141 ran 6 rounds.

## Scope hints

- `COR-1617` §Phase 8 only — new §Round-count cap subsection
- `COR-1622` new §R-count cap section + 3 Worked Example rows
- `FXA-2276` new §R-count cap section

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)