### PR TITLE
release: v1.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@
 
 Alfred is a CLI-based agent runbook (`af`) that manages SOPs, workflows, and structured documents across three layers (PKG, USR, PRJ). It provides:
 
-- **NEW in v1.18.0** — `af issue lint <body-file>` Phase 1 MVP — pre-creation lint for GitHub issue bodies; detects TBD-after-PR-review anti-patterns (5 canonical phrases, case-insensitive substring match) with `--json` output and `-` stdin support. Plus PKG SOP additions: [Two-Worker TDD Dispatch (PRP-1507)](src/fx_alfred/rules/COR-1507-PRP-Two-Worker-TDD-Dispatch.md) opt-in cross-validation pattern (new `<test-writer-worker-agent>` parameter in COR-1622, dispatch contract in COR-1619, Worker-assignment rule in COR-1500); [COR-1620 Primitive 5](src/fx_alfred/rules/COR-1620-SOP-Self-Pacing-Loop-Primitives.md) Status-Communication Contract forbidding silent wake-and-yield; [COR-1501 §Quality Criteria](src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md) author-side write-time targets; COR-1617/COR-1618 reconciled on loop-start triggers.
+- **NEW in v1.19.0** — Project-root auto-discovery: every command now resolves the nearest ancestor directory whose `rules/` contains Alfred documents, so `af` works from any project subdirectory without `--root` (explicit `--root` still wins). `af plan` no longer silently drops steps: section extraction and step rendering are now fence-aware (bash comments and numbered lines inside code blocks are body content, not boundaries or steps) — 10 bundled/user SOPs were affected. `af validate` warns on unknown document TYPE codes instead of silently skipping type-specific checks (`--json` gains an additive `warnings` field). All `--json` output is now uniformly indented UTF-8 (CJK content renders as written instead of `\uXXXX` escapes). CI now tests Python 3.10/3.12/3.14 with pyright and format gates.
+- **v1.18.0** — `af issue lint <body-file>` Phase 1 MVP — pre-creation lint for GitHub issue bodies; detects TBD-after-PR-review anti-patterns (5 canonical phrases, case-insensitive substring match) with `--json` output and `-` stdin support. Plus PKG SOP additions: [Two-Worker TDD Dispatch (PRP-1507)](src/fx_alfred/rules/COR-1507-PRP-Two-Worker-TDD-Dispatch.md) opt-in cross-validation pattern (new `<test-writer-worker-agent>` parameter in COR-1622, dispatch contract in COR-1619, Worker-assignment rule in COR-1500); [COR-1620 Primitive 5](src/fx_alfred/rules/COR-1620-SOP-Self-Pacing-Loop-Primitives.md) Status-Communication Contract forbidding silent wake-and-yield; [COR-1501 §Quality Criteria](src/fx_alfred/rules/COR-1501-SOP-Create-GitHub-Issue.md) author-side write-time targets; COR-1617/COR-1618 reconciled on loop-start triggers.
 - **v1.17.1** — PRJ-layer documentation: FXA-1623 review thread watchdog, FXA-2285 pre-merge bot sweep gate, review-loop refinements (COR-1602/1612/1615).
 - **v1.17.0** — [PR Review Thread Verification (COR-1623)](src/fx_alfred/rules/COR-1623-SOP-PR-Review-Thread-Verification.md) audits unresolved GitHub PR review threads against exact source content at the PR head SHA; [Review GitHub Issue Quality (COR-1506)](src/fx_alfred/rules/COR-1506-SOP-Review-GitHub-Issue-Quality.md) scores `blueprint-ready` issues with a weighted implementation-readiness rubric.
 - **v1.16.0** — [Build Weighted Decision Matrix (COR-1802)](src/fx_alfred/rules/COR-1802-SOP-Build-Weighted-Decision-Matrix.md) codifies rubric design and calibration; COR-1200 gained retrospective scoring; COR-1617 added Phase 11 Retrospective; COR-1622 added resilience parameters.
@@ -34,7 +35,7 @@ Alfred is a CLI-based agent runbook (`af`) that manages SOPs, workflows, and str
 - **Workflow Routing** — `af guide` tells AI agents which SOP to follow for any task
 - **Workflow Checklists** — `af plan` generates step-by-step checklists from SOPs. With `--task "<description>"` auto-composes the SOP set from tags; `--todo` flattens into a unified checklist; `--graph` renders ASCII + Mermaid flowcharts with intra-SOP loops and gates; `--with-skills` recommends matching skill docs
 - **Agent Helpers & Skills** — `af agent` runs explicitly gated local Python helpers/scripts, while `af skill` discovers and reads reusable REF/SOP skill documents without executing code
-- **Document Validation** — `af validate` enforces metadata format, status values, and section structure
+- **Document Validation** — `af validate` enforces metadata format, status values, and section structure; warns on unknown TYPE codes
 - **Document Formatting** — `af fmt` normalizes metadata order, whitespace, and table alignment to canonical style
 - **File Path Lookup** — `af where` prints the absolute filesystem path of any document by identifier
 - **Document Lifecycle** — Create, read, update, search, and index documents with consistent naming
@@ -167,10 +168,12 @@ Unknown markers fail because pytest runs with `--strict-markers`.
 
 ### Document Validation (`af validate`)
 
-Enforces document health across all layers:
+Enforces document health across all layers (H1 format, required metadata,
+status values, Change History, SOP sections, layer rules). Unknown TYPE
+codes emit a warning — type-specific checks are skipped but never silently:
 
 ```bash
-af validate --root /path/to/project
+af validate --root /path/to/project   # --root optional: nearest project root is auto-discovered
 ```
 
 Checks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "fx-alfred"
-version = "1.18.0"
+version = "1.19.0"
 description = "Alfred — Agent Runbook: workflow routing, SOP checklists, and document management for AI agents"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## v1.19.0 (2026-06-11)
+
+Quality-and-correctness release: nine reviewed PRs (#190–#198) clearing the
+2026-06-10 full-project review backlog. Every change passed a three-model
+review panel (30 verdicts, all >= 9.0) plus per-PR bot review.
+
+### New Features
+
+- **Project-root auto-discovery** — when `--root` is absent, every command
+  resolves the nearest ancestor directory whose `rules/` contains Alfred
+  documents (non-COR), falling back to the working directory exactly as
+  before. Run `af` from any project subdirectory. Explicit `--root` always
+  wins. (FXA-2300, #196)
+- **`af validate` unknown-TYPE warnings** — a filename TYPE code outside the
+  known set (SOP/PRP/CHG/ADR/REF/PLN/INC) now emits a per-document warning
+  instead of silently skipping Status and type-specific checks. Text mode
+  prints `~`-prefixed lines and the summary appends `, N warning(s)`; `--json`
+  results gain an additive `warnings` array. Warnings never affect the exit
+  code. (FXA-2296, #192)
+
+### Bug Fixes
+
+- **`af plan` silently dropped steps** — `extract_section` terminated
+  sections at `#`-prefixed lines inside fenced code blocks (e.g. bash
+  comments), truncating the Steps sections of 10 bundled/user SOPs
+  (COR-1612 rendered 1 of 8 authored steps). Section boundary detection is
+  now fence-aware. (FXA-2294, #190)
+- **Step renderers counted body lines as steps** — with sections no longer
+  truncated, nested numbered lists and fenced numbered lines could inflate
+  checklists (COR-1612: 21 items for 8 steps, duplicate indices). Renderers
+  now apply flush-left + fence-aware + heading-form-preference discipline;
+  validation stays permissive so loop/branch references keep resolving.
+  (FXA-2294 R2, #190)
+- **CJK content escaped in `--json`** — `af list/read/status` emitted
+  `ensure_ascii` JSON, turning Chinese document content into `\uXXXX`
+  escapes. All command JSON now goes through one emitter: indented,
+  raw UTF-8. (FXA-2301, #197)
+
+### Improvements
+
+- **CI matrix + type/format gates** — tests now run on Python 3.10, 3.12,
+  and 3.14 (the `requires-python >= 3.10` claim was previously untested);
+  `pyright` and `ruff format --check` are CI-enforced. (FXA-2298, #194)
+- **`core/` is now enforceably framework-agnostic** — `compose.py` (the lone
+  violator) raises domain `CompositionError` instead of `ClickException`;
+  an architecture guard test forbids Click imports under `core/` forever.
+  (FXA-2295, #191)
+- **Fence tracking has one implementation** — five inline CommonMark fence
+  loops consolidated onto `parser.iter_lines_with_fence_state`, guarded by
+  a fingerprint test. (FXA-2294/2299, #190/#195)
+- **`plan_cmd` decomposed** — the 376-line main function is now 76 lines of
+  orchestration over 8 named functions; duplicate todo builders merged onto
+  one classification path; an AST ratchet caps command-function length
+  (pre-existing oversized functions pinned shrink-only). Verified
+  byte-identical CLI output across 7 modes. (FXA-2302, #198)
+- **Unified JSON/exit conventions** — one `emit_json` helper, named
+  `SCHEMA_VERSION` constants, `ctx.exit` everywhere; three architecture
+  guards keep the conventions enforced. (FXA-2301, #197)
+- **Agent runbook refreshed with drift guards** — project CLAUDE.md caught
+  up (6 undocumented commands, 19 missing modules, broken smoke paths);
+  `tests/test_docs_drift.py` pins the command list and module inventory to
+  the code. (FXA-2297, #193)
+
+### Stats
+
+- 1000 tests (65 new), all passing on 3.10/3.12/3.14
+- 11 permanent architecture/drift guard tests added
+- 0 breaking changes (CLI surface unchanged; JSON additions are additive;
+  `core.compose` consumers: `CompositionError` replaces `ClickException`)
+
+### Install / Upgrade
+
+```bash
+pip install fx-alfred==1.19.0       # install specific version
+pipx install fx-alfred              # first install
+pipx upgrade fx-alfred              # upgrade existing
+```
+
 ## v1.18.0 (2026-05-17)
 
 Minor release introducing one new CLI subcommand (`af issue lint`) plus a


### PR DESCRIPTION
## release: v1.19.0

Per FXA-2102 (Release To PyPI) Step 1–2: readiness verified (1000 tests green on main; ruff/pyright/`af validate` clean) and README updated per FXA-2136 (What's New entry, validate feature description, auto-discovery note).

### Contents

Quality-and-correctness release clearing the **2026-06-10 full-project review backlog** — nine reviewed PRs (#190–#198), 30 trinity panel verdicts all ≥ 9.0, zero blocking findings shipped.

**New Features**
- Project-root auto-discovery (`--root` now optional from any project subdirectory) — FXA-2300
- `af validate` unknown-TYPE warnings + additive JSON `warnings` field — FXA-2296

**Bug Fixes**
- `af plan` silently dropped steps (fence-blind section extraction; 10 SOPs affected, COR-1612 rendered 1/8 steps) — FXA-2294
- Step renderers counted nested/fenced numbered lines as steps — FXA-2294 R2
- CJK content escaped to `\uXXXX` in `list/read/status --json` — FXA-2301

**Improvements**
- CI matrix 3.10/3.12/3.14 + pyright/format gates — FXA-2298
- core/ enforceably Click-free (`CompositionError`) — FXA-2295
- Fence tracking single-implementation — FXA-2294/2299
- plan_cmd decomposition (376→76) + function-length ratchet — FXA-2302
- Unified JSON emission / schema constants / exit idioms — FXA-2301
- Agent runbook refresh + docs drift guards — FXA-2297

**Stats**: 1000 tests (65 new) on three Python versions; 11 permanent guards; 0 breaking changes.

### After merge (FXA-2102 Steps 3–7)

`gh release create v1.19.0` with the template notes → GitHub Actions test → build → publish to PyPI → verify → mark the nine CHGs (FXA-2294…2302) Completed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
