### PR TITLE
docs(#167): add COR-1501 §Quality Criteria — author-side write-time targets

### DIFF
--- a/src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md
+++ b/src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md
@@ -1,8 +1,8 @@
 # SOP-1501: Create GitHub Issue
 
 **Applies to:** Repos using the Iterwheel intake bots (`iterwheel-blueprint[bot]` for body intake, `iterwheel-stack[bot]` for `stack-*` label pairs). The procedure (template, CLI, verify) generalizes; the label tables below reflect alfred's labels and must be substituted for repos with a different label set.
-**Last updated:** 2026-05-10
-**Last reviewed:** 2026-05-10
+**Last updated:** 2026-05-17
+**Last reviewed:** 2026-05-17
 **Status:** Active
 **Last executed:** 2026-05-10 (issue #126)
 
@@ -205,6 +205,26 @@ Once `blueprint-ready` is confirmed, validate content quality per **COR-1506** b
 
 ---
 
+## Quality Criteria
+
+Write-time targets the author should hit BEFORE submitting for `blueprint-ready` intake. Independent of COR-1506 scoring (reviewer-side gate); these are author-side aim-points so the issue passes COR-1506 without revision.
+
+1. **Anchor verbatim** — For any diff-style edit, paste the EXACT before-string from the file in a fenced code block. Do not describe ("find the last bullet under Guard Rails"); quote ("- Never auto-switch-and-pull on wake when the branch guard mismatches. Operator decides resume."). Reviewer must be able to `grep -F` the anchor against current HEAD and get exactly one hit.
+
+2. **Cell-by-cell diff for table edits** — When editing a markdown table row, show a separate "before / after" mini-table mapping each cell. Do not paste only the new row; the reviewer cannot otherwise know which cells changed.
+
+3. **LoC budget ≤ 100 net delta** (soft target) — If the issue's expected `git diff --stat` shows net additions > 100 lines, split into 2+ issues OR re-scope. One-session issues stay small; larger work belongs in a PRP per COR-1102.
+
+4. **Spec fully pre-committed** — Do not write "TBD after PR review" / "TBD after option selection" / "implementer chooses" / "exact spec to be drafted after reviewer pick". If a decision exists, commit to one option in the issue body (document the rejected alternative in a `## Rejected Alternatives` subsection). Decision-gated issues belong as PRPs, not inline CHGs.
+
+5. **Greppable references** — Every `file:line` and anchor in the issue body must be greppable verbatim against current HEAD. Run `grep -nF "<anchor string>" <file>` on each anchor before submitting; if grep returns ≠ 1 hit, the anchor is wrong (drifted, paraphrased, or stale).
+
+**Anti-example (alfred #165 R1):** Edit 1 anchor read `find this exact section heading + closing — the LAST line of the Primitive 4 block, immediately before `## Cadence rules``. Vague — reviewer cannot `grep -F` it. Fixed in R2 by pasting the verbatim 5-line block.
+
+**Positive example (alfred #163):** Each of 3 edits had a verbatim anchor (code block with exact before-string) + cell-by-cell diff for the table edit. Reviewed cleanly with no anchor-related findings.
+
+---
+
 ## Naming Conventions
 
 | Field | Convention |
@@ -233,3 +253,4 @@ Once `blueprint-ready` is confirmed, validate content quality per **COR-1506** b
 | 2026-03-20 | Added Why/When to Use/When NOT to Use sections per FXA-2223 | Claude Code |
 | 2026-05-10 | issue #127: align with current alfred repo conventions — stack-type-* + stack-area-* label pair (replaces old `sop`/`automation`/etc. taxonomy), Iterwheel Blueprint template (replaces Summary/Context template), `[Task]:` title chip, `--repo` flag in CLI example, `gh issue view` verify with intake-bot label check | Claude Opus 4.7 |
 | 2026-05-10 | issue #136: added COR-1506 quality-gate pointer after blueprint-ready verify step | Claude Sonnet 4.6 |
+| 2026-05-17 | issue #167: add §Quality Criteria — 5 author-side write-time targets (anchor verbatim, cell-by-cell diff, ≤100 LoC budget, pre-committed spec, greppable references) with anti-example + positive example from PR #164 trinity-review loop. | Claude Opus 4.7 |


### PR DESCRIPTION
## Summary

Adds a `## Quality Criteria` section to **COR-1501** (Create GitHub Issue) listing **5 author-side write-time targets** that complement the structural intake-bot check and the post-blueprint-ready COR-1506 content scoring.

This is the **author-side** of the issue-quality story; reviewer-side hard cap lands separately under #168.

## Targets (verbatim list)

1. **Anchor verbatim** — paste exact before-string, not description
2. **Cell-by-cell diff for table edits**
3. **LoC budget ≤ 100 net delta** (soft target — larger work → PRP)
4. **Spec fully pre-committed** — no "TBD after PR review" / "implementer chooses" / "exact spec to be drafted after reviewer pick"
5. **Greppable references** — every `file:line` and anchor must `grep -F` against current HEAD with exactly 1 hit

Plus one anti-example (alfred #165 R1 — vague anchor) and one positive example (alfred #163 — verbatim anchor + cell diff).

## Evidence

PR #164 review loop (2026-05-16) — three iterations on issue bodies #165 / #166 surfaced four recurring write-time defects worth codifying. Documented in issue body.

## Scope

- Single-file edit to `src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md`
- ~30 net lines added (new §Quality Criteria section + 1 Change History row + 2 frontmatter date updates)
- No code changes; no PRJ-layer edits

## Verification

- `af validate --root /Users/frank/Projects/alfred` — 281 docs, 0 issues
- `pytest -q` — 935 passed
- `ruff check` + `format --check` — clean

## Scope hints

- This is the author-side half — reviewer-side gate is a sibling CHG against COR-1506 (#168, separate PR)
- The 5 targets are canonical text; minor copy-edits OK but structural changes (drop a target, soften "MUST" to "should") need a follow-up CHG

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)