### PR TITLE
docs(cor-1508): trim Minimal Code Ladder to follow its own ladder

### DIFF
--- a/src/fx_alfred/rules/COR-1508-SOP-Minimal-Code-Ladder.md
+++ b/src/fx_alfred/rules/COR-1508-SOP-Minimal-Code-Ladder.md
@@ -60,14 +60,14 @@ A new abstraction, file, or dependency introduced without explicitly clearing th
 
 ## Intensity Posture
 
-The agent declares the active posture at the start of the implementation step (per COR-1402). Posture is resolved in this order: (1) explicit user instruction for the task, (2) the repo's COR-1508 project overlay if one exists (see Project Overlay), (3) default **full**.
+The agent declares the active posture at the start of the implementation step (per COR-1402): default **full**, unless the user authorizes **off** for the task.
 
 | Posture | Behavior |
 |---------|----------|
-| `lite` | Apply rungs 1–2 as advisory nudges. No justification required. Use for prototypes / spikes. Deferrals are not logged. |
 | `full` *(default)* | Walk all 6 rungs. Any net-new abstraction, file, or dependency must be justified against the rung that was cleared to reach it. |
-| `ultra` | Walk all 6 rungs **and** require a deletion offset: any net-positive line count must be justified by necessity. (Borrows COR-1800's compression-ratio *definition* as a per-task heuristic; it does not invoke the evolve-time gate.) Record all deferrals as debt (below). |
 | `off` | Gate disabled. **User-authorized only** — an agent may not self-select `off`. Record the authorizing instruction in the task log. |
+
+A project overlay MAY re-introduce finer gradations (e.g. an advisory-only or a deletion-offset posture) if it demonstrates the need (see Project Overlay).
 
 ---
 
@@ -87,11 +87,7 @@ Minimalism is bounded. The ladder must **never** be used to drop:
 
 ## Deferred-Simplification Debt
 
-When the ladder identifies a simplification that cannot be made safely *right now* (e.g. it would require a larger refactor out of scope), record it rather than silently keeping the bigger code:
-
-- One line per deferral: `surface — what could be simpler — why deferred`.
-- Record in the task's working notes, or as a CHG when the simplification is a tracked structural change (COR-1101).
-- Logging by posture: `ultra` logs every deferral; `full` logs **material** deferrals only — a deferral is material if the simpler form would change the public surface or remove a whole abstraction/file/dependency (cosmetic line-count differences are not logged); `lite` and `off` do not log.
+When the ladder finds a simplification that cannot be made safely *right now* (e.g. it would require a larger refactor out of scope), record it rather than silently keeping the bigger code: one line per deferral (`surface — what could be simpler — why deferred`) in the task's working notes, or as a CHG (COR-1101) when the simplification is a tracked structural change.
 
 ---
 
@@ -114,7 +110,7 @@ When the ladder identifies a simplification that cannot be made safely *right no
 
 A naive agent would have written a custom retry loop with sleep, jitter, and a max-attempts counter (~30 lines, its own bug surface). The ladder cut it to a decorator.
 
-**Task: "Build a `UserProfileFormatterFactory` to render display names."** (posture: `ultra`)
+**Task: "Build a `UserProfileFormatterFactory` to render display names."** (posture: `full`)
 
 - Rung 1 — needed? The requirement is "show `First Last`, falling back to email." A factory is speculative generality. ✅ **Stop at rung 1.** This is one expression: `f"{u.first} {u.last}".strip() or u.email`. Record nothing as debt — there was nothing to defer.
 
@@ -139,3 +135,4 @@ A cosmetic restatement is not a valid overlay (per COR-0002 Disposition rules).
 | 2026-06-19 | Initial draft — adapts the Ponytail "laziness ladder" into a COR write-time gate bound to COR-1500; adds intensity postures, safety floor, deferred-debt log, and COR-1610/1800 integration points. | Claude Code |
 | 2026-06-19 | COR-1600 review round 1 (2 reviewers, both FIX): added one-atom scope disclaimer + inherit-only clarification; moved COR-1500 to Related (no illegal overlay); reframed COR-1610 integration as operationalizing the existing Simplicity dimension; clarified `ultra` borrows COR-1800's metric (not the evolve gate); made `off` user-authorized-only; made posture resolution deterministic; defined "material" deferral + lite/off logging; dropped dangling COR-1207 relation. | Claude Code |
 | 2026-06-19 | COR-1600 review round 2: both reviewers 9.0/10 PASS. Promoted Draft → Active. | Claude Code |
+| 2026-06-19 | Trim per #218 (make the minimal-code SOP minimal): Intensity Posture reduced to `full` (default) + `off` (user-authorized) — removed `lite`/`ultra` and the posture-resolution prose, deferring gradations to a project overlay; Deferred-Simplification Debt compressed to one line (dropped the per-posture material-deferral protocol); Examples `ultra`→`full` to keep the posture reference valid. | Claude Code |

--- a/src/fx_alfred/rules/COR-1508-SOP-Minimal-Code-Ladder.md
+++ b/src/fx_alfred/rules/COR-1508-SOP-Minimal-Code-Ladder.md
@@ -60,7 +60,7 @@ A new abstraction, file, or dependency introduced without explicitly clearing th
 
 ## Intensity Posture
 
-The agent declares the active posture at the start of the implementation step (per COR-1402): default **full**, unless the user authorizes **off** for the task.
+The agent declares the active posture at the start of the implementation step (per COR-1402): default **full**, unless the user authorizes **off** for the task (or a project overlay sets a different repo default — see Project Overlay).
 
 | Posture | Behavior |
 |---------|----------|
@@ -136,3 +136,4 @@ A cosmetic restatement is not a valid overlay (per COR-0002 Disposition rules).
 | 2026-06-19 | COR-1600 review round 1 (2 reviewers, both FIX): added one-atom scope disclaimer + inherit-only clarification; moved COR-1500 to Related (no illegal overlay); reframed COR-1610 integration as operationalizing the existing Simplicity dimension; clarified `ultra` borrows COR-1800's metric (not the evolve gate); made `off` user-authorized-only; made posture resolution deterministic; defined "material" deferral + lite/off logging; dropped dangling COR-1207 relation. | Claude Code |
 | 2026-06-19 | COR-1600 review round 2: both reviewers 9.0/10 PASS. Promoted Draft → Active. | Claude Code |
 | 2026-06-19 | Trim per #218 (make the minimal-code SOP minimal): Intensity Posture reduced to `full` (default) + `off` (user-authorized) — removed `lite`/`ultra` and the posture-resolution prose, deferring gradations to a project overlay; Deferred-Simplification Debt compressed to one line (dropped the per-posture material-deferral protocol); Examples `ultra`→`full` to keep the posture reference valid. | Claude Code |
+| 2026-06-19 | Trinity review round (DeepSeek 9.8, MiniMax 9.3, both PASS): adopted the shared advisory — co-located the overlay-default precedence pointer in the Intensity Posture paragraph. | Claude Code |


### PR DESCRIPTION
## What

Trims COR-1508 (Minimal Code Ladder) so the SOP about writing less code follows its own ladder. Two sections were speculative generality — the exact thing rungs 1 and 6 warn against.

- **Intensity Posture: 4 levels → 2.** Keep `full` (default) and `off` (user-authorized only). Removed `lite`/`ultra` and the posture-resolution-order prose; a one-line note defers finer gradations to a project overlay if one demonstrates need (the Project Overlay section already permits this).
- **Deferred-Simplification Debt: → one line.** Dropped the per-posture logging protocol and the "material deferral" definition; deferrals go to task working notes, or a CHG (COR-1101) when tracked.
- **Examples: `ultra` → `full`** so the posture reference stays valid after `ultra` was removed.

Core ladder (rungs 1–6), Safety Floor, COR-1500/1610/1800 integration, and Project Overlay are unchanged. No edits to COR-1500/1610/1800/1103.

## Honest delta

The issue estimated "~142 → ~90 lines"; that was over-optimistic. Actual is **142 → 138 lines, −52 words net**. The removed content was dense single-line prose, and the mandatory Change-History row adds ~45 words back. The real win is **conceptual surface**, not line count: two postures, a resolution algorithm, and a graduated debt protocol removed — fewer concepts to reason about, which is the point.

## Test

`pytest` 1106 passed; `af validate` clean (only the pre-existing unrelated CTX warning). No test pins COR-1508 content.

## Scope hints

Docs-only trim of one SOP. Flag only: dangling references to the removed `lite`/`ultra` postures, self-contradiction between the trimmed sections and the rest of the SOP, or correctness of the COR-1101/overlay pointers.

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
