### PR TITLE
feat(#169): af issue lint Phase 1 MVP — TBD-phrase detection

### DIFF
--- a/src/fx_alfred/cli.py
+++ b/src/fx_alfred/cli.py
@@ -37,6 +37,7 @@ Quick Start:
         "fmt": "fx_alfred.commands.fmt_cmd:fmt_cmd",
         "guide": "fx_alfred.commands.guide_cmd:guide_cmd",
         "index": "fx_alfred.commands.index_cmd:index_cmd",
+        "issue": "fx_alfred.commands.issue_cmd:issue_cmd",
         "list": "fx_alfred.commands.list_cmd:list_cmd",
         "plan": "fx_alfred.commands.plan_cmd:plan_cmd",
         "read": "fx_alfred.commands.read_cmd:read_cmd",

--- a/src/fx_alfred/commands/issue_cmd.py
+++ b/src/fx_alfred/commands/issue_cmd.py
@@ -1,0 +1,98 @@
+"""af issue — issue body utilities (FXA-2292)."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+# Phase 1: TBD-phrase rule (same list as COR-1506 §Hard Cap Trigger B).
+# Order is significant — when two phrases appear on the same line, the one
+# earlier in this list is reported first.
+TBD_PHRASES = [
+    "TBD after PR review",
+    "TBD after option selection",
+    "implementer chooses",
+    "exact spec to be drafted after reviewer pick",
+    "to be decided in review",
+]
+
+
+def _check_tbd_phrases(text: str) -> list[dict]:
+    """Return one violation dict per TBD-phrase occurrence.
+
+    Case-insensitive substring match; line numbers are 1-based.
+    Each (phrase, line) pair contributes at most one violation
+    (duplicate occurrences of the same phrase on the same line are
+    collapsed). Violations are sorted by line number ascending;
+    ties preserve the order of TBD_PHRASES (stable sort).
+    """
+    violations: list[dict] = []
+    lower_lines = [line.lower() for line in text.splitlines()]
+    for phrase in TBD_PHRASES:
+        needle = phrase.lower()
+        for line_no, line in enumerate(lower_lines, start=1):
+            if needle in line:
+                violations.append(
+                    {
+                        "rule": "tbd-phrase",
+                        "line": line_no,
+                        "match": phrase,
+                    }
+                )
+    # Stable sort by line; ties keep declaration order of TBD_PHRASES.
+    violations.sort(key=lambda v: v["line"])
+    return violations
+
+
+@click.group(name="issue")
+def issue_cmd() -> None:
+    """Issue body utilities (lint, ...)."""
+
+
+@issue_cmd.command(name="lint")
+@click.argument(
+    "body_file",
+    type=click.Path(dir_okay=False, allow_dash=True),
+)
+@click.option("--json", "as_json", is_flag=True, help="Output violations as JSON.")
+def lint_cmd(body_file: str, as_json: bool) -> None:
+    """Lint a GitHub issue body for known anti-patterns.
+
+    Phase 1: detects TBD-after-PR-review phrases (see #168 §Hard Cap Trigger B).
+    Reads from BODY_FILE or stdin if BODY_FILE is `-`.
+    Exit 0 on PASS, 1 on FAIL.
+    """
+    if body_file == "-":
+        text = sys.stdin.read()
+    else:
+        path = Path(body_file)
+        if not path.exists():
+            raise click.FileError(body_file, hint="No such file")
+        text = path.read_text(encoding="utf-8")
+
+    violations = _check_tbd_phrases(text)
+
+    if as_json:
+        click.echo(
+            json.dumps(
+                {
+                    "result": "PASS" if not violations else "FAIL",
+                    "violation_count": len(violations),
+                    "violations": violations,
+                },
+                indent=2,
+            )
+        )
+    else:
+        for v in violations:
+            click.echo(f'✗ TBD-phrase detected at line {v["line"]}: "{v["match"]}"')
+        click.echo()
+        if violations:
+            click.echo(f"Lint result: FAIL ({len(violations)} violations)")
+        else:
+            click.echo("Lint result: PASS (0 violations)")
+
+    sys.exit(1 if violations else 0)

--- a/tests/commands/test_issue_lint_cmd.py
+++ b/tests/commands/test_issue_lint_cmd.py
@@ -29,6 +29,7 @@ TBD_PHRASES = [
 # AC1 / AC22: help text
 # ---------------------------------------------------------------------------
 
+
 def test_lint_help_shows_body_file_and_json_flag():
     """AC1: af issue lint --help shows BODY_FILE positional and --json flag."""
     runner = CliRunner()
@@ -51,6 +52,7 @@ def test_lint_issue_help_shows_lint_subcommand():
 # AC2: clean body → PASS
 # ---------------------------------------------------------------------------
 
+
 def test_lint_clean_body_pass(tmp_path):
     """AC2: clean body with no TBD phrases → exit 0, PASS message."""
     body = tmp_path / "body.md"
@@ -64,6 +66,7 @@ def test_lint_clean_body_pass(tmp_path):
 # ---------------------------------------------------------------------------
 # AC3: violations — each phrase, multi-violation, multi-phrase
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.parametrize("phrase", TBD_PHRASES)
 def test_lint_each_phrase_fails(tmp_path, phrase):
@@ -91,7 +94,7 @@ def test_lint_multi_violation_same_phrase(tmp_path):
     assert result.exit_code == 1
     assert "FAIL (3 violations)" in result.output
 
-    lines = [l for l in result.output.split("\n") if l.startswith("✗")]
+    lines = [ln for ln in result.output.split("\n") if ln.startswith("✗")]
     assert len(lines) == 3
     assert "line 2" in lines[0]
     assert "line 4" in lines[1]
@@ -112,7 +115,7 @@ def test_lint_multi_phrase_mixed_sorted(tmp_path):
     assert result.exit_code == 1
     assert "FAIL (2 violations)" in result.output
 
-    lines = [l for l in result.output.split("\n") if l.startswith("✗")]
+    lines = [ln for ln in result.output.split("\n") if ln.startswith("✗")]
     assert len(lines) == 2
     # sorted by line: line 2 then line 4
     assert "line 2" in lines[0]
@@ -124,6 +127,7 @@ def test_lint_multi_phrase_mixed_sorted(tmp_path):
 # ---------------------------------------------------------------------------
 # AC3: case-insensitive match
 # ---------------------------------------------------------------------------
+
 
 def test_lint_case_insensitive_detection(tmp_path):
     """AC3: each phrase detected in UPPERCASE, lowercase, and MiXeD case."""
@@ -141,7 +145,7 @@ def test_lint_case_insensitive_detection(tmp_path):
     assert "FAIL (5 violations)" in result.output
 
     # Each line should report the canonical phrase, not the input text
-    violations = [l for l in result.output.split("\n") if l.startswith("✗")]
+    violations = [ln for ln in result.output.split("\n") if ln.startswith("✗")]
     assert len(violations) == 5
     canonical_matches = []
     for v in violations:
@@ -157,6 +161,7 @@ def test_lint_case_insensitive_detection(tmp_path):
 # ---------------------------------------------------------------------------
 # AC3: embedded / fenced code
 # ---------------------------------------------------------------------------
+
 
 def test_lint_phrase_embedded_in_sentence(tmp_path):
     """AC3: phrase as substring in a longer sentence is matched."""
@@ -175,10 +180,7 @@ def test_lint_phrase_in_fenced_code_block(tmp_path):
     """AC3: phrase inside a fenced code block is matched (Phase 1 — deliberate)."""
     body = tmp_path / "body.md"
     body.write_text(
-        "```python\n"
-        "# TBD after option selection: choose parser\n"
-        "x = 1\n"
-        "```\n"
+        "```python\n# TBD after option selection: choose parser\nx = 1\n```\n"
     )
     runner = CliRunner()
     result = runner.invoke(cli, ["issue", "lint", str(body)])
@@ -190,11 +192,13 @@ def test_lint_phrase_in_fenced_code_block(tmp_path):
 # AC4: stdin via -
 # ---------------------------------------------------------------------------
 
+
 def test_lint_stdin_dash_clean():
     """AC4: af issue lint - reads clean stdin → PASS."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["issue", "lint", "-"],
+        cli,
+        ["issue", "lint", "-"],
         input="All decisions final.\nNo TBDs here.\n",
     )
     assert result.exit_code == 0
@@ -205,7 +209,8 @@ def test_lint_stdin_dash_dirty():
     """AC4: af issue lint - reads stdin with TBD phrase → FAIL."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["issue", "lint", "-"],
+        cli,
+        ["issue", "lint", "-"],
         input="implementer chooses: still open\n",
     )
     assert result.exit_code == 1
@@ -215,6 +220,7 @@ def test_lint_stdin_dash_dirty():
 # ---------------------------------------------------------------------------
 # AC5: --json output
 # ---------------------------------------------------------------------------
+
 
 def test_lint_json_clean(tmp_path):
     """AC5: --json on clean body → {result: PASS, violation_count: 0, violations: []}."""
@@ -233,10 +239,7 @@ def test_lint_json_with_violations(tmp_path):
     """AC5: --json with violations → proper JSON shape, violations sorted by line."""
     body = tmp_path / "body.md"
     body.write_text(
-        "line 1\n"
-        "TBD after PR review: pending\n"
-        "line 3\n"
-        "implementer chooses: toolkit\n"
+        "line 1\nTBD after PR review: pending\nline 3\nimplementer chooses: toolkit\n"
     )
     runner = CliRunner()
     result = runner.invoke(cli, ["issue", "lint", str(body), "--json"])
@@ -283,19 +286,17 @@ def test_lint_json_no_stray_text(tmp_path):
 # AC6: phrase-order / multiple-phrase semantics
 # ---------------------------------------------------------------------------
 
+
 def test_lint_two_phrases_same_line(tmp_path):
     """AC6: one line with 2 canonical phrases → 2 violations at same line number."""
     body = tmp_path / "body.md"
-    body.write_text(
-        "header\n"
-        "TBD after PR review and implementer chooses both apply\n"
-    )
+    body.write_text("header\nTBD after PR review and implementer chooses both apply\n")
     runner = CliRunner()
     result = runner.invoke(cli, ["issue", "lint", str(body)])
     assert result.exit_code == 1
     assert "FAIL (2 violations)" in result.output
 
-    violations = [l for l in result.output.split("\n") if l.startswith("✗")]
+    violations = [ln for ln in result.output.split("\n") if ln.startswith("✗")]
     assert len(violations) == 2
     # Both at the same line number (line 2, 1-based)
     assert "line 2" in violations[0]
@@ -317,9 +318,7 @@ def test_lint_substring_no_word_boundary(tmp_path):
 def test_lint_duplicate_phrase_same_line_counted_once(tmp_path):
     """Duplicate phrase on same line: substring check is boolean → 1 per phrase per line."""
     body = tmp_path / "body.md"
-    body.write_text(
-        "implementer chooses: A or implementer chooses: B, take pick\n"
-    )
+    body.write_text("implementer chooses: A or implementer chooses: B, take pick\n")
     runner = CliRunner()
     result = runner.invoke(cli, ["issue", "lint", str(body)])
     # "implementer chooses" appears twice on same line → counted once
@@ -330,11 +329,13 @@ def test_lint_duplicate_phrase_same_line_counted_once(tmp_path):
 # Edge cases: file I/O
 # ---------------------------------------------------------------------------
 
+
 def test_lint_file_not_found():
     """Non-existent file → non-zero exit code."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["issue", "lint", "/nonexistent/path/to/file.md"],
+        cli,
+        ["issue", "lint", "/nonexistent/path/to/file.md"],
     )
     assert result.exit_code != 0
 
@@ -376,6 +377,7 @@ def test_lint_utf8_with_emoji_and_chinese(tmp_path):
 # ---------------------------------------------------------------------------
 # Output structure / blank-line handling
 # ---------------------------------------------------------------------------
+
 
 def test_lint_output_blank_line_before_result(tmp_path):
     """A blank line separates the violations list from the Lint result line."""

--- a/tests/commands/test_issue_lint_cmd.py
+++ b/tests/commands/test_issue_lint_cmd.py
@@ -1,0 +1,417 @@
+"""Tests for af issue lint subcommand (FXA-2292 / issue #169)."""
+
+import json
+
+import pytest
+
+from click.testing import CliRunner
+from fx_alfred.cli import cli
+
+# Import-time assertion: this proves the production module is genuinely absent.
+# When the implementer adds src/fx_alfred/commands/issue_cmd.py with `issue_cmd`,
+# this import succeeds and all 27 tests transition from RED → GREEN. Until then,
+# pytest collection fails with ModuleNotFoundError, which is the correct TDD RED state.
+from fx_alfred.commands.issue_cmd import issue_cmd  # noqa: F401
+
+
+pytestmark = pytest.mark.cli
+
+TBD_PHRASES = [
+    "TBD after PR review",
+    "TBD after option selection",
+    "implementer chooses",
+    "exact spec to be drafted after reviewer pick",
+    "to be decided in review",
+]
+
+
+# ---------------------------------------------------------------------------
+# AC1 / AC22: help text
+# ---------------------------------------------------------------------------
+
+def test_lint_help_shows_body_file_and_json_flag():
+    """AC1: af issue lint --help shows BODY_FILE positional and --json flag."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", "--help"])
+    assert result.exit_code == 0
+    assert "issue lint" in result.output or "lint" in result.output
+    assert "BODY_FILE" in result.output
+    assert "--json" in result.output
+
+
+def test_lint_issue_help_shows_lint_subcommand():
+    """AC22: af issue --help shows lint as a subcommand of the issue group."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "--help"])
+    assert result.exit_code == 0
+    assert "lint" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC2: clean body → PASS
+# ---------------------------------------------------------------------------
+
+def test_lint_clean_body_pass(tmp_path):
+    """AC2: clean body with no TBD phrases → exit 0, PASS message."""
+    body = tmp_path / "body.md"
+    body.write_text("This is a clean spec.\nAll decisions are made.\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC3: violations — each phrase, multi-violation, multi-phrase
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("phrase", TBD_PHRASES)
+def test_lint_each_phrase_fails(tmp_path, phrase):
+    """AC3: each canonical TBD phrase produces a failure."""
+    body = tmp_path / "body.md"
+    body.write_text(f"Some text.\n{phrase}\nMore text.\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (1 violations)" in result.output
+
+
+def test_lint_multi_violation_same_phrase(tmp_path):
+    """AC3: same phrase on 3 lines → 3 violations sorted by line."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "intro\n"
+        "TBD after PR review: decision 1\n"
+        "ok line\n"
+        "TBD after PR review: decision 2\n"
+        "TBD after PR review: decision 3\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (3 violations)" in result.output
+
+    lines = [l for l in result.output.split("\n") if l.startswith("✗")]
+    assert len(lines) == 3
+    assert "line 2" in lines[0]
+    assert "line 4" in lines[1]
+    assert "line 5" in lines[2]
+
+
+def test_lint_multi_phrase_mixed_sorted(tmp_path):
+    """AC3: 2 different phrases on different lines → sorted by line number."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "header\n"
+        "to be decided in review: something\n"
+        "middle\n"
+        "implementer chooses: something else\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (2 violations)" in result.output
+
+    lines = [l for l in result.output.split("\n") if l.startswith("✗")]
+    assert len(lines) == 2
+    # sorted by line: line 2 then line 4
+    assert "line 2" in lines[0]
+    assert "to be decided in review" in lines[0]
+    assert "line 4" in lines[1]
+    assert "implementer chooses" in lines[1]
+
+
+# ---------------------------------------------------------------------------
+# AC3: case-insensitive match
+# ---------------------------------------------------------------------------
+
+def test_lint_case_insensitive_detection(tmp_path):
+    """AC3: each phrase detected in UPPERCASE, lowercase, and MiXeD case."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "TBD AFTER PR REVIEW\n"
+        "tbd after option selection\n"
+        "ImPlEmEnTeR cHoOsEs\n"
+        "ExAcT sPeC tO bE dRaFtEd AfTeR rEvIeWeR pIcK\n"
+        "To Be DeCiDeD iN rEvIeW\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (5 violations)" in result.output
+
+    # Each line should report the canonical phrase, not the input text
+    violations = [l for l in result.output.split("\n") if l.startswith("✗")]
+    assert len(violations) == 5
+    canonical_matches = []
+    for v in violations:
+        # Extract match text (between last pair of quotes)
+        canonical_matches.append(v.split('"')[-2])
+    assert canonical_matches[0] == "TBD after PR review"
+    assert canonical_matches[1] == "TBD after option selection"
+    assert canonical_matches[2] == "implementer chooses"
+    assert canonical_matches[3] == "exact spec to be drafted after reviewer pick"
+    assert canonical_matches[4] == "to be decided in review"
+
+
+# ---------------------------------------------------------------------------
+# AC3: embedded / fenced code
+# ---------------------------------------------------------------------------
+
+def test_lint_phrase_embedded_in_sentence(tmp_path):
+    """AC3: phrase as substring in a longer sentence is matched."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "We need to handle the case where implementer chooses the library.\n"
+        "The decision is TBD after PR review with the team.\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (2 violations)" in result.output
+
+
+def test_lint_phrase_in_fenced_code_block(tmp_path):
+    """AC3: phrase inside a fenced code block is matched (Phase 1 — deliberate)."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "```python\n"
+        "# TBD after option selection: choose parser\n"
+        "x = 1\n"
+        "```\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (1 violations)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC4: stdin via -
+# ---------------------------------------------------------------------------
+
+def test_lint_stdin_dash_clean():
+    """AC4: af issue lint - reads clean stdin → PASS."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["issue", "lint", "-"],
+        input="All decisions final.\nNo TBDs here.\n",
+    )
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
+
+
+def test_lint_stdin_dash_dirty():
+    """AC4: af issue lint - reads stdin with TBD phrase → FAIL."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["issue", "lint", "-"],
+        input="implementer chooses: still open\n",
+    )
+    assert result.exit_code == 1
+    assert "FAIL (1 violations)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC5: --json output
+# ---------------------------------------------------------------------------
+
+def test_lint_json_clean(tmp_path):
+    """AC5: --json on clean body → {result: PASS, violation_count: 0, violations: []}."""
+    body = tmp_path / "body.md"
+    body.write_text("Clean spec.\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body), "--json"])
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["result"] == "PASS"
+    assert data["violation_count"] == 0
+    assert data["violations"] == []
+
+
+def test_lint_json_with_violations(tmp_path):
+    """AC5: --json with violations → proper JSON shape, violations sorted by line."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "line 1\n"
+        "TBD after PR review: pending\n"
+        "line 3\n"
+        "implementer chooses: toolkit\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body), "--json"])
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    assert data["result"] == "FAIL"
+    assert data["violation_count"] == 2
+    violations = data["violations"]
+    assert len(violations) == 2
+
+    # Each violation has all 4 fields
+    for v in violations:
+        assert v["rule"] == "tbd-phrase"
+        assert isinstance(v["line"], int)
+        assert v["match"] in TBD_PHRASES
+
+    # Sorted by line number
+    assert violations[0]["line"] < violations[1]["line"]
+    assert violations[0]["line"] == 2
+    assert violations[1]["line"] == 4
+
+
+def test_lint_json_parseable(tmp_path):
+    """AC5: JSON output is valid and parseable by json.loads (no stray text)."""
+    body = tmp_path / "body.md"
+    body.write_text("implementer chooses: x\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body), "--json"])
+    # json.loads must not raise
+    data = json.loads(result.output)
+    assert data["violation_count"] == 1
+
+
+def test_lint_json_no_stray_text(tmp_path):
+    """AC5: --json output contains NO ✗ lines — only the JSON blob."""
+    body = tmp_path / "body.md"
+    body.write_text("TBD after PR review: needs review\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body), "--json"])
+    assert "✗" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC6: phrase-order / multiple-phrase semantics
+# ---------------------------------------------------------------------------
+
+def test_lint_two_phrases_same_line(tmp_path):
+    """AC6: one line with 2 canonical phrases → 2 violations at same line number."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "header\n"
+        "TBD after PR review and implementer chooses both apply\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (2 violations)" in result.output
+
+    violations = [l for l in result.output.split("\n") if l.startswith("✗")]
+    assert len(violations) == 2
+    # Both at the same line number (line 2, 1-based)
+    assert "line 2" in violations[0]
+    assert "line 2" in violations[1]
+    assert "TBD after PR review" in violations[0]
+    assert "implementer chooses" in violations[1]
+
+
+def test_lint_substring_no_word_boundary(tmp_path):
+    """AC6: phrase embedded without spaces as substring of a longer word → matched."""
+    body = tmp_path / "body.md"
+    body.write_text("FooTBD after PR reviewBar\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (1 violations)" in result.output
+
+
+def test_lint_duplicate_phrase_same_line_counted_once(tmp_path):
+    """Duplicate phrase on same line: substring check is boolean → 1 per phrase per line."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "implementer chooses: A or implementer chooses: B, take pick\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    # "implementer chooses" appears twice on same line → counted once
+    assert "FAIL (1 violations)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Edge cases: file I/O
+# ---------------------------------------------------------------------------
+
+def test_lint_file_not_found():
+    """Non-existent file → non-zero exit code."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["issue", "lint", "/nonexistent/path/to/file.md"],
+    )
+    assert result.exit_code != 0
+
+
+def test_lint_empty_file_pass(tmp_path):
+    """Empty file → 0 violations, PASS exit 0."""
+    body = tmp_path / "body.md"
+    body.write_text("")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
+
+
+def test_lint_whitespace_only_pass(tmp_path):
+    """File with only newlines and whitespace → 0 violations, PASS exit 0."""
+    body = tmp_path / "body.md"
+    body.write_text("   \n\n  \t \n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
+
+
+def test_lint_utf8_with_emoji_and_chinese(tmp_path):
+    """UTF-8 BOM and non-ASCII chars: phrase still detected with emoji/Chinese."""
+    body = tmp_path / "body.md"
+    body.write_text(
+        "﻿# Spec\n"
+        "决策: implementer chooses the approach 🎉\n"
+        "备注: TBD after PR review with 团队\n"
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "FAIL (2 violations)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Output structure / blank-line handling
+# ---------------------------------------------------------------------------
+
+def test_lint_output_blank_line_before_result(tmp_path):
+    """A blank line separates the violations list from the Lint result line."""
+    body = tmp_path / "body.md"
+    body.write_text("TBD after PR review\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    # After the violations line, there should be a blank line before "Lint result:"
+    output = result.output
+    # Strip trailing whitespace but keep internal structure
+    assert "\n\nLint result:" in output
+
+
+def test_lint_output_structure_clean_pass(tmp_path):
+    """Exact output structure for clean PASS case."""
+    body = tmp_path / "body.md"
+    body.write_text("All decided.\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    # Clean case: blank line then "Lint result: PASS (0 violations)"
+    # click.echo() adds \n, so: echo("") → "\n", echo("Lint result: ...") → "Lint result: ...\n"
+    # Combined: "\nLint result: PASS (0 violations)\n"
+    assert "✗" not in result.output
+    assert "PASS (0 violations)" in result.output
+
+
+def test_lint_output_structure_exact_fail(tmp_path):
+    """Exact output structure for a single-violation FAIL case."""
+    body = tmp_path / "body.md"
+    body.write_text("line 1\nto be decided in review: item\nline 3\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    output = result.output
+    # Should contain: ✗ line → blank line → Lint result: FAIL line
+    assert "✗ TBD-phrase detected at line 2:" in output
+    assert '"to be decided in review"' in output
+    assert "\n\nLint result:" in output
+    assert "FAIL (1 violations)" in output
+    assert result.exit_code == 1


### PR DESCRIPTION
## Summary

Implements #169 Phase 1 MVP — new `af issue lint <body-file>` subcommand detecting TBD-phrase anti-patterns in GitHub issue bodies pre-creation. **Alfred's FIRST two-worker TDD dispatch under FXA-2292** (PR #178).

## Two-worker dispatch trace (PRP-1507 §Validation log entry 1)

| Phase | Worker | Model | Result |
|---|---|---|---|
| **Test-writer (RED)** | trinity-deepseek | `deepseek-v4-pro[1m]` via api.deepseek.com | 26 test functions + 5 parametrized = 29 tests covering 10 ACs; RED state `ModuleNotFoundError`; 2 dispatch rounds |
| **Quality gate (Rule #4)** | orchestrator | — | Vacuity 0, trivial-RED 0, zero-assertion 0 — PASS |
| **Test commit** | orchestrator | — | `test:` at 97450cf |
| **Implementer (GREEN)** | trinity-glm | `custom:GLM-5.1-(Z.AI)-0` via api.z.ai | 1 round (after 1 prior round on built-in `glm-5.1` aborted HTTP 402 Factory droid quota) |
| **Orchestrator inline lint fix** | orchestrator | — | 4× E741 + format on test file (per COR-1619 "5+ small fixes" rule); `style:` at ab8407e |
| **Impl commit** | orchestrator | — | `feat:` at 4218684 |
| **Refactor pass** | n/a | — | skipped — implementation is small and clean |

### Cross-validation observations

- **Reading constraint honored**: implementer (glm) did NOT read test-writer commentary; consumed only failing tests + issue #169 body + production source
- **Test-file edit constraint honored**: implementer reported test-writer's 4 lint defects upward instead of unilaterally fixing; orchestrator handled inline per CHG-C1
- **Implement-to-fit bias mitigation**: test-writer (deepseek) wrote tests BEFORE seeing any implementation; the spec body did contain canonical code, which weakens but doesn't eliminate the cross-validation — documented as known limitation for §Validation re-evaluation
- **Outage class encountered**: implementer dispatch initially aborted on HTTP 402 Factory droid quota; resolved via prompt-level model override to `custom:GLM-5.1-(Z.AI)-0` (Z.AI direct API key bypasses Factory billing). Permanent fix queued in a separate follow-up CHG against the `.claude` repo

## Files

- **NEW**: `src/fx_alfred/commands/issue_cmd.py` (98 lines)
- **EDIT**: `src/fx_alfred/cli.py` (+1 line — register `"issue"` alphabetically)
- **NEW**: `tests/commands/__init__.py`, `tests/commands/test_issue_lint_cmd.py` (29 tests)

## Verification

- `pytest -q` — **935 passed** (906 existing + 29 new — 0 regressions)
- `ruff check .` + `ruff format --check .` — clean
- `af validate --root /Users/frank/Projects/alfred` — 281 docs, 0 issues
- Manual smoke: `af issue lint --help` displays subcommand correctly

## Retrospective items surfaced for follow-up CHGs

1. **trinity-glm.md custom-model gap** (`.claude` repo): both committed `custom:GLM-5-1` (orphan id, doesn't exist in `~/.factory/settings.json`) and WIP `glm-5.1` (built-in, hits Factory 402) are broken; correct id is `custom:GLM-5.1-(Z.AI)-0`. Requires permission-allowlist on `~/.claude/` writes before I can patch.
2. **COR-1619 §Two-Worker TDD Dispatch step 5** doesn't explicitly cover the "test-writer's tests pass but lint-fail" path. The implementer correctly reported lint defects upward; orchestrator handled inline per the COR-1619 §When NOT to Use "5+ small fixes" exception. Worth folding into the queued PRP-1507 cleanup CHG.
3. **§Validation log scaffold** is alfred's first two-worker dispatch entry; second dispatch will close more of the re-evaluation trigger surface.

## Scope hints

- Single-feature CHG (inline per COR-1104). New file + tests + 1-line cli registration.
- 29 tests cover all 10 ACs + edge cases (vacuity in test code, rename target unstaging not applicable, etc.).
- Phase 2 rules (vague-anchor regex, LoC estimate, AC↔Spec cross-grep, anchor uniqueness) are explicitly deferred per #169 §Out of Scope.

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)