### PR TITLE
[Test]: Voyager v0.4.0 alfred Clearance canary

### DIFF
--- a/voyager-alfred-canary-v040-2026-05-24.md
+++ b/voyager-alfred-canary-v040-2026-05-24.md
@@ -1,0 +1,5 @@
+Voyager v0.4.0 alfred Clearance canary nominal.
+
+This temporary file exists only to exercise PR-opened Clearance routing on
+frankyxhl/alfred. The canary PR must be closed without merging after
+verification.


### PR DESCRIPTION
## Purpose
Temporary Voyager v0.4.0 canary to verify Clearance routing on `frankyxhl/alfred`.

Refs #186.

## Scope
- Adds one temporary canary markdown file.
- Does not change production behavior.
- Must be closed without merging after verification.

## Expected Verification
- Clearance writes a readiness comment.
- Clearance applies a `clearance-*` label.
