### PR TITLE
feat(cor): COR-1508 Minimal Code Ladder — write-time minimal-code gate

### DIFF
--- a/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
+++ b/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
@@ -1,7 +1,7 @@
 # REF-0000: Document Index
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-05-09
+**Last updated:** 2026-06-19
 **Last reviewed:** 2026-05-09
 **Status:** Active
 **Disposition:** inherit-only
@@ -50,6 +50,8 @@ A reference index of all documents in the COR system.
 | 1504 | REF | Diagnose Phase Gates |
 | 1505 | SOP | Branch and Identity Hygiene |
 | 1506 | SOP | Review GitHub Issue Quality |
+| 1507 | PRP | Two-Worker TDD Dispatch |
+| 1508 | SOP | Minimal Code Ladder |
 | 1600 | SOP | Workflow — Direct Review Loop |
 | 1601 | SOP | Workflow — Leader Mediated Review Loop |
 | 1602 | SOP | Workflow — Multi Model Parallel Review |
@@ -106,3 +108,4 @@ A reference index of all documents in the COR system.
 | 2026-05-10 | Added COR-1802 (Build Weighted Decision Matrix) per CHG FXA-2281 (issue #135). | Claude Sonnet 4.6 |
 | 2026-05-10 | Added COR-1506 (Review GitHub Issue Quality) per issue #136. | Claude Sonnet 4.6 |
 | 2026-05-10 | Added COR-1623 (PR Review Thread Verification) per issue #142. | Claude Sonnet 4.6 |
+| 2026-06-19 | Added COR-1507 (Two-Worker TDD Dispatch — shipped earlier, index entry missed) and COR-1508 (Minimal Code Ladder — write-time minimal-code gate adapted from the Ponytail ruleset). | Claude Code |

--- a/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
+++ b/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
@@ -1,7 +1,7 @@
 # SOP-1103: Workflow Routing
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-05-07
+**Last updated:** 2026-06-19
 **Last reviewed:** 2026-05-05
 **Status:** Active
 **Related:** COR-1607 (deprecated, replaced by this document), COR-1614, COR-1616
@@ -132,6 +132,7 @@ like PRP, CHG, ADR, PLN, INC. Those match branches 2-6.
 ═══ OVERLAYS (apply after primary route) ═══
 
 • Code changes              → COR-1500 (TDD: RED → GREEN → REFACTOR)
+• Writing new code (inside GREEN / REFACTOR) → COR-1508 (Minimal Code Ladder: walk need-it? → stdlib → native → installed-dep → one-line → min-build before adding any abstraction, file, or dependency; safety floor is non-negotiable)
 • PRP approval              → COR-1602 strict (both reviewers >= 9)
 • New SOP/doc created       → Review via COR-1600 (Direct Review) at minimum
 • Before any multi-agent work → COR-1606 (select review or implementation workflow)
@@ -162,6 +163,7 @@ COR-1102: New capability/design → PRP; no implementation until COR-1602 strict
 COR-1606: Before any multi-agent work → select workflow (COR-1600–1605) based on task characteristics
 COR-1101: Existing system/config change → CHG with What, Why, Impact, Plan; Standard changes are pre-approved (no review)
 COR-1500: Code change → TDD overlay (RED→GREEN→REFACTOR) applied on top of selected workflow
+COR-1508: Writing new code → walk the Minimal Code Ladder (need-it? → stdlib → native → installed-dep → one-line → min-build) before adding any abstraction/file/dependency; the safety floor (validation, error handling, security, accessibility, tests) is non-negotiable
 COR-1100: Durable decision already made → ADR, write immediately
 PLN: Execution coordination for approved/in-progress work → PLN before starting multi-phase or multi-agent implementation
 COR-1300: Existing document edit → af update, update Last updated + Change History; never delete, deprecate instead (COR-1301)
@@ -256,3 +258,4 @@ To create a routing document, follow **COR-1004** (Create Routing Document).
 | 2026-05-05 | Add COR-1801 routing entries for PRJ-to-PKG pattern promotion. | Codex |
 | 2026-05-06 | Add COR-1614 routing entries for approved multi-phase continuous execution contracts. | Codex |
 | 2026-05-07 | Add COR-1616 routing entries (OVERLAY + Golden Rule) for Contract-First Delivery Workflow promoted from BAB-1503 per issue #106. | Claude Code |
+| 2026-06-19 | Add COR-1508 routing entries (OVERLAYS line + Golden Rule) for the Minimal Code Ladder write-time gate, adapted from the Ponytail ruleset. | Claude Code |

--- a/src/fx_alfred/rules/COR-1508-SOP-Minimal-Code-Ladder.md
+++ b/src/fx_alfred/rules/COR-1508-SOP-Minimal-Code-Ladder.md
@@ -1,0 +1,141 @@
+# SOP-1508: Minimal Code Ladder
+
+**Applies to:** All projects using the COR document system
+**Last updated:** 2026-06-19
+**Last reviewed:** 2026-06-19
+**Status:** Active
+**Related:** COR-1500 (TDD Development Workflow), COR-1800 (Evolution Philosophy), COR-1610 (Code Review Scoring), COR-1400 (Atomic SOP Principle)
+**Disposition:** optional-overlay
+**Workflow input:** task:routed
+**Workflow output:** code:minimal
+**Workflow provides:** minimal-code-ladder
+
+---
+
+## What Is It?
+
+A write-time gate that runs **before and during** the implementation step of any coding task. It forces the agent to walk a fixed decision ladder — cheapest option first — so the default outcome is *less code*, not more. The principle: the code you never wrote has zero bugs and zero CVEs and scales infinitely.
+
+It is the implementation-time counterpart of COR-1800 (Evolution Philosophy). COR-1800 compresses **structure** at evolve/audit time (`Fitness = same behavior / (LoC + doc words)`); this SOP compresses **new code** at the moment it is written. Same philosophy, different gate.
+
+**Scope (one atom):** this SOP is solely the *write-time ordering gate* — the ranked "reach for the cheaper option first" procedure. It does not re-implement COR-1500 GREEN ("write the minimum code to pass"), COR-1610's Simplicity dimension (review-time scoring), or COR-1800's compression metric (evolve-time structure). It is the missing piece those three assume but none specify: the explicit order in which an agent rules out cheaper options before writing. COR-1500 is `inherit-only`; COR-1508 only *references* it (via `Related:`) and does not overlay it — `optional-overlay` here means projects may overlay COR-1508 itself (see Project Overlay).
+
+Adapted from the open-source *Ponytail* ruleset (the "lazy senior developer" laziness ladder, https://github.com/DietrichGebert/ponytail), restated in COR terms and bound to the TDD workflow.
+
+---
+
+## Why
+
+AI coding agents default to *adding* — a new helper, a new abstraction, a new dependency, a speculative config layer — because adding looks like progress. The cost lands later: every line is a line to test, secure, review, and maintain. COR-1800 already prunes this at evolve time, but pruning after the fact is more expensive than not writing the code. This SOP moves the compression decision to the cheapest possible moment: before the line exists. Making "reach for the cheaper option first" an explicit, ordered gate turns minimalism from a vibe into a checkable procedure.
+
+---
+
+## When to Use
+
+- During the GREEN and REFACTOR phases of COR-1500 — every time the answer to "what code do I write?" is being decided.
+- Before introducing a new abstraction, helper, dependency, config layer, or file.
+- During code review (reviewer walks the ladder against the diff — see COR-1610 integration below).
+
+## When NOT to Use
+
+- For documents, SOPs, or non-code artefacts (those are governed by COR-1800 / COR-1400 atomicity).
+- As an excuse to skip required safety work — see the Safety Floor below. Minimalism never overrides correctness, security, validation, error handling, accessibility, or tests.
+
+---
+
+## Steps
+
+Walk these rungs **top to bottom** and stop at the first one that satisfies the requirement. Each rung must be ruled out before descending to the next.
+
+1. **Does this need to exist?** Can the requirement be deleted, deferred, or satisfied by existing behavior? (YAGNI) If yes, stop — write nothing.
+2. **Standard library.** Does the language's stdlib already do this? If yes, use it.
+3. **Native platform / framework feature.** Does the runtime, framework, or platform already provide it? If yes, use it.
+4. **Installed dependency.** Does a dependency already in the lockfile cover it? If yes, use it. No *new* dependency without ruling this out first.
+5. **One line / one expression.** Can it be a single expression instead of a new function, class, or file? If yes, write the one line.
+6. **Minimum viable build.** Only now: build the smallest thing that passes the test. No speculative generality, no "we might need it later."
+
+A new abstraction, file, or dependency introduced without explicitly clearing the rungs above it is a ladder violation and must be justified in the PR body or removed.
+
+---
+
+## Intensity Posture
+
+The agent declares the active posture at the start of the implementation step (per COR-1402). Posture is resolved in this order: (1) explicit user instruction for the task, (2) the repo's COR-1508 project overlay if one exists (see Project Overlay), (3) default **full**.
+
+| Posture | Behavior |
+|---------|----------|
+| `lite` | Apply rungs 1–2 as advisory nudges. No justification required. Use for prototypes / spikes. Deferrals are not logged. |
+| `full` *(default)* | Walk all 6 rungs. Any net-new abstraction, file, or dependency must be justified against the rung that was cleared to reach it. |
+| `ultra` | Walk all 6 rungs **and** require a deletion offset: any net-positive line count must be justified by necessity. (Borrows COR-1800's compression-ratio *definition* as a per-task heuristic; it does not invoke the evolve-time gate.) Record all deferrals as debt (below). |
+| `off` | Gate disabled. **User-authorized only** — an agent may not self-select `off`. Record the authorizing instruction in the task log. |
+
+---
+
+## Safety Floor (Hard, Non-Negotiable)
+
+Minimalism is bounded. The ladder must **never** be used to drop:
+
+- Input validation and boundary checks
+- Error and failure handling
+- Security controls (authz, authn, secret handling, injection defenses)
+- Accessibility requirements
+- The tests required by COR-1500
+
+"Fewer lines" that removes any of the above is not minimalism — it is a defect. Reviewers reject it.
+
+---
+
+## Deferred-Simplification Debt
+
+When the ladder identifies a simplification that cannot be made safely *right now* (e.g. it would require a larger refactor out of scope), record it rather than silently keeping the bigger code:
+
+- One line per deferral: `surface — what could be simpler — why deferred`.
+- Record in the task's working notes, or as a CHG when the simplification is a tracked structural change (COR-1101).
+- Logging by posture: `ultra` logs every deferral; `full` logs **material** deferrals only — a deferral is material if the simpler form would change the public surface or remove a whole abstraction/file/dependency (cosmetic line-count differences are not logged); `lite` and `off` do not log.
+
+---
+
+## Integration Points
+
+- **COR-1500 (TDD):** this gate runs *inside* GREEN ("write the minimum code to pass") and REFACTOR (rung 1 re-check: does this still need to exist?). The ladder is how "minimum" is operationalized.
+- **COR-1610 (Code Review Scoring):** the ladder *operationalizes* COR-1610's existing **Simplicity** dimension — it gives reviewers a concrete rule for scoring it: flag any new abstraction, file, or dependency that skipped a cheaper rung. It adds no new dimension; it makes the existing one checkable.
+- **COR-1800 (Evolution Philosophy):** ladder violations that already shipped become signal sources for the evolve loop's Compression-ratio and Scope-restraint dimensions.
+
+---
+
+## Examples
+
+**Task: "Add retry-with-backoff to the HTTP client."** (posture: `full`)
+
+- Rung 1 — needed? The flaky endpoint is third-party and out of our control, so yes.
+- Rung 2 — stdlib? No backoff in stdlib `http`.
+- Rung 3 — framework? The client wraps `httpx`; check if it ships retries. It does not by default.
+- Rung 4 — installed dependency? `tenacity` is already in the lockfile. ✅ **Stop here.** Decorate the call with `@tenacity.retry(...)` — three lines, no new code path, no new dependency.
+
+A naive agent would have written a custom retry loop with sleep, jitter, and a max-attempts counter (~30 lines, its own bug surface). The ladder cut it to a decorator.
+
+**Task: "Build a `UserProfileFormatterFactory` to render display names."** (posture: `ultra`)
+
+- Rung 1 — needed? The requirement is "show `First Last`, falling back to email." A factory is speculative generality. ✅ **Stop at rung 1.** This is one expression: `f"{u.first} {u.last}".strip() or u.email`. Record nothing as debt — there was nothing to defer.
+
+---
+
+## Project Overlay (optional)
+
+Projects MAY overlay this SOP (`**Overlays:** COR-1508`) to add substantive project-specific content, e.g.:
+
+- The project's standard-library / framework catalog of "things you should reach for before writing" (rungs 2–3).
+- The lockfile dependencies that count for rung 4.
+- The default intensity posture for the repo.
+
+A cosmetic restatement is not a valid overlay (per COR-0002 Disposition rules).
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-06-19 | Initial draft — adapts the Ponytail "laziness ladder" into a COR write-time gate bound to COR-1500; adds intensity postures, safety floor, deferred-debt log, and COR-1610/1800 integration points. | Claude Code |
+| 2026-06-19 | COR-1600 review round 1 (2 reviewers, both FIX): added one-atom scope disclaimer + inherit-only clarification; moved COR-1500 to Related (no illegal overlay); reframed COR-1610 integration as operationalizing the existing Simplicity dimension; clarified `ultra` borrows COR-1800's metric (not the evolve gate); made `off` user-authorized-only; made posture resolution deterministic; defined "material" deferral + lite/off logging; dropped dangling COR-1207 relation. | Claude Code |
+| 2026-06-19 | COR-1600 review round 2: both reviewers 9.0/10 PASS. Promoted Draft → Active. | Claude Code |


### PR DESCRIPTION
## What

Adds **COR-1508 — Minimal Code Ladder**, a new PKG/COR SOP that gives AI coding agents an explicit, ordered **write-time gate**: before writing any new abstraction, file, or dependency, walk a fixed "cheapest option first" ladder and stop at the first rung that satisfies the requirement.

```
1. Does this need to exist?     (YAGNI — write nothing)
2. Standard library?
3. Native platform / framework feature?
4. Installed dependency?         (no NEW dep without ruling this out)
5. One line / one expression?
6. Minimum viable build          (no speculative generality)
```

It is the implementation-time counterpart to **COR-1800** (which compresses *structure* at evolve/audit time). Same philosophy, different gate. Adapted from the open-source [Ponytail](https://github.com/DietrichGebert/ponytail) ruleset, restated in COR terms and bound to **COR-1500** (TDD).

Includes:
- **Intensity postures** `lite / full / ultra / off`, with a deterministic resolution order (user instruction → project overlay → default `full`); `off` is user-authorized-only.
- A **non-negotiable safety floor** — validation, error handling, security, accessibility, and COR-1500 tests are never traded for fewer lines.
- A **deferred-simplification debt log** with a concrete "material" bar.
- **Integration points** that *operationalize* COR-1610's existing Simplicity dimension (adds no new dimension) and feed COR-1800's evolve signals.

## Wiring

- **COR-1103 (Workflow Routing):** OVERLAYS line + Golden Rule, so `af guide` routes coding tasks to the ladder.
- **COR-0000 (Document Index):** add COR-1508; also **backfill COR-1507** (Two-Worker TDD Dispatch), whose index entry had been missed.

## Review

Reviewed via **COR-1600 Direct Review Loop**, two independent reviewers:
- Round 1: 8.75 and 8.5 → FIX (atomicity scope, COR-1610 framing, posture determinism, `off` actionability, COR-1800 boundary).
- Round 2 (after revision): **both 9.0/10 → PASS**. Status promoted Draft → Active.

`af validate` clean for all three docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)