### PR TITLE
docs(cor): mark COR-1617 cluster optional-overlay

### DIFF
--- a/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
+++ b/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
@@ -5,7 +5,7 @@
 **Last reviewed:** 2026-05-17
 **Status:** Active
 **Related:** COR-1602 (Multi Model Parallel Review — composes for plan-review and code-review panels), COR-1615 (GitHub App PR Review Bot Loop — composes for §8 bot polling), COR-1618 (consent auto-pick), COR-1619 (worker dispatch), COR-1620 (loop primitives), COR-1621 (triage), COR-1505 (branch + identity hygiene), COR-1104 (CHG sizing), COR-1622 (parameter schema), COR-1506 (issue quality gate — Phase 1 autonomous picks)
-**Disposition:** inherit-only
+**Disposition:** optional-overlay
 
 ---
 

--- a/src/fx_alfred/rules/COR-1618-SOP-Out-of-Band-Consent-Auto-Pick.md
+++ b/src/fx_alfred/rules/COR-1618-SOP-Out-of-Band-Consent-Auto-Pick.md
@@ -5,7 +5,7 @@
 **Last reviewed:** 2026-05-17
 **Status:** Active
 **Related:** COR-1617 (umbrella), COR-1622 (parameter schema — `<consent-signal>`, `<repo-trusted-reactor-list>`, `<intake-quality-mode>`, `<intake-quality-label>`, `<intake-quality-applier-set>`, `<repo>`)
-**Disposition:** inherit-only
+**Disposition:** optional-overlay
 
 ---
 

--- a/src/fx_alfred/rules/COR-1619-SOP-Orchestrator-vs-Worker-Dispatch.md
+++ b/src/fx_alfred/rules/COR-1619-SOP-Orchestrator-vs-Worker-Dispatch.md
@@ -5,7 +5,7 @@
 **Last reviewed:** 2026-05-17
 **Status:** Active
 **Related:** COR-1617 (umbrella), COR-1622 (parameter schema — `<worker-agent>`, `<worker-min-loc>`)
-**Disposition:** inherit-only
+**Disposition:** optional-overlay
 
 ---
 

--- a/src/fx_alfred/rules/COR-1620-SOP-Self-Pacing-Loop-Primitives.md
+++ b/src/fx_alfred/rules/COR-1620-SOP-Self-Pacing-Loop-Primitives.md
@@ -5,7 +5,7 @@
 **Last reviewed:** 2026-05-17
 **Status:** Active
 **Related:** COR-1617 (umbrella; uses these primitives in §1 idle-with-retry, §8 iterate, §10 merge-watch, §12 loop restart; §11 retrospective is synchronous — no primitive needed), COR-1622 (parameter schema — `<wakeup-tool>`, `<idle-cap>`, `<merge-watch-cap>`)
-**Disposition:** inherit-only
+**Disposition:** optional-overlay
 
 ---
 

--- a/src/fx_alfred/rules/COR-1621-SOP-Multi-Reviewer-Triage-and-Severity.md
+++ b/src/fx_alfred/rules/COR-1621-SOP-Multi-Reviewer-Triage-and-Severity.md
@@ -5,7 +5,7 @@
 **Last reviewed:** 2026-05-09
 **Status:** Active
 **Related:** COR-1602 (Multi Model Parallel Review — composes), COR-1615 (GitHub App PR Review Bot Loop — feeds), COR-1617 (umbrella; phase 9), COR-1622 (parameter schema — `<panel-providers>`, `<panel-pass-threshold>`)
-**Disposition:** inherit-only
+**Disposition:** optional-overlay
 
 ---
 


### PR DESCRIPTION
Follow-up to #211 / #205 review.

## Summary

- Reclassifies the COR-1617 multi-agent loop cluster from `inherit-only` to `optional-overlay`.
- Scope is limited to `COR-1617`, `COR-1618`, `COR-1619`, `COR-1620`, and `COR-1621`.
- Leaves routing docs (`COR-1103`, `COR-1607`) as `inherit-only` because PRJ routing supplements the routing layer rather than declaring an `Overlays:` binding.
- Leaves `COR-1622` as `mandatory-bind` because projects instantiate its schema.

## Rationale

TRN-1008 retains a Trinity-specific overlay that consumes the PKG multi-agent loop cluster. Under the binding semantics added in #210, future `Overlays:` targets must be `optional-overlay`; leaving these five docs as `inherit-only` would make a legitimate TRN-1008 overlay look like over-localization.

## Verification

- `af validate --root .`: 293 documents checked, 0 issues found.
- `.venv/bin/pytest -v --tb=short`: 1060 passed.
- `git diff --check`: clean.

Refs #205.