### PR TITLE
[Task]: Support multi-target localization bindings (Refs #208)

### DIFF
--- a/src/fx_alfred/commands/validate_cmd.py
+++ b/src/fx_alfred/commands/validate_cmd.py
@@ -137,12 +137,16 @@ def _validate_binding_field(
 ) -> list[str]:
     """Validate a PRJ/USR binding field against its PKG COR target."""
     issues: list[str] = []
-    target_id = raw_value.strip()
+    target_ids = [part.strip() for part in raw_value.split(",")]
 
-    if not re.match(COR_REFERENCE_PATTERN, target_id):
+    if any(
+        not target_id or not re.match(COR_REFERENCE_PATTERN, target_id)
+        for target_id in target_ids
+    ):
         issues.append(
-            f"Invalid {field_name} value '{target_id}' — "
-            "must match COR-NNNN format (e.g. COR-1622)"
+            f"Invalid {field_name} value '{raw_value.strip()}' — "
+            "must be a comma-separated list of COR-NNNN values "
+            "(e.g. COR-1622, COR-1623)"
         )
         return issues
 
@@ -150,20 +154,21 @@ def _validate_binding_field(
         issues.append(f"{field_name} field is only allowed on PRJ/USR documents")
         return issues
 
-    if target_id not in cor_dispositions:
-        issues.append(
-            f"{field_name} target '{target_id}' does not exist in PKG COR documents"
-        )
-        return issues
+    for target_id in target_ids:
+        if target_id not in cor_dispositions:
+            issues.append(
+                f"{field_name} target '{target_id}' does not exist in PKG COR documents"
+            )
+            continue
 
-    target_disposition = cor_dispositions[target_id]
-    if target_disposition is None:
-        issues.append(f"{field_name} target '{target_id}' has no Disposition value")
-    elif target_disposition != expected_disposition:
-        issues.append(
-            f"{field_name} target '{target_id}' has Disposition "
-            f"'{target_disposition}' (expected '{expected_disposition}')"
-        )
+        target_disposition = cor_dispositions[target_id]
+        if target_disposition is None:
+            issues.append(f"{field_name} target '{target_id}' has no Disposition value")
+        elif target_disposition != expected_disposition:
+            issues.append(
+                f"{field_name} target '{target_id}' has Disposition "
+                f"'{target_disposition}' (expected '{expected_disposition}')"
+            )
     return issues
 
 

--- a/src/fx_alfred/rules/COR-0002-REF-Document-Format-Contract.md
+++ b/src/fx_alfred/rules/COR-0002-REF-Document-Format-Contract.md
@@ -1,7 +1,7 @@
 # REF-0002: Document Format Contract
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-06-14
+**Last updated:** 2026-06-15
 **Last reviewed:** 2026-03-20
 **Status:** Active
 **Disposition:** inherit-only
@@ -113,8 +113,8 @@ The `**Instantiates:**` and `**Overlays:**` fields appear on PRJ-layer or USR-la
 
 | Field | Meaning | Format |
 |-------|---------|--------|
-| `**Instantiates:** COR-NNNN` | Required localization of the referenced COR doc. Used when the COR doc has `**Disposition:** mandatory-bind`. | `COR-NNNN` |
-| `**Overlays:** COR-NNNN` | Optional customization of the referenced COR doc. Used when the COR doc has `**Disposition:** optional-overlay`. | `COR-NNNN` |
+| `**Instantiates:** COR-NNNN[, COR-NNNN...]` | Required localization of the referenced COR doc(s). Used when every referenced COR doc has `**Disposition:** mandatory-bind`. | Comma-separated `COR-NNNN` references |
+| `**Overlays:** COR-NNNN[, COR-NNNN...]` | Optional customization of the referenced COR doc(s). Used when every referenced COR doc has `**Disposition:** optional-overlay`. | Comma-separated `COR-NNNN` references |
 
 ### Layer Applicability
 
@@ -125,6 +125,32 @@ The `**Disposition:**` field applies to COR (PKG-layer) documents only. The `**I
 All three fields are **optional** for documents created before the adoption of this specification. Documents created after this specification is adopted MUST include the relevant field when the document participates in the localization governance model — i.e., COR docs declare `**Disposition:**`, and PRJ/USR docs that localize a COR doc declare `**Instantiates:**` or `**Overlays:**`. Existing documents are never required to add these fields retroactively.
 
 Section-level disposition is out of scope for v1; `**Disposition:**` applies to the whole COR document.
+
+### Disposition Change Procedure
+
+A change to a COR document's `**Disposition:**` is a COR-layer governance change, not a local cleanup. Use the standard CHG path for a reclassification whose semantics are already clear. Start with a PRP when the change also redesigns the localization model, changes validation behavior, or redefines what downstream projects must own.
+
+Procedure:
+
+1. Identify the COR document and proposed transition (`inherit-only`, `optional-overlay`, or `mandatory-bind`).
+2. Record the rationale in the governing CHG or PRP, including why the old disposition is no longer correct.
+3. Update the COR document's `**Disposition:**`, `**Last updated:**`, and `## Change History`.
+4. Audit known PRJ/USR adopters with `af validate --root <repo>` and by searching their `rules/` docs for the COR id.
+5. Reconcile downstream binding fields:
+   - `mandatory-bind` targets use `**Instantiates:**`.
+   - `optional-overlay` targets use `**Overlays:**` only when the local doc adds substantive project-specific content.
+   - `inherit-only` targets must not be localized; downstream docs may cite them through `**Related:**` or prose only.
+6. Re-run `af validate --root <repo>` for each reconciled downstream repo before closing the CHG/PRP.
+
+Downstream implications:
+
+| Transition | Downstream action |
+|------------|-------------------|
+| `inherit-only` -> `optional-overlay` | Existing references remain valid. PRJ/USR projects may add `**Overlays:**` only for substantive local content. |
+| `optional-overlay` -> `inherit-only` | Remove or deprecate PRJ/USR overlays; replace with `**Related:**` references where needed. |
+| `optional-overlay` -> `mandatory-bind` | Convert valid overlays to `**Instantiates:**` and verify every required project-specific value is bound. |
+| `mandatory-bind` -> `optional-overlay` | Convert `**Instantiates:**` to `**Overlays:**` only where substantive local customization remains; otherwise remove the local document or keep a plain reference. |
+| Any -> any | `af validate` enforces binding-field correctness when fields are present. It does not discover every missing binding automatically, so the adopter audit is part of the procedure. |
 
 
 ---
@@ -139,3 +165,4 @@ Section-level disposition is out of scope for v1; `**Disposition:**` applies to 
 | 2026-04-05 | Added Workflow input/output/requires/provides optional fields (SOP only) per FXA-2204 | GLM |
 | 2026-04-26 | Added Section Rule 4 clarifying author-project ID attribution in Change History per FXA-2219 | Claude Code |
 | 2026-06-14 | Added Localization Governance Fields section with Disposition (mandatory-bind/optional-overlay/inherit-only), Instantiates/Overlays, USR-layer applicability, backward-compat rules, and v1 section-level out-of-scope note per COR-204 | Claude Code |
+| 2026-06-15 | Added comma-separated binding target format and Disposition Change Procedure with downstream audit requirements per issue #208. | Codex |

--- a/tests/test_validate_cmd.py
+++ b/tests/test_validate_cmd.py
@@ -2300,6 +2300,21 @@ def test_validate_instantiates_valid_target_disposition():
     )
 
 
+def test_validate_instantiates_accepts_multiple_mandatory_bind_targets():
+    """Instantiates accepts comma-separated mandatory-bind COR targets."""
+    parsed = _parsed_sop_doc("**Instantiates:** COR-1622, COR-1623\n")
+    doc = _governance_doc()
+
+    assert (
+        _validate_governance_fields(
+            doc,
+            parsed,
+            {"COR-1622": "mandatory-bind", "COR-1623": "mandatory-bind"},
+        )
+        == []
+    )
+
+
 def test_validate_instantiates_invalid_format(tmp_path):
     """Invalid Instantiates format should be reported as issue."""
     rules_dir = tmp_path / "rules"
@@ -2371,6 +2386,38 @@ def test_validate_overlays_valid_target_disposition():
         )
         == []
     )
+
+
+def test_validate_overlays_accepts_multiple_optional_overlay_targets():
+    """Overlays accepts comma-separated optional-overlay COR targets."""
+    parsed = _parsed_sop_doc("**Overlays:** COR-1617, COR-1618\n")
+    doc = _governance_doc()
+
+    assert (
+        _validate_governance_fields(
+            doc,
+            parsed,
+            {"COR-1617": "optional-overlay", "COR-1618": "optional-overlay"},
+        )
+        == []
+    )
+
+
+def test_validate_overlays_multiple_rejects_wrong_target_disposition():
+    """Every Overlays target must be optional-overlay, even in a list."""
+    parsed = _parsed_sop_doc("**Overlays:** COR-1617, COR-1622\n")
+    doc = _governance_doc()
+
+    issues = _validate_governance_fields(
+        doc,
+        parsed,
+        {"COR-1617": "optional-overlay", "COR-1622": "mandatory-bind"},
+    )
+
+    assert issues == [
+        "Overlays target 'COR-1622' has Disposition "
+        "'mandatory-bind' (expected 'optional-overlay')"
+    ]
 
 
 def test_validate_overlays_requires_optional_overlay_target():


### PR DESCRIPTION
## Summary

- Allow `Instantiates:` and `Overlays:` to contain comma-separated COR target lists.
- Keep per-target enforcement intact: each `Instantiates` target must be `mandatory-bind`; each `Overlays` target must be `optional-overlay`.
- Document the Disposition Change Procedure in COR-0002, including downstream audit requirements.

## Why

Issue #208 needs PRJ repos to record real localization bindings after COR disposition classification. Some valid PRJ docs, especially `TRN-1008`, overlay multiple COR optional-overlay docs, so the field format must express more than one target without weakening validation.

## Validation

- `.venv/bin/pytest -q tests/test_validate_cmd.py -k "governance or instantiates or overlays"`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/pytest -v --tb=short`
- `.venv/bin/af validate --root /Users/frank/Projects/alfred` (0 issues, existing FXA-2271 CTX warning only)
- `.venv/bin/af validate --root /Users/frank/Projects/trinity` (0 issues, using this branch's validator)
- `.venv/bin/af validate --root /Users/frank/Projects/claude-code-setup-208` (0 issues, using this branch's validator)

Refs frankyxhl/alfred#208
