### PR TITLE
feat(cor): add COR-1623 SOP — PR Review Thread Verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
+++ b/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
@@ -72,6 +72,7 @@ A reference index of all documents in the COR system.
 | 1620 | SOP | Self-Pacing Loop Primitives |
 | 1621 | SOP | Multi-Reviewer Triage and Severity |
 | 1622 | REF | Multi-Agent Loop Project Configuration |
+| 1623 | SOP | PR Review Thread Verification |
 | 1700 | SOP | Initialize Project |
 | 1701 | SOP | Archive Project |
 | 1702 | SOP | Sync Project |
@@ -103,3 +104,4 @@ A reference index of all documents in the COR system.
 | 2026-05-09 | Added COR-1617 cluster (1617/1618/1619/1620/1621/1622) + COR-1505 + COR-1104 — promoted from trinity TRN-1008 per alfred#115. | Claude Opus 4.7 |
 | 2026-05-10 | Added COR-1802 (Build Weighted Decision Matrix) per CHG FXA-2281 (issue #135). | Claude Sonnet 4.6 |
 | 2026-05-10 | Added COR-1506 (Review GitHub Issue Quality) per issue #136. | Claude Sonnet 4.6 |
+| 2026-05-10 | Added COR-1623 (PR Review Thread Verification) per issue #142. | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -92,21 +92,25 @@ Note: the Step 1 commands emit the current line anchor when available (`line`), 
 
 ### Step 3 — Verify against source
 
-Read the actual file at the identified location — **not** the diff:
+Read the actual file at the identified location and exact PR head SHA — **not** the diff and not whatever happens to be in the local working tree:
 
 ```bash
-# Via git (local checkout) — LINE is the line number from Step 1
+# Via git object lookup — BRANCH_SHA is the PR head used in the report
+BRANCH_SHA=<branch-sha>
+FILE_PATH=<path>
 LINE=<line>
 START=$(( LINE > 20 ? LINE - 20 : 1 ))
 END=$(( LINE + 20 ))
-sed -n "${START},${END}p" <path>
+
+git cat-file -e "${BRANCH_SHA}^{commit}" || git fetch origin "${BRANCH_SHA}"
+git show "${BRANCH_SHA}:${FILE_PATH}" | sed -n "${START},${END}p"
 
 # Via GitHub API (no local checkout needed)
-gh api "repos/<repo>/contents/<path>?ref=<branch-sha>" \
+gh api "repos/<repo>/contents/${FILE_PATH}?ref=${BRANCH_SHA}" \
   --jq '.content' | base64 -d | sed -n "${START},${END}p"
 ```
 
-Note: the Contents API returns `content: null` for files larger than 1 MB — use the local checkout method for large files.
+Note: the Contents API returns `content: null` for files larger than 1 MB — use the local Git object lookup for large files.
 
 Use a window of ±20 lines around the flagged line to capture context.
 
@@ -189,3 +193,4 @@ gh api repos/<repo>/pulls/<pr>/comments/<comment-id>/replies \
 | 2026-05-10 | R2 fix (DeepSeek B1): GraphQL `first:100` caps at 100 — replaced "Fetch all" claim with accurate "Fetch up to 100"; added Pitfalls entry directing to REST `--paginate` for large PRs; clarified REST fallback description. | Claude Sonnet 4.6 |
 | 2026-05-10 | R1 fixes (GLM panel): P0 — corrected remaining Phase 11 references to Phase 8 Iterate (Related: header, §When to Use, §Change History); P1-1 — added `gh pr comment` command for posting report; P1-2 — added GraphQL/REST thread reply commands (COR-1612 §Step 7 requires reply-not-resolve); P2-1 — noted GraphQL node ID vs REST numeric ID difference for reply commands. | Claude Sonnet 4.6 |
 | 2026-05-15 | PR #153 review follow-up: Step 1 now uses paginated GraphQL with `$endCursor` / `pageInfo`, filters out outdated threads, emits current `line` before falling back to original anchors, and the REST fallback mirrors current-line preference. Step 3 clamps the `sed` context start to line 1. | Codex |
+| 2026-05-15 | PR #153 review follow-up: Step 3 now verifies source against the exact PR head SHA via `git show <sha>:<path>` or the Contents API `ref`, preventing stale local working trees from producing false thread classifications. | Codex |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -154,10 +154,9 @@ gh api graphql -f query='mutation($t:ID!,$b:String!){
     comment{url}}}' \
   -f t="<PRRT_...>" -f b="Verified RESOLVED-IN-CODE — see verification report."
 
-# REST reply (uses numeric comment ID from fallback)
-gh api repos/<repo>/pulls/<pr>/comments \
-  -f body="Verified RESOLVED-IN-CODE — see verification report." \
-  -f in_reply_to_id=<comment-id>
+# REST reply (uses numeric comment ID from fallback — dedicated replies endpoint)
+gh api repos/<repo>/pulls/<pr>/comments/<comment-id>/replies \
+  -f body="Verified RESOLVED-IN-CODE — see verification report."
 ```
 
 ---
@@ -179,5 +178,6 @@ gh api repos/<repo>/pulls/<pr>/comments \
 |------|--------|----|
 | 2026-05-10 | Initial version — 4-step procedure (Enumerate / Locate / Verify / Classify) for auditing PR review threads against source file content. Addresses false-positive bot verdicts observed on PR #141 (alfred). Composable with COR-1617 §Phase 8 Iterate. Issue #142. | Claude Sonnet 4.6 |
 | 2026-05-10 | R1 fixes (DeepSeek panel): B1 — replaced invalid `gh pr view --json reviewThreads` with `gh api graphql` primary + REST fallback (field not supported by gh CLI); B2 — removed self-resolve instruction (contradicts COR-1612 §Step 7); A1 — fixed prerequisite claim (Phase 11 does not enumerate threads; Step 1 does); A2 — added deleted-file classification note; A4 — documented REST/GraphQL field-name difference (`original_line` vs `originalLine`). | Claude Sonnet 4.6 |
+| 2026-05-10 | R2 fix (GLM B1): REST reply command used wrong pattern (`POST /comments` with `in_reply_to_id`); replaced with dedicated replies endpoint (`POST /comments/<id>/replies`) which only requires `body`. | Claude Sonnet 4.6 |
 | 2026-05-10 | R2 fix (DeepSeek B1): GraphQL `first:100` caps at 100 — replaced "Fetch all" claim with accurate "Fetch up to 100"; added Pitfalls entry directing to REST `--paginate` for large PRs; clarified REST fallback description. | Claude Sonnet 4.6 |
 | 2026-05-10 | R1 fixes (GLM panel): P0 — corrected remaining Phase 11 references to Phase 8 Iterate (Related: header, §When to Use, §Change History); P1-1 — added `gh pr comment` command for posting report; P1-2 — added GraphQL/REST thread reply commands (COR-1612 §Step 7 requires reply-not-resolve); P2-1 — noted GraphQL node ID vs REST numeric ID difference for reply commands. | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -1,0 +1,147 @@
+# SOP-1623: PR Review Thread Verification
+
+**Applies to:** All projects using GitHub PR review workflows
+**Last updated:** 2026-05-10
+**Last reviewed:** 2026-05-10
+**Status:** Active
+**Related:** COR-1617 (§Phase 11 Retrospective — composable sub-procedure), COR-1615 (GitHub App PR Review Bot Loop)
+
+---
+
+## What Is It?
+
+A 4-step procedure for auditing GitHub PR review threads against actual source file content. Produces a per-thread classification (RESOLVED-IN-CODE / GENUINELY-OPEN / NEEDS-FOLLOWUP) with file-path-and-line evidence, replacing bot verdicts that may be wrong due to truncated diff windows.
+
+---
+
+## Why
+
+GitHub review bots (clearance bots, SWM bots) decide whether a thread is resolved by inspecting the PR diff. Their diff window is often truncated — they cannot reliably distinguish "the fix exists but I can't see it in the diff" from "no fix exists." This produces false-positive OPEN verdicts that block merges unnecessarily.
+
+A human or agent following this procedure reads the actual file content (not the diff) and classifies each thread with concrete evidence in minutes. Demonstrated on PR #141 (alfred), where 2 of 4 "unresolved" threads were confirmed fixed by direct file inspection.
+
+---
+
+## When to Use
+
+- During COR-1617 §Phase 11 Retrospective, when a PR has threads marked unresolved by a bot
+- Any time a bot flags a thread as OPEN/NEEDS_HUMAN_JUDGMENT and the fix appears to be present in the codebase
+- Before pushing an additional round solely to address threads the bot cannot confirm as resolved
+
+## When NOT to Use
+
+- When the thread is clearly genuinely open (no corresponding fix was attempted)
+- When the thread discusses a design decision rather than a concrete change — these cannot be verified by file inspection alone
+- When the bot's diff window is not the limiting factor (the bot read the full file and still flagged the thread)
+
+---
+
+## Prerequisites
+
+- `gh` CLI authenticated with read access to the repo
+- The PR branch is checked out locally (or files are accessible via `gh api`)
+- The list of open threads has been collected (COR-1617 §Phase 11 provides this)
+
+---
+
+## Steps
+
+### Step 1 — Enumerate open threads
+
+Fetch all unresolved review threads from the PR:
+
+```bash
+gh pr view <pr> --repo <repo> --json reviewThreads \
+  --jq '.reviewThreads[] | select(.isResolved == false) |
+    {id: .id, path: .path, line: .line,
+     body: (.comments.nodes[0].body | .[0:120])}'
+```
+
+For the raw per-comment view (useful when `reviewThreads` is empty due to API lag):
+
+```bash
+gh api repos/<repo>/pulls/<pr>/comments \
+  --paginate \
+  --jq '.[] | select(.in_reply_to_id == null) |
+    {id: .id, path: .path, line: .original_line,
+     body: (.body | .[0:120])}'
+```
+
+Record each unresolved thread: thread ID, file path, line number, and the finding summary (first ~120 chars of the lead comment).
+
+### Step 2 — Locate the claim
+
+For each thread, identify the exact source location it references:
+
+1. Extract `path` (file path) and `line` (line number) from the thread record.
+2. If `line` is null — thread on a deleted line or an outdated diff position — use the lead comment text to identify the construct (function name, variable, section heading) and `grep` for it instead.
+
+Note: `original_line` is the line number at comment-post time; it may differ from the current line if the file changed since. Use the construct name as a fallback locator when line numbers have drifted.
+
+### Step 3 — Verify against source
+
+Read the actual file at the identified location — **not** the diff:
+
+```bash
+# Via git (local checkout)
+sed -n '<start>,<end>p' <path>
+
+# Via GitHub API (no local checkout needed)
+gh api "repos/<repo>/contents/<path>?ref=<branch-sha>" \
+  --jq '.content' | base64 -d | sed -n '<start>,<end>p'
+```
+
+Use a window of ±20 lines around the flagged line to capture context.
+
+Check whether the fix is present:
+- Does the flagged code/text still exist?
+- Is the replacement or addition the reviewer requested now in place?
+- Is the surrounding context consistent with the change?
+
+### Step 4 — Classify
+
+Assign one of three classifications to each thread:
+
+| Classification | Condition | Evidence to record |
+|----------------|-----------|-------------------|
+| **RESOLVED-IN-CODE** | The fix is present in the source file; bot could not confirm due to truncated diff | File path, line range, quoted snippet confirming fix |
+| **GENUINELY-OPEN** | The issue the reviewer flagged is still present; no fix attempt found | File path, line range, quoted snippet showing issue persists |
+| **NEEDS-FOLLOWUP** | A fix was attempted but is incomplete, addresses only part of the concern, or introduces a new issue | File path, line range, current state quote + description of remaining gap |
+
+### Verification Report
+
+Post the classification as a PR comment using this template:
+
+```
+## PR Review Thread Verification Report
+
+Verified against: <branch-sha>
+
+| Thread | Path | Line | Classification | Evidence |
+|--------|------|------|----------------|----------|
+| #<id> | `<path>` | <line> | RESOLVED-IN-CODE | `<quoted snippet>` — fix present |
+| #<id> | `<path>` | <line> | GENUINELY-OPEN | `<quoted snippet>` — issue still present |
+| #<id> | `<path>` | <line> | NEEDS-FOLLOWUP | Fix at line <N> addresses X but not Y |
+
+**Summary:** <n> RESOLVED-IN-CODE · <n> GENUINELY-OPEN · <n> NEEDS-FOLLOWUP
+```
+
+After posting: resolve the RESOLVED-IN-CODE threads explicitly on GitHub so bots see the updated state. Do not resolve GENUINELY-OPEN or NEEDS-FOLLOWUP threads.
+
+---
+
+## Pitfalls
+
+- **Read the file, not the diff.** The diff is what the bot reads and why it fails. Always read actual file content at the current HEAD.
+- **`original_line` drifts.** If the file changed after the review comment was posted, `original_line` no longer points to the right place. Use the construct name and `grep` to re-locate.
+- **Deletion ≠ fix.** If the flagged code was deleted rather than replaced with a correct version, verify whether deletion satisfies the reviewer's concern — it may or may not.
+- **RESOLVED-IN-CODE is not the same as thread resolved.** Post the report and then resolve threads explicitly on GitHub; bots read thread resolution state, not comments.
+- **Classify by file content, not author intent.** What the author said they would do is irrelevant — classify by what is in the file at the verified SHA.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-05-10 | Initial version — 4-step procedure (Enumerate / Locate / Verify / Classify) for auditing PR review threads against source file content. Addresses false-positive bot verdicts observed on PR #141 (alfred). Composable with COR-1617 §Phase 11 Retrospective. Issue #142. | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -93,13 +93,16 @@ Note: GraphQL returns `originalLine` (camelCase); REST returns `original_line` (
 Read the actual file at the identified location — **not** the diff:
 
 ```bash
-# Via git (local checkout)
-sed -n '<start>,<end>p' <path>
+# Via git (local checkout) — LINE is the line number from Step 1
+LINE=<line>
+sed -n "$((LINE-20)),$((LINE+20))p" <path>
 
 # Via GitHub API (no local checkout needed)
 gh api "repos/<repo>/contents/<path>?ref=<branch-sha>" \
-  --jq '.content' | base64 -d | sed -n '<start>,<end>p'
+  --jq '.content' | base64 -d | sed -n "$((LINE-20)),$((LINE+20))p"
 ```
+
+Note: the Contents API returns `content: null` for files larger than 1 MB — use the local checkout method for large files.
 
 Use a window of ±20 lines around the flagged line to capture context.
 
@@ -136,11 +139,10 @@ Verified against: <branch-sha>
 **Summary:** <n> RESOLVED-IN-CODE · <n> GENUINELY-OPEN · <n> NEEDS-FOLLOWUP
 ```
 
-Post the report:
+Post the report (write the filled-in template to a file first, then post):
 
 ```bash
-gh pr comment <pr> --repo <repo> --body "## PR Review Thread Verification Report
-..."
+gh pr comment <pr> --repo <repo> --body-file /tmp/thread-verification-report.md
 ```
 
 After posting: for each RESOLVED-IN-CODE thread, reply referencing the relevant report row as evidence. Per COR-1612 §Step 7, do not self-resolve — the original reviewer must resolve the thread. Do not reply to GENUINELY-OPEN or NEEDS-FOLLOWUP threads; address their findings in the next round.
@@ -164,7 +166,7 @@ gh api repos/<repo>/pulls/<pr>/comments/<comment-id>/replies \
 ## Pitfalls
 
 - **Read the file, not the diff.** The diff is what the bot reads and why it fails. Always read actual file content at the current HEAD.
-- **`original_line` drifts.** If the file changed after the review comment was posted, `original_line` no longer points to the right place. Use the construct name and `grep` to re-locate.
+- **Line numbers drift.** The `line` field in Step 1 output (remapped from `originalLine`/`original_line`) is the line at comment-post time. If the file changed since, it no longer points to the right place. Use the construct name and `grep` to re-locate.
 - **Deletion ≠ fix.** If the flagged code was deleted rather than replaced with a correct version, verify whether deletion satisfies the reviewer's concern — it may or may not.
 - **RESOLVED-IN-CODE is not the same as thread resolved.** Post the report and reply to each RESOLVED-IN-CODE thread with the relevant evidence row. Bots read thread resolution state; per COR-1612 §Step 7, only the original reviewer can resolve a thread — prompt them if timely resolution is critical.
 - **GraphQL caps at 100 threads.** If the PR has more than 100 review threads, the GraphQL primary silently omits the rest. Use the REST fallback with `--paginate` for large PRs and filter resolved threads manually.
@@ -178,6 +180,7 @@ gh api repos/<repo>/pulls/<pr>/comments/<comment-id>/replies \
 |------|--------|----|
 | 2026-05-10 | Initial version — 4-step procedure (Enumerate / Locate / Verify / Classify) for auditing PR review threads against source file content. Addresses false-positive bot verdicts observed on PR #141 (alfred). Composable with COR-1617 §Phase 8 Iterate. Issue #142. | Claude Sonnet 4.6 |
 | 2026-05-10 | R1 fixes (DeepSeek panel): B1 — replaced invalid `gh pr view --json reviewThreads` with `gh api graphql` primary + REST fallback (field not supported by gh CLI); B2 — removed self-resolve instruction (contradicts COR-1612 §Step 7); A1 — fixed prerequisite claim (Phase 11 does not enumerate threads; Step 1 does); A2 — added deleted-file classification note; A4 — documented REST/GraphQL field-name difference (`original_line` vs `originalLine`). | Claude Sonnet 4.6 |
+| 2026-05-10 | R2 advisories (GLM P2-1/P2-2/P2-3/P2-4): Step 3 — Contents API returns null >1 MB (added note); sed placeholder replaced with `$((LINE±20))` arithmetic; pitfall renamed from `original_line drifts` to `Line numbers drift` (GraphQL path outputs `line` not `original_line`); posting command changed from inline `--body` to `--body-file /tmp/thread-verification-report.md`. | Claude Sonnet 4.6 |
 | 2026-05-10 | R2 fix (GLM B1): REST reply command used wrong pattern (`POST /comments` with `in_reply_to_id`); replaced with dedicated replies endpoint (`POST /comments/<id>/replies`) which only requires `body`. | Claude Sonnet 4.6 |
 | 2026-05-10 | R2 fix (DeepSeek B1): GraphQL `first:100` caps at 100 — replaced "Fetch all" claim with accurate "Fetch up to 100"; added Pitfalls entry directing to REST `--paginate` for large PRs; clarified REST fallback description. | Claude Sonnet 4.6 |
 | 2026-05-10 | R1 fixes (GLM panel): P0 — corrected remaining Phase 11 references to Phase 8 Iterate (Related: header, §When to Use, §Change History); P1-1 — added `gh pr comment` command for posting report; P1-2 — added GraphQL/REST thread reply commands (COR-1612 §Step 7 requires reply-not-resolve); P2-1 — noted GraphQL node ID vs REST numeric ID difference for reply commands. | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -55,21 +55,32 @@ gh api graphql --paginate -f query='
   query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){
     repository(owner:$owner,name:$repo){
       pullRequest(number:$number){
+        number
+        headRefOid
+        headRepository{nameWithOwner}
         reviewThreads(first:100, after:$endCursor){
           nodes{ id isResolved isOutdated path line originalLine
             comments(first:1){nodes{body}} }
           pageInfo{hasNextPage endCursor}
         }}}}' \
   -f owner=<owner> -f repo=<repo> -F number=<pr> \
-  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+  --jq '.data.repository.pullRequest as $pr
+    | $pr.reviewThreads.nodes[]
     | select((.isResolved == false) and (.isOutdated == false))
-    | {id, path, line: (.line // .originalLine),
+    | {id, pr: $pr.number,
+       headRepo: ($pr.headRepository.nameWithOwner // "<deleted-head-repo>"),
+       branchSha: $pr.headRefOid,
+       path, line: (.line // .originalLine),
        body: (.comments.nodes[0].body // "" | .[0:120])}'
 ```
 
 Fallback via REST when GraphQL is unavailable or API lag hides thread nodes (no `isResolved` / `isOutdated` fields; compare against GitHub UI thread count to identify resolved or outdated threads):
 
 ```bash
+gh pr view <pr> --repo <repo> --json number,headRefOid,headRepository \
+  --jq '{pr: .number, branchSha: .headRefOid,
+         headRepo: .headRepository.nameWithOwner}'
+
 gh api repos/<repo>/pulls/<pr>/comments \
   --paginate \
   --jq '.[] | select(.in_reply_to_id == null) |
@@ -96,21 +107,25 @@ Read the actual file at the identified location and exact PR head SHA — **not*
 
 ```bash
 # Via git object lookup — BRANCH_SHA is the PR head used in the report
+PR_NUM=<pr>
+HEAD_REPO=<head-owner/head-repo>
 BRANCH_SHA=<branch-sha>
 FILE_PATH=<path>
 LINE=<line>
 START=$(( LINE > 20 ? LINE - 20 : 1 ))
 END=$(( LINE + 20 ))
 
-git cat-file -e "${BRANCH_SHA}^{commit}" || git fetch origin "${BRANCH_SHA}"
+if ! git cat-file -e "${BRANCH_SHA}^{commit}"; then
+  git fetch origin "refs/pull/${PR_NUM}/head"
+fi
 git show "${BRANCH_SHA}:${FILE_PATH}" | sed -n "${START},${END}p"
 
 # Via GitHub API (no local checkout needed)
-gh api "repos/<repo>/contents/${FILE_PATH}?ref=${BRANCH_SHA}" \
+gh api "repos/${HEAD_REPO}/contents/${FILE_PATH}?ref=${BRANCH_SHA}" \
   --jq '.content' | base64 -d | sed -n "${START},${END}p"
 ```
 
-Note: the Contents API returns `content: null` for files larger than 1 MB — use the local Git object lookup for large files.
+Note: `origin` must be the base repository remote so `refs/pull/<pr>/head` is available. For fork PRs, use `HEAD_REPO` for the Contents API; reading from the base repo can fail when the head commit only exists in the fork. The Contents API returns `content: null` for files larger than 1 MB — use the local Git object lookup for large files.
 
 Use a window of ±20 lines around the flagged line to capture context.
 
@@ -194,3 +209,4 @@ gh api repos/<repo>/pulls/<pr>/comments/<comment-id>/replies \
 | 2026-05-10 | R1 fixes (GLM panel): P0 — corrected remaining Phase 11 references to Phase 8 Iterate (Related: header, §When to Use, §Change History); P1-1 — added `gh pr comment` command for posting report; P1-2 — added GraphQL/REST thread reply commands (COR-1612 §Step 7 requires reply-not-resolve); P2-1 — noted GraphQL node ID vs REST numeric ID difference for reply commands. | Claude Sonnet 4.6 |
 | 2026-05-15 | PR #153 review follow-up: Step 1 now uses paginated GraphQL with `$endCursor` / `pageInfo`, filters out outdated threads, emits current `line` before falling back to original anchors, and the REST fallback mirrors current-line preference. Step 3 clamps the `sed` context start to line 1. | Codex |
 | 2026-05-15 | PR #153 review follow-up: Step 3 now verifies source against the exact PR head SHA via `git show <sha>:<path>` or the Contents API `ref`, preventing stale local working trees from producing false thread classifications. | Codex |
+| 2026-05-15 | PR #153 review follow-up: Step 1 now emits PR number, head repository, and head SHA; Step 3 fetches `refs/pull/<pr>/head` instead of relying on a bare SHA fetch and reads fork PR content through `HEAD_REPO`. | Codex |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -1,8 +1,8 @@
 # SOP-1623: PR Review Thread Verification
 
 **Applies to:** All projects using GitHub PR review workflows
-**Last updated:** 2026-05-10
-**Last reviewed:** 2026-05-10
+**Last updated:** 2026-05-15
+**Last reviewed:** 2026-05-15
 **Status:** Active
 **Related:** COR-1617 (§Phase 8 Iterate — composable sub-procedure for bot thread verification), COR-1615 (GitHub App PR Review Bot Loop)
 
@@ -48,30 +48,32 @@ A human or agent following this procedure reads the actual file content (not the
 
 ### Step 1 — Enumerate open threads
 
-Fetch up to 100 unresolved review threads from the PR via GraphQL (supports `isResolved` filtering; GitHub caps `first` at 100 — use the REST fallback for PRs with more than 100 threads):
+Fetch unresolved, non-outdated review threads from the PR via paginated GraphQL (supports `isResolved` / `isOutdated` filtering):
 
 ```bash
-gh api graphql -f query='
-  query($owner:String!,$repo:String!,$number:Int!){
+gh api graphql --paginate -f query='
+  query($owner:String!,$repo:String!,$number:Int!,$endCursor:String){
     repository(owner:$owner,name:$repo){
       pullRequest(number:$number){
-        reviewThreads(first:100){
-          nodes{ id isResolved path line originalLine
-            comments(first:1){nodes{body}} }}}}}' \
+        reviewThreads(first:100, after:$endCursor){
+          nodes{ id isResolved isOutdated path line originalLine
+            comments(first:1){nodes{body}} }
+          pageInfo{hasNextPage endCursor}
+        }}}}' \
   -f owner=<owner> -f repo=<repo> -F number=<pr> \
   --jq '.data.repository.pullRequest.reviewThreads.nodes[]
-    | select(.isResolved == false)
-    | {id, path, line: .originalLine,
+    | select((.isResolved == false) and (.isOutdated == false))
+    | {id, path, line: (.line // .originalLine),
        body: (.comments.nodes[0].body // "" | .[0:120])}'
 ```
 
-Fallback via REST (no `isResolved` field; paginated; compare against GitHub UI thread count to identify resolved threads):
+Fallback via REST when GraphQL is unavailable or API lag hides thread nodes (no `isResolved` / `isOutdated` fields; compare against GitHub UI thread count to identify resolved or outdated threads):
 
 ```bash
 gh api repos/<repo>/pulls/<pr>/comments \
   --paginate \
   --jq '.[] | select(.in_reply_to_id == null) |
-    {id: .id, path: .path, line: .original_line,
+    {id: .id, path: .path, line: (.line // .original_line),
      body: (.body | .[0:120])}'
 ```
 
@@ -86,7 +88,7 @@ For each thread, identify the exact source location it references:
 1. Extract `path` (file path) and `line` (line number) from the thread record.
 2. If `line` is null — thread on a deleted line or an outdated diff position — use the lead comment text to identify the construct (function name, variable, section heading) and `grep` for it instead.
 
-Note: GraphQL returns `originalLine` (camelCase); REST returns `original_line` (snake_case). Both are the line number at comment-post time and drift when the file changes afterward. Use the construct name as a fallback locator when line numbers have drifted. If the file no longer exists (deleted), classify the thread as NEEDS-FOLLOWUP unless the reviewer's concern was the file's existence itself.
+Note: the Step 1 commands emit the current line anchor when available (`line`), falling back to the original line anchor (`originalLine` in GraphQL, `original_line` in REST). Line anchors can still drift when files change after a comment is posted. Use the construct name as a fallback locator when line numbers no longer point to the reviewed code. If the file no longer exists (deleted), classify the thread as NEEDS-FOLLOWUP unless the reviewer's concern was the file's existence itself.
 
 ### Step 3 — Verify against source
 
@@ -95,11 +97,13 @@ Read the actual file at the identified location — **not** the diff:
 ```bash
 # Via git (local checkout) — LINE is the line number from Step 1
 LINE=<line>
-sed -n "$((LINE-20)),$((LINE+20))p" <path>
+START=$(( LINE > 20 ? LINE - 20 : 1 ))
+END=$(( LINE + 20 ))
+sed -n "${START},${END}p" <path>
 
 # Via GitHub API (no local checkout needed)
 gh api "repos/<repo>/contents/<path>?ref=<branch-sha>" \
-  --jq '.content' | base64 -d | sed -n "$((LINE-20)),$((LINE+20))p"
+  --jq '.content' | base64 -d | sed -n "${START},${END}p"
 ```
 
 Note: the Contents API returns `content: null` for files larger than 1 MB — use the local checkout method for large files.
@@ -166,10 +170,10 @@ gh api repos/<repo>/pulls/<pr>/comments/<comment-id>/replies \
 ## Pitfalls
 
 - **Read the file, not the diff.** The diff is what the bot reads and why it fails. Always read actual file content at the current HEAD.
-- **Line numbers drift.** The `line` field in Step 1 output (remapped from `originalLine`/`original_line`) is the line at comment-post time. If the file changed since, it no longer points to the right place. Use the construct name and `grep` to re-locate.
+- **Line numbers drift.** The `line` field in Step 1 output is GitHub's current line anchor when available, otherwise the original anchor. If the file changed after GitHub computed that anchor, it can still point to the wrong place. Use the construct name and `grep` to re-locate.
 - **Deletion ≠ fix.** If the flagged code was deleted rather than replaced with a correct version, verify whether deletion satisfies the reviewer's concern — it may or may not.
 - **RESOLVED-IN-CODE is not the same as thread resolved.** Post the report and reply to each RESOLVED-IN-CODE thread with the relevant evidence row. Bots read thread resolution state; per COR-1612 §Step 7, only the original reviewer can resolve a thread — prompt them if timely resolution is critical.
-- **GraphQL caps at 100 threads.** If the PR has more than 100 review threads, the GraphQL primary silently omits the rest. Use the REST fallback with `--paginate` for large PRs and filter resolved threads manually.
+- **Pagination is part of correctness.** Do not remove GraphQL `--paginate`, `$endCursor`, or `pageInfo`; without them, PRs with more than 100 review threads silently omit later threads.
 - **Classify by file content, not author intent.** What the author said they would do is irrelevant — classify by what is in the file at the verified SHA.
 
 ---
@@ -184,3 +188,4 @@ gh api repos/<repo>/pulls/<pr>/comments/<comment-id>/replies \
 | 2026-05-10 | R2 fix (GLM B1): REST reply command used wrong pattern (`POST /comments` with `in_reply_to_id`); replaced with dedicated replies endpoint (`POST /comments/<id>/replies`) which only requires `body`. | Claude Sonnet 4.6 |
 | 2026-05-10 | R2 fix (DeepSeek B1): GraphQL `first:100` caps at 100 — replaced "Fetch all" claim with accurate "Fetch up to 100"; added Pitfalls entry directing to REST `--paginate` for large PRs; clarified REST fallback description. | Claude Sonnet 4.6 |
 | 2026-05-10 | R1 fixes (GLM panel): P0 — corrected remaining Phase 11 references to Phase 8 Iterate (Related: header, §When to Use, §Change History); P1-1 — added `gh pr comment` command for posting report; P1-2 — added GraphQL/REST thread reply commands (COR-1612 §Step 7 requires reply-not-resolve); P2-1 — noted GraphQL node ID vs REST numeric ID difference for reply commands. | Claude Sonnet 4.6 |
+| 2026-05-15 | PR #153 review follow-up: Step 1 now uses paginated GraphQL with `$endCursor` / `pageInfo`, filters out outdated threads, emits current `line` before falling back to original anchors, and the REST fallback mirrors current-line preference. Step 3 clamps the `sed` context start to line 1. | Codex |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -48,7 +48,7 @@ A human or agent following this procedure reads the actual file content (not the
 
 ### Step 1 — Enumerate open threads
 
-Fetch all unresolved review threads from the PR via GraphQL (supports `isResolved` filtering):
+Fetch up to 100 unresolved review threads from the PR via GraphQL (supports `isResolved` filtering; GitHub caps `first` at 100 — use the REST fallback for PRs with more than 100 threads):
 
 ```bash
 gh api graphql -f query='
@@ -65,7 +65,7 @@ gh api graphql -f query='
        body: (.comments.nodes[0].body // "" | .[0:120])}'
 ```
 
-Fallback via REST (no `isResolved` field — includes all top-level comments; filter manually):
+Fallback via REST (no `isResolved` field; paginated; compare against GitHub UI thread count to identify resolved threads):
 
 ```bash
 gh api repos/<repo>/pulls/<pr>/comments \
@@ -168,6 +168,7 @@ gh api repos/<repo>/pulls/<pr>/comments \
 - **`original_line` drifts.** If the file changed after the review comment was posted, `original_line` no longer points to the right place. Use the construct name and `grep` to re-locate.
 - **Deletion ≠ fix.** If the flagged code was deleted rather than replaced with a correct version, verify whether deletion satisfies the reviewer's concern — it may or may not.
 - **RESOLVED-IN-CODE is not the same as thread resolved.** Post the report and reply to each RESOLVED-IN-CODE thread with the relevant evidence row. Bots read thread resolution state; per COR-1612 §Step 7, only the original reviewer can resolve a thread — prompt them if timely resolution is critical.
+- **GraphQL caps at 100 threads.** If the PR has more than 100 review threads, the GraphQL primary silently omits the rest. Use the REST fallback with `--paginate` for large PRs and filter resolved threads manually.
 - **Classify by file content, not author intent.** What the author said they would do is irrelevant — classify by what is in the file at the verified SHA.
 
 ---
@@ -178,4 +179,5 @@ gh api repos/<repo>/pulls/<pr>/comments \
 |------|--------|----|
 | 2026-05-10 | Initial version — 4-step procedure (Enumerate / Locate / Verify / Classify) for auditing PR review threads against source file content. Addresses false-positive bot verdicts observed on PR #141 (alfred). Composable with COR-1617 §Phase 8 Iterate. Issue #142. | Claude Sonnet 4.6 |
 | 2026-05-10 | R1 fixes (DeepSeek panel): B1 — replaced invalid `gh pr view --json reviewThreads` with `gh api graphql` primary + REST fallback (field not supported by gh CLI); B2 — removed self-resolve instruction (contradicts COR-1612 §Step 7); A1 — fixed prerequisite claim (Phase 11 does not enumerate threads; Step 1 does); A2 — added deleted-file classification note; A4 — documented REST/GraphQL field-name difference (`original_line` vs `originalLine`). | Claude Sonnet 4.6 |
+| 2026-05-10 | R2 fix (DeepSeek B1): GraphQL `first:100` caps at 100 — replaced "Fetch all" claim with accurate "Fetch up to 100"; added Pitfalls entry directing to REST `--paginate` for large PRs; clarified REST fallback description. | Claude Sonnet 4.6 |
 | 2026-05-10 | R1 fixes (GLM panel): P0 — corrected remaining Phase 11 references to Phase 8 Iterate (Related: header, §When to Use, §Change History); P1-1 — added `gh pr comment` command for posting report; P1-2 — added GraphQL/REST thread reply commands (COR-1612 §Step 7 requires reply-not-resolve); P2-1 — noted GraphQL node ID vs REST numeric ID difference for reply commands. | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -40,7 +40,7 @@ A human or agent following this procedure reads the actual file content (not the
 
 - `gh` CLI authenticated with read access to the repo
 - The PR branch is checked out locally (or files are accessible via `gh api`)
-- The list of open threads has been collected (COR-1617 §Phase 11 provides this)
+- Open threads are enumerated in Step 1 of this SOP (or obtained from a prior COR-1615 or COR-1612 inspection)
 
 ---
 
@@ -48,16 +48,24 @@ A human or agent following this procedure reads the actual file content (not the
 
 ### Step 1 — Enumerate open threads
 
-Fetch all unresolved review threads from the PR:
+Fetch all unresolved review threads from the PR via GraphQL (supports `isResolved` filtering):
 
 ```bash
-gh pr view <pr> --repo <repo> --json reviewThreads \
-  --jq '.reviewThreads[] | select(.isResolved == false) |
-    {id: .id, path: .path, line: .line,
-     body: (.comments.nodes[0].body | .[0:120])}'
+gh api graphql -f query='
+  query($owner:String!,$repo:String!,$number:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$number){
+        reviewThreads(first:100){
+          nodes{ id isResolved path line originalLine
+            comments(first:1){nodes{body}} }}}}}' \
+  -f owner=<owner> -f repo=<repo> -F number=<pr> \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+    | select(.isResolved == false)
+    | {id, path, line: .originalLine,
+       body: (.comments.nodes[0].body // "" | .[0:120])}'
 ```
 
-For the raw per-comment view (useful when `reviewThreads` is empty due to API lag):
+Fallback via REST (no `isResolved` field — includes all top-level comments; filter manually):
 
 ```bash
 gh api repos/<repo>/pulls/<pr>/comments \
@@ -76,7 +84,7 @@ For each thread, identify the exact source location it references:
 1. Extract `path` (file path) and `line` (line number) from the thread record.
 2. If `line` is null — thread on a deleted line or an outdated diff position — use the lead comment text to identify the construct (function name, variable, section heading) and `grep` for it instead.
 
-Note: `original_line` is the line number at comment-post time; it may differ from the current line if the file changed since. Use the construct name as a fallback locator when line numbers have drifted.
+Note: GraphQL returns `originalLine` (camelCase); REST returns `original_line` (snake_case). Both are the line number at comment-post time and drift when the file changes afterward. Use the construct name as a fallback locator when line numbers have drifted. If the file no longer exists (deleted), classify the thread as NEEDS-FOLLOWUP unless the reviewer's concern was the file's existence itself.
 
 ### Step 3 — Verify against source
 
@@ -126,7 +134,7 @@ Verified against: <branch-sha>
 **Summary:** <n> RESOLVED-IN-CODE · <n> GENUINELY-OPEN · <n> NEEDS-FOLLOWUP
 ```
 
-After posting: resolve the RESOLVED-IN-CODE threads explicitly on GitHub so bots see the updated state. Do not resolve GENUINELY-OPEN or NEEDS-FOLLOWUP threads.
+After posting: for each RESOLVED-IN-CODE thread, reply referencing the relevant report row as evidence. Per COR-1612 §Step 7, do not self-resolve — the original reviewer must resolve the thread. Do not reply to GENUINELY-OPEN or NEEDS-FOLLOWUP threads; address their findings in the next round.
 
 ---
 
@@ -135,7 +143,7 @@ After posting: resolve the RESOLVED-IN-CODE threads explicitly on GitHub so bots
 - **Read the file, not the diff.** The diff is what the bot reads and why it fails. Always read actual file content at the current HEAD.
 - **`original_line` drifts.** If the file changed after the review comment was posted, `original_line` no longer points to the right place. Use the construct name and `grep` to re-locate.
 - **Deletion ≠ fix.** If the flagged code was deleted rather than replaced with a correct version, verify whether deletion satisfies the reviewer's concern — it may or may not.
-- **RESOLVED-IN-CODE is not the same as thread resolved.** Post the report and then resolve threads explicitly on GitHub; bots read thread resolution state, not comments.
+- **RESOLVED-IN-CODE is not the same as thread resolved.** Post the report and reply to each RESOLVED-IN-CODE thread with the relevant evidence row. Bots read thread resolution state; per COR-1612 §Step 7, only the original reviewer can resolve a thread — prompt them if timely resolution is critical.
 - **Classify by file content, not author intent.** What the author said they would do is irrelevant — classify by what is in the file at the verified SHA.
 
 ---
@@ -145,3 +153,4 @@ After posting: resolve the RESOLVED-IN-CODE threads explicitly on GitHub so bots
 | Date | Change | By |
 |------|--------|----|
 | 2026-05-10 | Initial version — 4-step procedure (Enumerate / Locate / Verify / Classify) for auditing PR review threads against source file content. Addresses false-positive bot verdicts observed on PR #141 (alfred). Composable with COR-1617 §Phase 11 Retrospective. Issue #142. | Claude Sonnet 4.6 |
+| 2026-05-10 | R1 fixes: B1 — replaced invalid `gh pr view --json reviewThreads` with `gh api graphql` primary + REST fallback (field not supported by gh CLI); B2 — removed self-resolve instruction (contradicts COR-1612 §Step 7); A1 — fixed prerequisite claim (Phase 11 does not enumerate threads; Step 1 does); A2 — added deleted-file classification note; A4 — documented REST/GraphQL field-name difference (`original_line` vs `originalLine`). | Claude Sonnet 4.6 |

--- a/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
+++ b/src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md
@@ -4,7 +4,7 @@
 **Last updated:** 2026-05-10
 **Last reviewed:** 2026-05-10
 **Status:** Active
-**Related:** COR-1617 (§Phase 11 Retrospective — composable sub-procedure), COR-1615 (GitHub App PR Review Bot Loop)
+**Related:** COR-1617 (§Phase 8 Iterate — composable sub-procedure for bot thread verification), COR-1615 (GitHub App PR Review Bot Loop)
 
 ---
 
@@ -24,7 +24,7 @@ A human or agent following this procedure reads the actual file content (not the
 
 ## When to Use
 
-- During COR-1617 §Phase 11 Retrospective, when a PR has threads marked unresolved by a bot
+- During COR-1617 §Phase 8 Iterate, after CI passes and bot review is complete on the current HEAD, when threads remain unresolved despite fixes being present
 - Any time a bot flags a thread as OPEN/NEEDS_HUMAN_JUDGMENT and the fix appears to be present in the codebase
 - Before pushing an additional round solely to address threads the bot cannot confirm as resolved
 
@@ -74,6 +74,8 @@ gh api repos/<repo>/pulls/<pr>/comments \
     {id: .id, path: .path, line: .original_line,
      body: (.body | .[0:120])}'
 ```
+
+Note: the GraphQL primary returns global node IDs (`PRRT_kwDO…`); the REST fallback returns numeric comment IDs. Choose the matching reply command in §Verification Report.
 
 Record each unresolved thread: thread ID, file path, line number, and the finding summary (first ~120 chars of the lead comment).
 
@@ -134,7 +136,29 @@ Verified against: <branch-sha>
 **Summary:** <n> RESOLVED-IN-CODE · <n> GENUINELY-OPEN · <n> NEEDS-FOLLOWUP
 ```
 
+Post the report:
+
+```bash
+gh pr comment <pr> --repo <repo> --body "## PR Review Thread Verification Report
+..."
+```
+
 After posting: for each RESOLVED-IN-CODE thread, reply referencing the relevant report row as evidence. Per COR-1612 §Step 7, do not self-resolve — the original reviewer must resolve the thread. Do not reply to GENUINELY-OPEN or NEEDS-FOLLOWUP threads; address their findings in the next round.
+
+Reply commands (choose based on ID type from Step 1):
+
+```bash
+# GraphQL reply (uses global node ID from primary command)
+gh api graphql -f query='mutation($t:ID!,$b:String!){
+  addPullRequestReviewThreadReply(input:{pullRequestReviewThreadId:$t,body:$b}){
+    comment{url}}}' \
+  -f t="<PRRT_...>" -f b="Verified RESOLVED-IN-CODE — see verification report."
+
+# REST reply (uses numeric comment ID from fallback)
+gh api repos/<repo>/pulls/<pr>/comments \
+  -f body="Verified RESOLVED-IN-CODE — see verification report." \
+  -f in_reply_to_id=<comment-id>
+```
 
 ---
 
@@ -152,5 +176,6 @@ After posting: for each RESOLVED-IN-CODE thread, reply referencing the relevant 
 
 | Date | Change | By |
 |------|--------|----|
-| 2026-05-10 | Initial version — 4-step procedure (Enumerate / Locate / Verify / Classify) for auditing PR review threads against source file content. Addresses false-positive bot verdicts observed on PR #141 (alfred). Composable with COR-1617 §Phase 11 Retrospective. Issue #142. | Claude Sonnet 4.6 |
-| 2026-05-10 | R1 fixes: B1 — replaced invalid `gh pr view --json reviewThreads` with `gh api graphql` primary + REST fallback (field not supported by gh CLI); B2 — removed self-resolve instruction (contradicts COR-1612 §Step 7); A1 — fixed prerequisite claim (Phase 11 does not enumerate threads; Step 1 does); A2 — added deleted-file classification note; A4 — documented REST/GraphQL field-name difference (`original_line` vs `originalLine`). | Claude Sonnet 4.6 |
+| 2026-05-10 | Initial version — 4-step procedure (Enumerate / Locate / Verify / Classify) for auditing PR review threads against source file content. Addresses false-positive bot verdicts observed on PR #141 (alfred). Composable with COR-1617 §Phase 8 Iterate. Issue #142. | Claude Sonnet 4.6 |
+| 2026-05-10 | R1 fixes (DeepSeek panel): B1 — replaced invalid `gh pr view --json reviewThreads` with `gh api graphql` primary + REST fallback (field not supported by gh CLI); B2 — removed self-resolve instruction (contradicts COR-1612 §Step 7); A1 — fixed prerequisite claim (Phase 11 does not enumerate threads; Step 1 does); A2 — added deleted-file classification note; A4 — documented REST/GraphQL field-name difference (`original_line` vs `originalLine`). | Claude Sonnet 4.6 |
+| 2026-05-10 | R1 fixes (GLM panel): P0 — corrected remaining Phase 11 references to Phase 8 Iterate (Related: header, §When to Use, §Change History); P1-1 — added `gh pr comment` command for posting report; P1-2 — added GraphQL/REST thread reply commands (COR-1612 §Step 7 requires reply-not-resolve); P2-1 — noted GraphQL node ID vs REST numeric ID difference for reply commands. | Claude Sonnet 4.6 |


### PR DESCRIPTION
## Summary

- New PKG SOP `COR-1623-SOP-PR-Review-Thread-Verification.md` with a 4-step verification procedure
- `COR-0000-REF-Document-Index.md` updated with COR-1623 entry
- `af validate` passes (268 documents, 0 issues)

## What

4-step procedure (Enumerate / Locate / Verify / Classify) for auditing GitHub PR review threads against actual source file content, producing a per-thread classification with evidence pointers:

- **RESOLVED-IN-CODE** — fix is present; bot couldn't confirm due to truncated diff
- **GENUINELY-OPEN** — issue still present in source
- **NEEDS-FOLLOWUP** — fix attempted but incomplete

Integrates as a composable sub-procedure with COR-1617 §Phase 11 Retrospective.

## Why

Review bots (clearance bots, SWM bots) read diffs, not files. Truncated diff windows produce false-positive OPEN verdicts that block merges unnecessarily. Demonstrated on PR #141 where 2 of 4 "unresolved" threads were confirmed fixed by direct file inspection.

## Test plan

- [x] `af validate --root /Users/frank/Projects/alfred` passes (268 docs, 0 issues)
- [x] COR-1623 metadata: Status Active, Type SOP, all required sections present
- [x] COR-0000 index entry added

## Scope hints

This PR adds one new PKG SOP file and updates the index. Review focus: correctness of the 4-step procedure, shell command accuracy, classification taxonomy completeness, and pitfalls coverage.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)