### PR TITLE
docs(#183): fold 11-star SOP experience review into FXA-2148 §Phase 2 Step 8

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -203,6 +203,7 @@
 | 2290 | CHG | COR 1619 Decision Tree Two Worker Branch |
 | 2291 | CHG | COR 1622 Test Writer Worker Agent Schema Row |
 | 2292 | CHG | Alfred Opt In Two Worker TDD Split |
+| 2293 | PRP | 11 Star SOP Experience Review |
 
 ---
 

--- a/rules/FXA-2148-SOP-Evolve-SOP.md
+++ b/rules/FXA-2148-SOP-Evolve-SOP.md
@@ -4,7 +4,7 @@
 **Last updated:** 2026-03-30
 **Last reviewed:** 2026-03-30
 **Status:** Active
-**Workflow loops:** [{id: review-retry, from: 27, to: 24, max_iterations: 3, condition: "CI not green or unresolved comments"}]
+**Workflow loops:** [{id: review-retry, from: 28, to: 25, max_iterations: 3, condition: "CI not green or unresolved comments"}]
 **Task tags:** [evolve, sop, refactor-sop, improve-sop]
 
 ---
@@ -60,59 +60,66 @@ Alfred SOPs currently improve only through manual human-initiated sessions. This
 5. **Content analysis** — Read all SOPs via `af --root /path/to/fx_alfred list --type SOP --json`, then `af --root /path/to/fx_alfred read <ACID>` for each. Check for logic gaps, ambiguity, or drift vs COR-0002.
 6. **GitHub Issues** — `gh issue list --label agent-input --json number,title,body`. Record relevant issues.
 7. **Session logs** — Optional: scan Claude Code session history for SOP violation patterns. Skip if unavailable.
+8. **Experience-axis signals (optional)** — For each candidate target SOP, run a brief star-ladder exercise to surface friction the structural signals miss. Write a 1-line description for each rung:
+   - **1-star**: SOP is broken or causes the agent to take the wrong path.
+   - **5-star**: SOP as it currently reads — executable but mechanical.
+   - **7-star**: feasible magic — anticipates failure modes, includes recovery paths, gives clear gates.
+   - **11-star**: fantasy — the SOP plus tooling auto-detects intent and proposes fixes with zero operator burden.
+
+   Any 5→7 delta becomes a candidate signal (file path + proposed change + evidence). The 11-star rung is a discovery tool only — do NOT propose 11-star candidates. See FXA-2293 for full method. Skip this step if no target SOP feels experience-hostile.
 
 ### Phase 3: Generate candidates
 
-8. **Generator role** — Produce a list of improvement candidates based on signals collected. Each candidate must include: target SOP, proposed change, evidence source.
+9. **Generator role** — Produce a list of improvement candidates based on signals collected. Each candidate must include: target SOP, proposed change, evidence source.
 
 ### Phase 4: Evaluate candidates (Evaluator role)
 
-9. **Switch to Evaluator role** (skeptical by default). Score each candidate using Evolve-SOP weights from FXA-2146:
+10. **Switch to Evaluator role** (skeptical by default). Score each candidate using Evolve-SOP weights from FXA-2146:
    - Necessity 30% / Consistency 25% / Atomicity 20% / Actionability 15% / Impact 10%
-10. **Discard candidates scoring < 7.0**. Record scores and discards in the run log.
-11. **If no candidates pass** — update run log with "no-op: no candidate reached threshold", leave file as uncommitted working-tree file, exit.
+11. **Discard candidates scoring < 7.0**. Record scores and discards in the run log.
+12. **If no candidates pass** — update run log with "no-op: no candidate reached threshold", leave file as uncommitted working-tree file, exit.
 
 ### Phase 5: Implement (for each passing candidate)
 
-12. **Open GitHub issue** — `gh issue create --title "evolve: <change-title>" --label evolve`
-13. **Create branch** — `git checkout -b chore/<issue-number>-evolve-sop-YYYYMMDD`
-14. **Create PRP** — `af --root /path/to/fx_alfred create prp --prefix FXA --area 21 --title "<change-title>"`
-15. **Fill PRP** with candidate details (problem, proposed change, evidence).
-16. **Review PRP** — dispatch via `/trinity codex "Review PRP <ACID>" gemini "Review PRP <ACID>"`. Both must score >= 9.0. If either fails, revise PRP and re-dispatch following COR-1602 round rules.
-17. **Create CHG** — `af --root /path/to/fx_alfred create chg --prefix FXA --area 21 --title "<change-title>"`
-18. **Implement change** using Claude's built-in tools (Read, Write, Edit).
-19. **Hard gate** — `af --root /path/to/fx_alfred validate`. Must pass with 0 issues on modified documents. If it fails, fix and re-run.
-20. **Code review** — dispatch via `/trinity codex "Review CHG <ACID> implementation" gemini "Review CHG <ACID> implementation"`. Both must score >= 9.0. If either fails, revise and re-dispatch following COR-1602 round rules.
+13. **Open GitHub issue** — `gh issue create --title "evolve: <change-title>" --label evolve`
+14. **Create branch** — `git checkout -b chore/<issue-number>-evolve-sop-YYYYMMDD`
+15. **Create PRP** — `af --root /path/to/fx_alfred create prp --prefix FXA --area 21 --title "<change-title>"`
+16. **Fill PRP** with candidate details (problem, proposed change, evidence).
+17. **Review PRP** — dispatch via `/trinity codex "Review PRP <ACID>" gemini "Review PRP <ACID>"`. Both must score >= 9.0. If either fails, revise PRP and re-dispatch following COR-1602 round rules.
+18. **Create CHG** — `af --root /path/to/fx_alfred create chg --prefix FXA --area 21 --title "<change-title>"`
+19. **Implement change** using Claude's built-in tools (Read, Write, Edit).
+20. **Hard gate** — `af --root /path/to/fx_alfred validate`. Must pass with 0 issues on modified documents. If it fails, fix and re-run.
+21. **Code review** — dispatch via `/trinity codex "Review CHG <ACID> implementation" gemini "Review CHG <ACID> implementation"`. Both must score >= 9.0. If either fails, revise and re-dispatch following COR-1602 round rules.
 
 ### Phase 6: Git / PR
 
-21. **Commit changes** — stage modified/new files, `git commit`
-22. **Push branch** — `git push -u origin <branch>`
-23. **Open PR** — `gh pr create --title "evolve: <change-title>" --body "<run log summary: signals, scores, change>"` — body auto-populated from run log REF
+22. **Commit changes** — stage modified/new files, `git commit`
+23. **Push branch** — `git push -u origin <branch>`
+24. **Open PR** — `gh pr create --title "evolve: <change-title>" --body "<run log summary: signals, scores, change>"` — body auto-populated from run log REF
 
 ### Phase 7: Post-Push Review Loop
 
-> **Loop limit:** Steps 24–27 repeat at most **3 iterations** in total (counting both CI-wait retries and actionable-fix cycles). If the limit is reached, go to Step 28.
+> **Loop limit:** Steps 25–28 repeat at most **3 iterations** in total (counting both CI-wait retries and actionable-fix cycles). If the limit is reached, go to Step 29.
 
-24. **Wait for CI + automated reviews** — sleep 3 minutes after PR is opened (or after each fix-push), then:
+25. **Wait for CI + automated reviews** — sleep 3 minutes after PR is opened (or after each fix-push), then:
     ```bash
     gh pr checks <PR-number>
     gh api --paginate repos/{owner}/{repo}/pulls/<PR-number>/comments
     ```
-25. **Categorize each review comment:**
+26. **Categorize each review comment:**
     - **Actionable** — valid issue, fix it
     - **Advisory** — noted, no code change needed (reply explaining why)
     - **False positive** — reply with reasoning, no change
-26. **If actionable items exist:**
-    a. Fix the issues — fixes must be **mechanical** (doc wording, formatting, metadata). If a fix requires substantive content changes, stop the loop and re-run Phase 5 Step 20 (code review gate) instead.
+27. **If actionable items exist:**
+    a. Fix the issues — fixes must be **mechanical** (doc wording, formatting, metadata). If a fix requires substantive content changes, stop the loop and re-run Phase 5 Step 21 (code review gate) instead.
     b. Re-run hard gate (`af --root /path/to/fx_alfred validate` must pass with 0 issues on modified documents)
     c. Commit + push
-27. **Check CI** — if CI is not green and no fixes were pushed in Step 26, go to Step 24 (counts as one iteration). If fixes were pushed in Step 26, go to Step 24 (CI will re-run on the new push).
-28. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain, list them in the completion checklist for human review.
+28. **Check CI** — if CI is not green and no fixes were pushed in Step 27, go to Step 25 (counts as one iteration). If fixes were pushed in Step 27, go to Step 25 (CI will re-run on the new push).
+29. **Exit loop** when: CI passes AND 0 unresolved actionable comments, OR max iterations reached. If unresolved items remain, list them in the completion checklist for human review.
 
 ### Phase 8: Completion Checklist
 
-29. **Display checklist** — After all phases complete (or on early exit at Step 11), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
+30. **Display checklist** — After all phases complete (or on early exit at Step 12), print the following checklist with results filled in. Every item must show an explicit status — never omit silently.
 
 ```
 ## Evolve-SOP Run Checklist
@@ -152,10 +159,11 @@ claude -p "Follow the SOP at $(af --root /path/to/fx_alfred where FXA-2148)"
 
 ## Change History
 
-| Date       | Change                                                                                                           | By             |
-|------------|------------------------------------------------------------------------------------------------------------------|----------------|
-| 2026-03-30 | Initial version from FXA-2145 PRP (approved R9), CHG FXA-2147                                                    | Frank + Claude |
-| 2026-03-30 | D1: move gh issue create + git checkout to start of Phase 5 (before PRP); D3: fix af where identifier in example | Frank + Claude |
-| 2026-04-01 | CHG FXA-2174: Define "review gate" in Prohibited Actions                                                         | Claude Code    |
-| 2026-04-06 | CHG FXA-2110: Add Phase 7 Completion Checklist — mandatory post-run audit trail                                  | Frank + Claude |
-| 2026-04-06 | CHG FXA-2111: Add Phase 7 Post-Push Review Loop; renumber Checklist to Phase 8                                   | Frank + Claude |
+| Date       | Change                                                                                                                                                                                                                                                                           | By              |
+|------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| 2026-03-30 | Initial version from FXA-2145 PRP (approved R9), CHG FXA-2147                                                                                                                                                                                                                    | Frank + Claude  |
+| 2026-03-30 | D1: move gh issue create + git checkout to start of Phase 5 (before PRP); D3: fix af where identifier in example                                                                                                                                                                 | Frank + Claude  |
+| 2026-04-01 | CHG FXA-2174: Define "review gate" in Prohibited Actions                                                                                                                                                                                                                         | Claude Code     |
+| 2026-04-06 | CHG FXA-2110: Add Phase 7 Completion Checklist — mandatory post-run audit trail                                                                                                                                                                                                  | Frank + Claude  |
+| 2026-04-06 | CHG FXA-2111: Add Phase 7 Post-Push Review Loop; renumber Checklist to Phase 8                                                                                                                                                                                                   | Frank + Claude  |
+| 2026-05-17 | issue #183: insert §Phase 2 Step 8 — optional star-ladder exercise for experience-axis signals; cascade-renumber Phase 3+ steps 8–29 → 9–30 (+ workflow_loops `from: 27, to: 24` → `from: 28, to: 25`, 6 prose Step-N cross-refs); implements Option B from PRP-2293 (FXA-2293). | Claude Opus 4.7 |

--- a/rules/FXA-2178-PRP-Add-AF-Tool-Context-To-Review-Dispatch-Template.md
+++ b/rules/FXA-2178-PRP-Add-AF-Tool-Context-To-Review-Dispatch-Template.md
@@ -1,7 +1,7 @@
 # PRP-2178: Add-AF-Tool-Context-To-Review-Dispatch-Template
 
 **Applies to:** FXA project
-**Last updated:** 2026-04-01
+**Last updated:** 2026-05-17
 **Last reviewed:** 2026-04-01
 **Status:** Approved
 
@@ -23,6 +23,7 @@ Read these source files: <file list>
 ```
 It provides no guidance on project-specific tools needed to locate documents.
 
+
 ## Proposed Solution
 
 Add a **conditional** "Tool Context" guidance note to FXA-2100's Review Prompt Template section. This is a template example, not a mandatory inclusion — the dispatcher (Leader) decides whether to include it based on the review target.
@@ -42,17 +43,19 @@ Add a note after the template: "When dispatching reviews for projects with speci
 
 **Insertion semantics:** This is a template example showing the Leader how to provide tool context. It is NOT automatically appended to every dispatch. The Leader includes it when the review involves project-managed documents.
 
-**How this reaches FXA-2148/FXA-2149 dispatches:** FXA-2100 is the canonical Review Prompt Template for the FXA project. The evolve SOPs (FXA-2148 Step 16, FXA-2149 equivalent) instruct the Leader to "dispatch via `/trinity`" but do not define their own prompt template — the Leader composes each dispatch prompt at runtime, referencing FXA-2100's template as the base. By adding Tool Context guidance to FXA-2100, the Leader gains awareness of when and how to include it in ALL dispatch types (code reviews, PRP reviews, CHG reviews). FXA-2148/2149 are in the prohibited mutation surface and cannot be edited; this approach works through Leader behavior, not SOP text.
+**How this reaches FXA-2148/FXA-2149 dispatches:** FXA-2100 is the canonical Review Prompt Template for the FXA project. The evolve SOPs (FXA-2148 Step 17, FXA-2149 Step 17) instruct the Leader to "dispatch via `/trinity`" but do not define their own prompt template — the Leader composes each dispatch prompt at runtime, referencing FXA-2100's template as the base. By adding Tool Context guidance to FXA-2100, the Leader gains awareness of when and how to include it in ALL dispatch types (code reviews, PRP reviews, CHG reviews). FXA-2148/2149 are in the prohibited mutation surface and cannot be edited; this approach works through Leader behavior, not SOP text.
 
 **Files changed:** `rules/FXA-2100-SOP-Leader-Mediated-Development.md` only.
 
 **No SOPs affected** besides FXA-2100 itself. FXA-2148 and FXA-2149 are explicitly out of scope (prohibited mutation surface per FXA-2146).
+
 
 ## Risk
 
 - **False-positive guidance.** If the Tool Context block is included in dispatches for non-alfred_ops projects, reviewers may attempt to use `af` commands that don't apply. Mitigation: the block is marked `[OPTIONAL]` and the note explicitly says "omit for pure code reviews."
 - **Omission by dispatcher.** If the Leader forgets to include the block, reviewers fall back to filesystem search (current behavior). This is a graceful degradation, not a failure.
 - **Rollback.** Revert via `git checkout HEAD -- rules/FXA-2100-*.md`. No behavioral impact on existing workflows.
+
 
 ## Open Questions
 
@@ -62,8 +65,9 @@ None.
 
 ## Change History
 
-| Date | Change | By |
-|------|--------|----|
-| 2026-04-01 | Initial version | — |
-| 2026-04-01 | R1: Clarify conditional/optional semantics, add structured Risk section, define insertion semantics (Codex feedback) | Claude Code |
-| 2026-04-01 | R2: Explain how template reaches FXA-2148/2149 dispatches via Leader behavior, note prohibited mutation surface (Codex R1 feedback) | Claude Code |
+| Date       | Change                                                                                                                                                                                                                               | By              |
+|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| 2026-04-01 | Initial version                                                                                                                                                                                                                      | —               |
+| 2026-04-01 | R1: Clarify conditional/optional semantics, add structured Risk section, define insertion semantics (Codex feedback)                                                                                                                 | Claude Code     |
+| 2026-04-01 | R2: Explain how template reaches FXA-2148/2149 dispatches via Leader behavior, note prohibited mutation surface (Codex R1 feedback)                                                                                                  | Claude Code     |
+| 2026-05-17 | issue #183 follow-up: update "FXA-2148 Step 16, FXA-2149 equivalent" → "FXA-2148 Step 17, FXA-2149 Step 17" — propagate FXA-2148 cascade-renumber consequence (8→9 .. 29→30). Now both Evolve SOPs co-align at Step 17 = Review PRP. | Claude Opus 4.7 |

--- a/rules/FXA-2293-PRP-11-Star-SOP-Experience-Review.md
+++ b/rules/FXA-2293-PRP-11-Star-SOP-Experience-Review.md
@@ -1,0 +1,91 @@
+# PRP-2293: 11-Star SOP Experience Review
+
+**Applies to:** FXA project
+**Last updated:** 2026-05-17
+**Last reviewed:** 2026-05-17
+**Status:** Implemented
+
+---
+
+## What Is It?
+
+A proposal to add an experience-design review lens for Alfred SOPs, inspired by Airbnb's "11-star experience" exercise. The lens imagines an impossible-ideal execution experience for a target SOP, then works backward to feasible 6–8 star improvements that reduce friction, clarify execution, and strengthen failure recovery.
+
+This is **not** a proposal to implement an 11-star workflow. The 11-star step is a discovery tool; the deliverables it produces are ordinary inline-CHG edits routed through existing Alfred governance (`Evolve-SOP`, COR-1610 scoring, PRP/CHG lifecycle).
+
+---
+
+## Problem
+
+Alfred's existing SOP evolution machinery — `Evolve-SOP`, COR-1800 evolution philosophy, COR-1610 code-review scoring, `af validate` — answers "is this SOP **structurally correct**?" and "is the candidate change **scored above threshold**?" Neither answers "**is this SOP comfortable to execute**?"
+
+Empirical friction modes observed on Alfred SOPs that are structurally valid but operator/agent-hostile:
+
+- SOP is executable but requires too much implicit context (agent must reconstruct the unstated invariant).
+- First-step ambiguity — agent does not know where to enter.
+- Failure recovery paths are unclear or missing.
+- No worked examples / expected outputs / decision gates.
+- Composability with `af plan`, task tags, routing is left to the reader.
+
+These are real costs (every PR #164-style R-cascade has some component of "the SOP didn't tell me what good looks like"), but they don't surface in the current scoring rubrics because the rubrics are correctness-axis, not experience-axis.
+
+
+## Scope
+
+**In scope:**
+- A review *method* (set of questions / a star-ladder exercise) that an author or reviewer can apply to a target SOP before proposing changes.
+- Integration contract with `Evolve-SOP`: this method *produces candidates*; `Evolve-SOP` *scores and governs* them.
+- A decision among Options A/B/C below.
+
+**Out of scope (this PRP):**
+- Creating any new CLI command (`af experience-review` etc.).
+- Replacing or modifying `Evolve-SOP`'s scoring rubric.
+- Promoting any of this to the COR (PKG) layer. Future-extension discussion only.
+- Drafting the candidate SOP/REF documents themselves — that work follows the chosen option as inline CHGs.
+
+
+## Proposed Solution
+
+Three options. Decision is the primary deliverable of this PRP.
+
+### Option A — Add new SOP + REF pair (the brief's original shape)
+
+- New `FXA-22xx-REF-11-Star-Experience-Philosophy.md` (star ladder, principles).
+- New `FXA-22xx-SOP-11-Star-SOP-Experience-Review.md` (6-phase review procedure: guard checks → identify journey → build ladder → work backward → score candidates → route outcome).
+- Score rubric: friction reduction (25%) / failure recovery (20%) / actionability (20%) / composability (15%) / evidence (10%) / atomicity (10%).
+
+**Pros:** Discoverable as a named workflow; clean separation from `Evolve-SOP`.
+**Cons:** Adds two new docs and a new process surface. Risk of overlap with `Evolve-SOP` ("which one do I run?"). Increases agent decision burden — exactly the kind of meta-process accretion CLD-1800 compresses *away*.
+
+### Option B — Fold into Evolve-SOP as a new scoring dimension or pre-step
+
+- No new doc. Add an "Experience review" pre-candidate step in `Evolve-SOP` (or a new dimension in the existing rubric, e.g. "Execution comfort 15%").
+- Star-ladder exercise becomes an optional method, documented inline.
+
+**Pros:** No new surface; reuses existing governance. One front door for SOP improvement work.
+**Cons:** Star-ladder method gets buried inside an unrelated scoring doc. Less discoverable; harder to invoke as a stand-alone exercise.
+
+### Option C — Do nothing
+
+Document this PRP as Rejected with rationale: existing `Evolve-SOP` + COR-1610 + retrospective loops are sufficient; experience-axis friction is already captured indirectly via reviewer R-cascades.
+
+**Pros:** Zero new surface. Aligns with CLD-1800 compression-first philosophy.
+**Cons:** Leaves the structural-vs-experience axis gap unaddressed. Future authors continue to ship SOPs that pass `af validate` but operators struggle to execute.
+
+
+## Open Questions
+
+1. **Which option?** Author leans toward Option B (fold-in) over Option A (new SOP pair) to avoid meta-process accretion, but the brief originally proposed Option A. Needs operator input.
+2. **Is the experience-axis gap real and Alfred-local?** Brief cites general SOP-friction patterns. Need ≥ 1 concrete Alfred-local incident where the gap caused measurable cost (an R-cascade root-caused to "SOP didn't tell me what good looks like" rather than "code was wrong"). Without this, Option C is the COR-1800 / CLD-1800 default.
+3. **Author-side or reviewer-side?** Brief frames it as both ("author or reviewer"). These have different SOP homes (COR-1501 author-side, COR-1506 reviewer-side). Probably should pick one for the first iteration.
+4. **Relationship to #167** (COR-1501 §Quality Criteria, currently open)? #167 adds *author-side write-time targets* — overlaps Option B's "fold into Evolve-SOP". Worth resolving #167 first so this PRP can build on or supersede.
+5. **Filename ACID for Option A docs**: PRP currently uses `FXA-22xx` placeholder. If Option A is selected, replace with concrete next-available ACIDs at CHG-draft time (per #167 §Quality Criteria target 4: spec fully pre-committed).
+
+---
+
+## Change History
+
+| Date       | Change                                                                                                                                                      | By              |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------|
+| 2026-05-17 | Initial version — reshape ~/Downloads/20260517/alfred-11-star-sop-experience-review-issue.md from inline-CHG brief into PRP with Option A/B/C decision open | Claude Opus 4.7 |
+| 2026-05-17 | issue #183: Option B selected and implemented — star-ladder folded into FXA-2148 §Phase 2 Step 8 with cascade-renumber Phase 3+ 8–29 → 9–30. PRP closed.    | Claude Opus 4.7 |


### PR DESCRIPTION
## Summary

- Implements **PRP-2293 Option B** — folds the 11-star SOP experience-review lens into `FXA-2148-SOP-Evolve-SOP.md` as a new optional Step 8 in §Phase 2 (Collect signals). No new SOP, no new CLI, no new scoring axis.
- Cascade-renumbers Phase 3+ steps 8–29 → 9–30 (single global counter; necessary because the new Step 8 collides with Phase 3's prior `8. **Generator role**`). Updates 6 prose Step-N cross-refs + frontmatter `workflow_loops: from/to` accordingly.
- Flips PRP-2293 status `Draft → Implemented` and registers it in the FXA-0000 index.

## Plan amendment from issue body

Issue #183's verbatim Edit 1 patch produced a duplicate "Step 8" label because FXA-2148 uses a single global step counter (1-29 across all phases), and Phase 3's existing first step was already labeled `8.`. AC #3 self-contradicted on the renumbering question — first clause said "step numbers remain stable" but parenthetical said "Phase 3 starts at Step 9 = current Step 8".

This PR implements the parenthetical (cascading renumber). The trinity plan-review panel converged on the same fix:
- GLM: REVISE 8.18 (caught duplicate Step 8 collision as P1)
- DeepSeek: REVISE 7.00 (enumerated all ~12 cross-reference sites that needed updating, P0)
- MiniMax: PASS 9.50 (relied on a surface-grep that missed the structural collision)

DeepSeek's enumeration drove the comprehensive fix: 22 ordinal renumbers + 8 cross-ref updates + 1 frontmatter loop update + 4 doc edits (Step 8 insert, FXA-2148 Change History, FXA-2293 status flip, FXA-2293 Change History).

## Test plan

- [x] `af validate --root /Users/frank/Projects/alfred` → 0 issues across 282 documents
- [x] `af fmt FXA-2148 FXA-2293 --check` → already formatted
- [x] `.venv/bin/pytest -q` → 935 passed (incl. `test_workflow_loops.py` which exercises the workflow_loops metadata schema)
- [x] `.venv/bin/ruff check .` → clean
- [x] Manual visual scan of renumbered steps: 1-30 contiguous, no duplicates, no gaps
- [x] All Step-N cross-references in prose updated (Steps 11→12, 20→21, 24→25 ×2, 26→27 ×2, 27→28, 28→29)
- [x] frontmatter `workflow_loops` updated from `from: 27, to: 24` → `from: 28, to: 25`
- [x] PRP-2293 lifecycle: status `Draft → Implemented` (precedent: FXA-2104, FXA-2106, FXA-2116)
- [x] FXA-0000 index registers PRP-2293

## Scope hints

- Issue body's AC #3 self-contradiction (first clause vs parenthetical) is resolved by this PR in favor of the parenthetical. Reviewers may want to flag that the issue body itself should be updated to remove the contradicting first clause, but this is a PR-body comment, not a code change.
- Open Question #4 in PRP-2293 (overlap with issue #167 "COR-1501 §Quality Criteria") is now moot — issue #167 closed 2026-05-17T08:45:44Z prior to this PR. PRP-2293 §Open Questions was left as-authored (historical record); future authors reading the PRP can see #167 was resolved.
- Open Question #2 (Alfred-local evidence for the experience-axis gap) remains unresolved, acknowledged by the operator in the issue body as a known caveat. Acceptable for a P3 doc-only change with trivial revert; not blocking.
- The new Step 8 is **optional** — existing Evolve-SOP runs that don't surface experience-hostile SOPs will skip it with no behavior change.

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)