### PR TITLE
feat(issue-lint): enforce COR-1501 blueprint structure, not just TBD-phrases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ rules/logs/
 
 # macOS
 .DS_Store
+
+# Stray agent/session transcripts
+transcript.jsonl

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ src/fx_alfred/
 │   ├── fmt_cmd.py      # format to canonical style (metadata order, whitespace, table align)
 │   ├── guide_cmd.py    # workflow routing (layered PKG→USR→PRJ)
 │   ├── index_cmd.py    # regenerate document index (COR-0002 compliant)
-│   ├── issue_cmd.py    # af issue lint (TBD-phrase detection)
+│   ├── issue_cmd.py    # af issue lint (TBD-phrase + COR-1501 blueprint-structure checks)
 │   ├── list_cmd.py     # list + filtering + --json
 │   ├── log_cmd.py          # Phase 0 scaffolding (CHG-2231) — NOT wired into cli.py
 │   ├── log_archive_cmd.py  # Phase 0 scaffolding (CHG-2231) — NOT wired into cli.py

--- a/src/fx_alfred/commands/issue_cmd.py
+++ b/src/fx_alfred/commands/issue_cmd.py
@@ -60,14 +60,18 @@ def _check_tbd_phrases(text: str) -> list[dict]:
 
 
 def _h2_headings(text: str) -> list[str]:
-    """Non-fenced ``## `` heading titles, in order (fence-aware)."""
+    """Non-fenced, column-0 ``## `` heading titles, in order (fence-aware).
+
+    The column-0 requirement matches ``extract_section``'s ``^##`` anchor, so a
+    heading counted "present" here is always extractable there — an indented
+    ``  ## Acceptance Criteria`` is treated as not-a-section by both.
+    """
     out: list[str] = []
     for line, fenced in iter_lines_with_fence_state(text):
         if fenced:
             continue
-        stripped = line.strip()
-        if stripped.startswith("## "):
-            out.append(stripped[3:].strip())
+        if line.startswith("## "):
+            out.append(line[3:].strip())
     return out
 
 
@@ -125,7 +129,7 @@ def _render(v: dict) -> str:
         return f"✗ Missing required section: ## {v['match']}"
     if rule == "no-acceptance-criteria":
         return f'✗ Section "## {v["match"]}" has no checkbox (- [ ]) item'
-    return f"✗ {rule}: {v['match']}"  # defensive; no current path reaches here
+    raise AssertionError(f"unknown violation rule: {rule}")
 
 
 @click.group(name="issue")
@@ -152,6 +156,11 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
 
     Reads from BODY_FILE or stdin if BODY_FILE is `-`.
     Exit 0 on PASS, 1 on FAIL.
+
+    Violation ordering: blueprint-structure violations (``missing-section``,
+    ``no-acceptance-criteria``; ``line: 0``) come first, then TBD-phrases by
+    line. The COR-1501 pointer is printed only when a structural violation is
+    present, so TBD-only output is identical to the pre-#219 behavior.
     """
     if body_file == "-":
         text = sys.stdin.read()
@@ -162,8 +171,8 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
         text = path.read_text(encoding="utf-8")
 
     # Structural violations first (overall shape), then TBD by line.
-    violations = _check_blueprint_structure(text, get_root(ctx))
-    violations += _check_tbd_phrases(text)
+    structural = _check_blueprint_structure(text, get_root(ctx))
+    violations = structural + _check_tbd_phrases(text)
 
     if as_json:
         emit_json(
@@ -179,7 +188,10 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
         click.echo()
         if violations:
             click.echo(f"Lint result: FAIL ({len(violations)} violations)")
-            click.echo(COR_1501_POINTER)
+            # Pointer only for structural fails — keeps TBD-only output
+            # byte-for-byte identical to pre-#219 behavior (AC#4).
+            if structural:
+                click.echo(COR_1501_POINTER)
         else:
             click.echo("Lint result: PASS (0 violations)")
 

--- a/src/fx_alfred/commands/issue_cmd.py
+++ b/src/fx_alfred/commands/issue_cmd.py
@@ -76,18 +76,24 @@ def _h2_headings(text: str) -> list[str]:
 
 
 def _find_blueprint(start: Path) -> Path | None:
-    """Nearest ``.github/ISSUE_TEMPLATE/blueprint.md`` at ``start`` or any
-    ancestor.
+    """Nearest ``.github/ISSUE_TEMPLATE/blueprint.md`` at ``start`` or an
+    ancestor, bounded to the current repository.
 
     Walking up (rather than checking only ``start``) means the check works
-    from a repo subdirectory and in repos that are not Alfred projects — where
+    from a repo subdirectory and in repos that are not Alfred projects, where
     ``get_root`` falls back to the cwd and the template lives further up
-    (PR #223 codex P2).
+    (PR #223 codex P2 #1). The walk stops at the repository boundary — the
+    first ancestor holding ``.git`` (a dir for normal checkouts, a file for
+    submodules/worktrees) — so a child repo without its own template never
+    picks up a parent repo's blueprint (codex P2 #2). The repo root's own
+    template is still considered before the walk stops there.
     """
     for directory in (start, *start.parents):
         candidate = directory / BLUEPRINT_REL
         if candidate.is_file():
             return candidate
+        if (directory / ".git").exists():
+            break  # repository boundary — do not cross into a parent repo
     return None
 
 

--- a/src/fx_alfred/commands/issue_cmd.py
+++ b/src/fx_alfred/commands/issue_cmd.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import click
 
 from fx_alfred.commands._helpers import emit_json
+from fx_alfred.context import get_root, root_option
+from fx_alfred.core.parser import extract_section, iter_lines_with_fence_state
 
 # Phase 1: TBD-phrase rule (same list as COR-1506 §Hard Cap Trigger B).
 # Order is significant — when two phrases appear on the same line, the one
@@ -19,6 +21,15 @@ TBD_PHRASES = [
     "exact spec to be drafted after reviewer pick",
     "to be decided in review",
 ]
+
+# Blueprint structural check (issue #219). The required-section contract is the
+# repo's own Iterwheel Blueprint template — NOT hardcoded here, because af ships
+# to many repos. COR-1501 names this file as the source of truth.
+BLUEPRINT_REL = Path(".github") / "ISSUE_TEMPLATE" / "blueprint.md"
+ACCEPTANCE_CRITERIA = "Acceptance Criteria"
+COR_1501_POINTER = (
+    "See COR-1501 (Create GitHub Issue) for the required blueprint structure."
+)
 
 
 def _check_tbd_phrases(text: str) -> list[dict]:
@@ -48,6 +59,75 @@ def _check_tbd_phrases(text: str) -> list[dict]:
     return violations
 
 
+def _h2_headings(text: str) -> list[str]:
+    """Non-fenced ``## `` heading titles, in order (fence-aware)."""
+    out: list[str] = []
+    for line, fenced in iter_lines_with_fence_state(text):
+        if fenced:
+            continue
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            out.append(stripped[3:].strip())
+    return out
+
+
+def _check_blueprint_structure(text: str, root: Path) -> list[dict]:
+    """Check the body against the repo's blueprint template.
+
+    Required sections are the template's ``## `` headings minus any ending in
+    ``(optional)``. Reports a ``missing-section`` violation per absent required
+    section, and a ``no-acceptance-criteria`` violation when the Acceptance
+    Criteria section exists but has no ``- [ ]`` checkbox. When the template is
+    absent the check is skipped (returns no violations).
+    """
+    template_path = root / BLUEPRINT_REL
+    if not template_path.is_file():
+        return []
+
+    required = [
+        h
+        for h in _h2_headings(template_path.read_text(encoding="utf-8"))
+        if not h.lower().endswith("(optional)")
+    ]
+    present = set(_h2_headings(text))
+
+    violations: list[dict] = []
+    for heading in required:
+        if heading not in present:
+            violations.append({"rule": "missing-section", "line": 0, "match": heading})
+
+    if ACCEPTANCE_CRITERIA in present:
+        section = extract_section(text, ACCEPTANCE_CRITERIA) or ""
+        # ponytail: only "- [ ]" counts as a checkbox; mirrors the blueprint
+        # bot's own check. Widen to "* [ ]"/indented forms only if a real
+        # issue body trips on it.
+        has_checkbox = any(
+            not fenced and line.strip().startswith("- [ ]")
+            for line, fenced in iter_lines_with_fence_state(section)
+        )
+        if not has_checkbox:
+            violations.append(
+                {
+                    "rule": "no-acceptance-criteria",
+                    "line": 0,
+                    "match": ACCEPTANCE_CRITERIA,
+                }
+            )
+    return violations
+
+
+def _render(v: dict) -> str:
+    """One-line text rendering for a violation dict."""
+    rule = v["rule"]
+    if rule == "tbd-phrase":
+        return f'✗ TBD-phrase detected at line {v["line"]}: "{v["match"]}"'
+    if rule == "missing-section":
+        return f"✗ Missing required section: ## {v['match']}"
+    if rule == "no-acceptance-criteria":
+        return f'✗ Section "## {v["match"]}" has no checkbox (- [ ]) item'
+    return f"✗ {rule}: {v['match']}"  # defensive; no current path reaches here
+
+
 @click.group(name="issue")
 def issue_cmd() -> None:
     """Issue body utilities (lint, ...)."""
@@ -59,11 +139,17 @@ def issue_cmd() -> None:
     type=click.Path(dir_okay=False, allow_dash=True),
 )
 @click.option("--json", "as_json", is_flag=True, help="Output violations as JSON.")
+@root_option
 @click.pass_context
 def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
     """Lint a GitHub issue body for known anti-patterns.
 
-    Phase 1: detects TBD-after-PR-review phrases (see #168 §Hard Cap Trigger B).
+    Checks (1) TBD-after-PR-review phrases and (2) the COR-1501 blueprint
+    structure — required ``## `` sections and a checkbox under
+    ``## Acceptance Criteria`` — derived from the repo's own
+    ``.github/ISSUE_TEMPLATE/blueprint.md`` (relative to --root). The
+    structural check is skipped when that template is absent.
+
     Reads from BODY_FILE or stdin if BODY_FILE is `-`.
     Exit 0 on PASS, 1 on FAIL.
     """
@@ -75,7 +161,9 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
             raise click.FileError(body_file, hint="No such file")
         text = path.read_text(encoding="utf-8")
 
-    violations = _check_tbd_phrases(text)
+    # Structural violations first (overall shape), then TBD by line.
+    violations = _check_blueprint_structure(text, get_root(ctx))
+    violations += _check_tbd_phrases(text)
 
     if as_json:
         emit_json(
@@ -87,10 +175,11 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
         )
     else:
         for v in violations:
-            click.echo(f'✗ TBD-phrase detected at line {v["line"]}: "{v["match"]}"')
+            click.echo(_render(v))
         click.echo()
         if violations:
             click.echo(f"Lint result: FAIL ({len(violations)} violations)")
+            click.echo(COR_1501_POINTER)
         else:
             click.echo("Lint result: PASS (0 violations)")
 

--- a/src/fx_alfred/commands/issue_cmd.py
+++ b/src/fx_alfred/commands/issue_cmd.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 
 from fx_alfred.commands._helpers import emit_json
-from fx_alfred.context import get_root, root_option
+from fx_alfred.context import root_option
 from fx_alfred.core.parser import extract_section, iter_lines_with_fence_state
 
 # Phase 1: TBD-phrase rule (same list as COR-1506 §Hard Cap Trigger B).
@@ -173,9 +173,10 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
     Checks (1) TBD-after-PR-review phrases and (2) the COR-1501 blueprint
     structure — required ``## `` sections and a checkbox under
     ``## Acceptance Criteria`` — derived from the repo's own
-    ``.github/ISSUE_TEMPLATE/blueprint.md``, searched at the resolved root
-    (--root or discovery) and every ancestor. The structural check is skipped
-    when no such template is found.
+    ``.github/ISSUE_TEMPLATE/blueprint.md``. The template is searched from the
+    invoking repo: explicit ``--root`` if given, else the body file's own
+    directory (cwd for stdin), walking up to the repository boundary. The
+    structural check is skipped when no such template is found.
 
     Reads from BODY_FILE or stdin if BODY_FILE is `-`.
     Exit 0 on PASS, 1 on FAIL.
@@ -193,8 +194,20 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
             raise click.FileError(body_file, hint="No such file")
         text = path.read_text(encoding="utf-8")
 
+    # Anchor the template search to the INVOKING repo, not the Alfred-doc root:
+    # discover_root walks past a child repo's .git to find a parent's rules/,
+    # which would borrow the parent's blueprint (codex P2 #3). Explicit --root
+    # wins; otherwise start at the body's own directory (cwd for stdin).
+    explicit_root = (ctx.find_root().obj or {}).get("root")
+    if explicit_root is not None:
+        search_start = Path(explicit_root)
+    elif body_file != "-":
+        search_start = Path(body_file).resolve().parent
+    else:
+        search_start = Path.cwd()
+
     # Structural violations first (overall shape), then TBD by line.
-    structural = _check_blueprint_structure(text, get_root(ctx))
+    structural = _check_blueprint_structure(text, search_start)
     violations = structural + _check_tbd_phrases(text)
 
     if as_json:

--- a/src/fx_alfred/commands/issue_cmd.py
+++ b/src/fx_alfred/commands/issue_cmd.py
@@ -174,9 +174,10 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
     structure — required ``## `` sections and a checkbox under
     ``## Acceptance Criteria`` — derived from the repo's own
     ``.github/ISSUE_TEMPLATE/blueprint.md``. The template is searched from the
-    invoking repo: explicit ``--root`` if given, else the body file's own
-    directory (cwd for stdin), walking up to the repository boundary. The
-    structural check is skipped when no such template is found.
+    invoking repo: explicit ``--root`` if given, else the current working
+    directory, walking up to the repository boundary. The structural check is
+    skipped when no such template is found; pass ``--root`` to lint a body
+    file that lives outside the invoking repo.
 
     Reads from BODY_FILE or stdin if BODY_FILE is `-`.
     Exit 0 on PASS, 1 on FAIL.
@@ -194,17 +195,13 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
             raise click.FileError(body_file, hint="No such file")
         text = path.read_text(encoding="utf-8")
 
-    # Anchor the template search to the INVOKING repo, not the Alfred-doc root:
-    # discover_root walks past a child repo's .git to find a parent's rules/,
-    # which would borrow the parent's blueprint (codex P2 #3). Explicit --root
-    # wins; otherwise start at the body's own directory (cwd for stdin).
+    # Anchor the template search to the INVOKING repo (cwd), not the Alfred-doc
+    # root (discover_root walks past a child repo's .git into a parent, codex
+    # P2 #3) and not the body file's dir (a body outside the repo, e.g.
+    # /tmp/body.md, would skip the check, codex P2 #4). Explicit --root wins;
+    # pass it to lint a body that lives outside the invoking repo.
     explicit_root = (ctx.find_root().obj or {}).get("root")
-    if explicit_root is not None:
-        search_start = Path(explicit_root)
-    elif body_file != "-":
-        search_start = Path(body_file).resolve().parent
-    else:
-        search_start = Path.cwd()
+    search_start = Path(explicit_root) if explicit_root is not None else Path.cwd()
 
     # Structural violations first (overall shape), then TBD by line.
     structural = _check_blueprint_structure(text, search_start)

--- a/src/fx_alfred/commands/issue_cmd.py
+++ b/src/fx_alfred/commands/issue_cmd.py
@@ -75,17 +75,33 @@ def _h2_headings(text: str) -> list[str]:
     return out
 
 
+def _find_blueprint(start: Path) -> Path | None:
+    """Nearest ``.github/ISSUE_TEMPLATE/blueprint.md`` at ``start`` or any
+    ancestor.
+
+    Walking up (rather than checking only ``start``) means the check works
+    from a repo subdirectory and in repos that are not Alfred projects — where
+    ``get_root`` falls back to the cwd and the template lives further up
+    (PR #223 codex P2).
+    """
+    for directory in (start, *start.parents):
+        candidate = directory / BLUEPRINT_REL
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _check_blueprint_structure(text: str, root: Path) -> list[dict]:
     """Check the body against the repo's blueprint template.
 
     Required sections are the template's ``## `` headings minus any ending in
     ``(optional)``. Reports a ``missing-section`` violation per absent required
     section, and a ``no-acceptance-criteria`` violation when the Acceptance
-    Criteria section exists but has no ``- [ ]`` checkbox. When the template is
-    absent the check is skipped (returns no violations).
+    Criteria section exists but has no ``- [ ]`` checkbox. When no template is
+    found at ``root`` or any ancestor the check is skipped (no violations).
     """
-    template_path = root / BLUEPRINT_REL
-    if not template_path.is_file():
+    template_path = _find_blueprint(root)
+    if template_path is None:
         return []
 
     required = [
@@ -151,8 +167,9 @@ def lint_cmd(ctx: click.Context, body_file: str, as_json: bool) -> None:
     Checks (1) TBD-after-PR-review phrases and (2) the COR-1501 blueprint
     structure — required ``## `` sections and a checkbox under
     ``## Acceptance Criteria`` — derived from the repo's own
-    ``.github/ISSUE_TEMPLATE/blueprint.md`` (relative to --root). The
-    structural check is skipped when that template is absent.
+    ``.github/ISSUE_TEMPLATE/blueprint.md``, searched at the resolved root
+    (--root or discovery) and every ancestor. The structural check is skipped
+    when no such template is found.
 
     Reads from BODY_FILE or stdin if BODY_FILE is `-`.
     Exit 0 on PASS, 1 on FAIL.

--- a/tests/commands/test_issue_lint_blueprint.py
+++ b/tests/commands/test_issue_lint_blueprint.py
@@ -1,0 +1,251 @@
+"""Tests for `af issue lint` blueprint structural check (issue #219).
+
+The check derives required sections from the repo's own
+``.github/ISSUE_TEMPLATE/blueprint.md`` (relative to the resolved --root) and
+flags bodies missing a required section or lacking a checkbox under
+``## Acceptance Criteria``. When the template is absent the check is skipped
+and only the TBD-phrase rule applies (byte-for-byte unchanged behavior).
+"""
+
+import json
+
+import pytest
+
+from click.testing import CliRunner
+from fx_alfred.cli import cli
+
+pytestmark = pytest.mark.cli
+
+# Mirrors the real blueprint's required H2 sections; "(optional)" is excluded.
+TEMPLATE = """\
+---
+name: Blueprint
+about: task ticket
+---
+
+## Work Type
+
+## Problem / Goal
+
+## Context
+
+## Expected Outcome
+
+## Acceptance Criteria
+
+## Reproduction Steps / Task Plan
+
+## Priority
+
+## Requester / Owner
+
+## Out of Scope (optional)
+"""
+
+REQUIRED = [
+    "Work Type",
+    "Problem / Goal",
+    "Context",
+    "Expected Outcome",
+    "Acceptance Criteria",
+    "Reproduction Steps / Task Plan",
+    "Priority",
+    "Requester / Owner",
+]
+
+
+def _make_root(tmp_path, with_template=True):
+    if with_template:
+        tpl = tmp_path / ".github" / "ISSUE_TEMPLATE" / "blueprint.md"
+        tpl.parent.mkdir(parents=True)
+        tpl.write_text(TEMPLATE)
+    return tmp_path
+
+
+def _section_block(h: str) -> str:
+    if h == "Acceptance Criteria":
+        return f"## {h}\n\n- [ ] first criterion\n"
+    return f"## {h}\n\ncontent\n"
+
+
+def _body_from(headings) -> str:
+    return "\n".join(_section_block(h) for h in headings)
+
+
+def _complete_body(extra="") -> str:
+    body = _body_from(REQUIRED)
+    return f"{body}\n{extra}" if extra else body
+
+
+def _run(tmp_path, body_text, root, *extra_args):
+    body = tmp_path / "body.md"
+    body.write_text(body_text)
+    runner = CliRunner()
+    return runner.invoke(
+        cli, ["issue", "lint", str(body), "--root", str(root), *extra_args]
+    )
+
+
+# ---------------------------------------------------------------------------
+# AC: complete body passes
+# ---------------------------------------------------------------------------
+
+
+def test_complete_body_passes(tmp_path):
+    root = _make_root(tmp_path)
+    result = _run(tmp_path, _complete_body(), root)
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC: missing required section(s)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_one_section_fails(tmp_path):
+    root = _make_root(tmp_path)
+    body = _body_from([h for h in REQUIRED if h != "Context"])
+    result = _run(tmp_path, body, root)
+    assert result.exit_code == 1
+    assert "Context" in result.output
+    assert "FAIL" in result.output
+
+
+def test_missing_multiple_sections_reports_each(tmp_path):
+    root = _make_root(tmp_path)
+    # Body with only two sections present
+    body = "## Work Type\nx\n\n## Priority\nP2\n"
+    result = _run(tmp_path, body, root, "--json")
+    data = json.loads(result.output)
+    missing = [v for v in data["violations"] if v["rule"] == "missing-section"]
+    names = {v["match"] for v in missing}
+    # Everything required except the two present must be reported
+    assert "Context" in names
+    assert "Acceptance Criteria" in names
+    assert "Work Type" not in names
+    assert "Priority" not in names
+
+
+# ---------------------------------------------------------------------------
+# AC: Acceptance Criteria with no checkbox
+# ---------------------------------------------------------------------------
+
+
+def test_acceptance_criteria_without_checkbox_fails(tmp_path):
+    root = _make_root(tmp_path)
+    body = _complete_body().replace("- [ ] first criterion", "just prose, no checkbox")
+    result = _run(tmp_path, body, root, "--json")
+    assert result.exit_code == 1
+    data = json.loads(result.output)
+    rules = {v["rule"] for v in data["violations"]}
+    assert "no-acceptance-criteria" in rules
+    # The section IS present, so it must not also be reported as missing
+    missing = {v["match"] for v in data["violations"] if v["rule"] == "missing-section"}
+    assert "Acceptance Criteria" not in missing
+
+
+def test_acceptance_criteria_with_checkbox_ok(tmp_path):
+    root = _make_root(tmp_path)
+    result = _run(tmp_path, _complete_body(), root, "--json")
+    data = json.loads(result.output)
+    assert data["result"] == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# AC: optional sections are not required
+# ---------------------------------------------------------------------------
+
+
+def test_optional_section_absence_is_ok(tmp_path):
+    root = _make_root(tmp_path)
+    # _complete_body has no "Out of Scope" — it's optional, so still PASS
+    result = _run(tmp_path, _complete_body(), root)
+    assert result.exit_code == 0
+    assert "Out of Scope" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC: template absent → check skipped, TBD-only behavior
+# ---------------------------------------------------------------------------
+
+
+def test_no_template_skips_structural_check(tmp_path):
+    root = _make_root(tmp_path, with_template=False)
+    # A body that would fail every structural rule, but has no TBD phrase
+    result = _run(tmp_path, "just a sentence, no sections at all\n", root)
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
+
+
+def test_no_template_still_catches_tbd(tmp_path):
+    root = _make_root(tmp_path, with_template=False)
+    result = _run(tmp_path, "implementer chooses the parser\n", root)
+    assert result.exit_code == 1
+    assert "FAIL" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC: COR-1501 pointer on FAIL (text mode only)
+# ---------------------------------------------------------------------------
+
+
+def test_fail_prints_cor1501_pointer(tmp_path):
+    root = _make_root(tmp_path)
+    result = _run(tmp_path, "## Work Type\nx\n", root)
+    assert result.exit_code == 1
+    assert "COR-1501" in result.output
+
+
+def test_json_has_no_cor1501_pointer_text(tmp_path):
+    root = _make_root(tmp_path)
+    result = _run(tmp_path, "## Work Type\nx\n", root, "--json")
+    # JSON mode must stay machine-parseable: no prose pointer, no ✗ glyphs
+    data = json.loads(result.output)
+    assert data["result"] == "FAIL"
+    assert "✗" not in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC: structural + TBD violations combine
+# ---------------------------------------------------------------------------
+
+
+def test_structural_and_tbd_combine(tmp_path):
+    root = _make_root(tmp_path)
+    body = "## Work Type\nimplementer chooses the lib\n"
+    result = _run(tmp_path, body, root, "--json")
+    data = json.loads(result.output)
+    rules = {v["rule"] for v in data["violations"]}
+    assert "tbd-phrase" in rules
+    assert "missing-section" in rules
+
+
+# ---------------------------------------------------------------------------
+# AC: fence-awareness — headings/checkboxes inside code fences don't count
+# ---------------------------------------------------------------------------
+
+
+def test_fenced_heading_does_not_satisfy_required_section(tmp_path):
+    root = _make_root(tmp_path)
+    # Real Context section omitted; "## Context" appears only inside a fenced
+    # code block → must not count as satisfying the required section.
+    body = _body_from([h for h in REQUIRED if h != "Context"])
+    body += "\n```markdown\n## Context\nfaux\n```\n"
+    result = _run(tmp_path, body, root, "--json")
+    data = json.loads(result.output)
+    missing = {v["match"] for v in data["violations"] if v["rule"] == "missing-section"}
+    assert "Context" in missing
+
+
+def test_fenced_checkbox_does_not_satisfy_acceptance_criteria(tmp_path):
+    root = _make_root(tmp_path)
+    # AC section present, but the only "- [ ]" is inside a code fence
+    body = _complete_body().replace(
+        "## Acceptance Criteria\n\n- [ ] first criterion\n",
+        "## Acceptance Criteria\n\n```\n- [ ] fenced, does not count\n```\n",
+    )
+    result = _run(tmp_path, body, root, "--json")
+    data = json.loads(result.output)
+    rules = {v["rule"] for v in data["violations"]}
+    assert "no-acceptance-criteria" in rules

--- a/tests/commands/test_issue_lint_blueprint.py
+++ b/tests/commands/test_issue_lint_blueprint.py
@@ -288,12 +288,44 @@ def test_autodiscovery_without_root_flag(tmp_path, monkeypatch):
 
 
 def test_template_found_from_subdirectory(tmp_path, monkeypatch):
-    """PR #223 codex P2: run from a subdir of a (non-Alfred) repo whose
+    """PR #223 codex P2 #1: run from a subdir of a (non-Alfred) repo whose
     template lives at the repo root. get_root falls back to the subdir, so the
     check must walk UP to find the template — not silently skip."""
     root = _make_root(tmp_path)  # template at repo root, no Alfred rules/
     subdir = root / "src" / "deep"
     subdir.mkdir(parents=True)
+    body = subdir / "body.md"
+    body.write_text("## Work Type\nx\n")
+    monkeypatch.chdir(subdir)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])  # no --root
+    assert result.exit_code == 1
+    assert "COR-1501" in result.output
+
+
+def test_walk_up_stops_at_repo_boundary(tmp_path, monkeypatch):
+    """PR #223 codex P2 #2: a child repo (has .git, no template) nested under a
+    parent that DOES have a template must NOT pick up the parent's blueprint —
+    the walk stops at the child repo boundary, so the check is skipped."""
+    _make_root(tmp_path)  # parent repo has a template
+    child = tmp_path / "child"
+    (child / ".git").mkdir(parents=True)  # child is its own repo, no template
+    body = child / "body.md"
+    body.write_text("anything, no sections\n")
+    monkeypatch.chdir(child)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])  # no --root
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
+
+
+def test_repo_root_with_git_and_template_still_found(tmp_path, monkeypatch):
+    """The repo root's own template is considered before the .git boundary
+    stops the walk (boundary check must not pre-empt the template at root)."""
+    root = _make_root(tmp_path)
+    (root / ".git").mkdir()
+    subdir = root / "pkg"
+    subdir.mkdir()
     body = subdir / "body.md"
     body.write_text("## Work Type\nx\n")
     monkeypatch.chdir(subdir)

--- a/tests/commands/test_issue_lint_blueprint.py
+++ b/tests/commands/test_issue_lint_blueprint.py
@@ -287,6 +287,22 @@ def test_autodiscovery_without_root_flag(tmp_path, monkeypatch):
     assert "COR-1501" in result.output
 
 
+def test_template_found_from_subdirectory(tmp_path, monkeypatch):
+    """PR #223 codex P2: run from a subdir of a (non-Alfred) repo whose
+    template lives at the repo root. get_root falls back to the subdir, so the
+    check must walk UP to find the template — not silently skip."""
+    root = _make_root(tmp_path)  # template at repo root, no Alfred rules/
+    subdir = root / "src" / "deep"
+    subdir.mkdir(parents=True)
+    body = subdir / "body.md"
+    body.write_text("## Work Type\nx\n")
+    monkeypatch.chdir(subdir)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])  # no --root
+    assert result.exit_code == 1
+    assert "COR-1501" in result.output
+
+
 # ---------------------------------------------------------------------------
 # AC: template edge cases
 # ---------------------------------------------------------------------------

--- a/tests/commands/test_issue_lint_blueprint.py
+++ b/tests/commands/test_issue_lint_blueprint.py
@@ -206,6 +206,22 @@ def test_json_has_no_cor1501_pointer_text(tmp_path):
     assert "✗" not in result.output
 
 
+def test_tbd_only_fail_has_no_pointer(tmp_path):
+    """AC#4: a TBD-only FAIL (no structural violation) prints no COR-1501
+    pointer — keeps text output byte-for-byte identical to pre-#219."""
+    root = _make_root(tmp_path, with_template=False)
+    result = _run(tmp_path, "implementer chooses the lib\n", root)
+    assert result.exit_code == 1
+    assert "COR-1501" not in result.output
+
+
+def test_structural_fail_with_tbd_still_prints_pointer(tmp_path):
+    """A mixed fail (structural + TBD) still prints the pointer."""
+    root = _make_root(tmp_path)
+    result = _run(tmp_path, "## Work Type\nimplementer chooses\n", root)
+    assert "COR-1501" in result.output
+
+
 # ---------------------------------------------------------------------------
 # AC: structural + TBD violations combine
 # ---------------------------------------------------------------------------
@@ -236,6 +252,70 @@ def test_fenced_heading_does_not_satisfy_required_section(tmp_path):
     data = json.loads(result.output)
     missing = {v["match"] for v in data["violations"] if v["rule"] == "missing-section"}
     assert "Context" in missing
+
+
+def test_indented_heading_not_counted_as_present(tmp_path):
+    """Column-0 discipline: an indented '## Acceptance Criteria' is not a
+    real section (matches extract_section's ^## anchor) → missing-section,
+    not a false no-acceptance-criteria."""
+    root = _make_root(tmp_path)
+    body = _body_from([h for h in REQUIRED if h != "Acceptance Criteria"])
+    body += "\n  ## Acceptance Criteria\n\n  - [ ] indented\n"
+    result = _run(tmp_path, body, root, "--json")
+    data = json.loads(result.output)
+    missing = {v["match"] for v in data["violations"] if v["rule"] == "missing-section"}
+    rules = {v["rule"] for v in data["violations"]}
+    assert "Acceptance Criteria" in missing
+    assert "no-acceptance-criteria" not in rules
+
+
+# ---------------------------------------------------------------------------
+# AC: auto-discovery (no --root) path — the headline real-user behavior
+# ---------------------------------------------------------------------------
+
+
+def test_autodiscovery_without_root_flag(tmp_path, monkeypatch):
+    """Run from inside a repo root (no --root): discover_root falls back to
+    cwd, the template is found, and the structural check activates."""
+    root = _make_root(tmp_path)
+    body = root / "body.md"
+    body.write_text("## Work Type\nx\n")
+    monkeypatch.chdir(root)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])
+    assert result.exit_code == 1
+    assert "COR-1501" in result.output
+
+
+# ---------------------------------------------------------------------------
+# AC: template edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_optional_casing_variance_not_required(tmp_path):
+    """A heading ending in '(Optional)' (capitalized) is still optional."""
+    tpl = tmp_path / ".github" / "ISSUE_TEMPLATE" / "blueprint.md"
+    tpl.parent.mkdir(parents=True)
+    tpl.write_text("## Work Type\n\n## Extras (Optional)\n")
+    body = tmp_path / "body.md"
+    body.write_text("## Work Type\ncontent\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body), "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "Extras" not in result.output
+
+
+def test_template_with_no_headings_is_noop(tmp_path):
+    """A template with zero '## ' headings imposes no structural requirement."""
+    tpl = tmp_path / ".github" / "ISSUE_TEMPLATE" / "blueprint.md"
+    tpl.parent.mkdir(parents=True)
+    tpl.write_text("Just prose, no sections.\n")
+    body = tmp_path / "body.md"
+    body.write_text("anything at all\n")
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body), "--root", str(tmp_path)])
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
 
 
 def test_fenced_checkbox_does_not_satisfy_acceptance_criteria(tmp_path):

--- a/tests/commands/test_issue_lint_blueprint.py
+++ b/tests/commands/test_issue_lint_blueprint.py
@@ -319,6 +319,28 @@ def test_walk_up_stops_at_repo_boundary(tmp_path, monkeypatch):
     assert "PASS (0 violations)" in result.output
 
 
+def test_child_repo_inside_alfred_parent_not_bypassed(tmp_path, monkeypatch):
+    """PR #223 codex P2 #3: a child Git repo (own .git, no template) nested
+    under an Alfred project (parent has rules/ + a template). discover_root
+    would walk past the child .git to the parent Alfred root; the template
+    lookup must instead anchor to the invoking repo and skip — not borrow the
+    parent's blueprint."""
+    root = _make_root(tmp_path)  # parent has .github template
+    rules = root / "rules"
+    rules.mkdir()
+    # A non-COR doc makes the parent a discoverable Alfred root.
+    (rules / "FXA-9999-SOP-Test-Doc.md").write_text("# placeholder\n")
+    child = root / "child"
+    (child / ".git").mkdir(parents=True)  # child is its own repo, no template
+    body = child / "body.md"
+    body.write_text("no sections\n")
+    monkeypatch.chdir(child)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])  # no --root
+    assert result.exit_code == 0
+    assert "PASS (0 violations)" in result.output
+
+
 def test_repo_root_with_git_and_template_still_found(tmp_path, monkeypatch):
     """The repo root's own template is considered before the .git boundary
     stops the walk (boundary check must not pre-empt the template at root)."""

--- a/tests/commands/test_issue_lint_blueprint.py
+++ b/tests/commands/test_issue_lint_blueprint.py
@@ -341,6 +341,24 @@ def test_child_repo_inside_alfred_parent_not_bypassed(tmp_path, monkeypatch):
     assert "PASS (0 violations)" in result.output
 
 
+def test_external_body_uses_cwd_repo_template(tmp_path, monkeypatch):
+    """PR #223 codex P2 #4: linting a body file that lives OUTSIDE the repo
+    (e.g. /tmp/body.md) while cwd is a repo with a template must validate
+    against the cwd repo's template — not silently skip because the body's own
+    directory has none."""
+    repo = tmp_path / "repo"
+    _make_root(repo)  # repo/.github/ISSUE_TEMPLATE/blueprint.md
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    body = elsewhere / "body.md"
+    body.write_text("no sections at all\n")
+    monkeypatch.chdir(repo)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["issue", "lint", str(body)])  # no --root
+    assert result.exit_code == 1
+    assert "COR-1501" in result.output
+
+
 def test_repo_root_with_git_and_template_still_found(tmp_path, monkeypatch):
     """The repo root's own template is considered before the .git boundary
     stops the walk (boundary check must not pre-empt the template at root)."""

--- a/tests/commands/test_issue_lint_cmd.py
+++ b/tests/commands/test_issue_lint_cmd.py
@@ -16,6 +16,21 @@ from fx_alfred.commands.issue_cmd import issue_cmd  # noqa: F401
 
 pytestmark = pytest.mark.cli
 
+
+@pytest.fixture(autouse=True)
+def _isolate_from_repo_blueprint(tmp_path, monkeypatch):
+    """Run each TBD-rule test from a template-less cwd.
+
+    The blueprint structural check (issue #219) discovers
+    ``.github/ISSUE_TEMPLATE/blueprint.md`` relative to the resolved root,
+    which defaults to ``discover_root(cwd)``. Under pytest the cwd is the repo
+    root, which *has* that template — so without this isolation the structural
+    check would activate and break these TBD-only tests. Chdir to an empty
+    tmp dir so no template is discoverable and behavior stays TBD-only.
+    """
+    monkeypatch.chdir(tmp_path)
+
+
 TBD_PHRASES = [
     "TBD after PR review",
     "TBD after option selection",


### PR DESCRIPTION
## What

Extends `af issue lint` to enforce the COR-1501 blueprint structure, not just TBD-phrases — so the tool authors already reach for catches a non-compliant issue body *before* creation, instead of the `iterwheel-blueprint[bot]` flagging it after the fact. Motivated by #218, which was created non-compliant despite a passing lint.

- **`missing-section`** — one per required `## ` heading absent from the body.
- **`no-acceptance-criteria`** — when `## Acceptance Criteria` is present but has no `- [ ]` item.
- Required sections are **derived from the repo's own `.github/ISSUE_TEMPLATE/blueprint.md`** (the COR-1501 source of truth) — NOT hardcoded, because `af` ships to many repos. `## ` headings ending in `(optional)` are not required.
- Template absent → structural check skipped; **TBD-only behavior is byte-for-byte unchanged**.
- COR-1501 pointer printed on structural fails only (text mode).
- Section/checkbox detection is **fence-aware** (reuses `core/parser`). Root resolves via the standard `--root`/`discover_root` path, so `af issue lint body.md` run inside a repo activates the check.

## Test

TDD. 21 new tests + 27 existing TBD tests (isolated to a template-less cwd via an autouse fixture so behavior is preserved). `1125 passed`, ruff + pyright clean. Dogfooded: a body with no Acceptance Criteria now fails with 8 violations + the pointer; a complete blueprint body passes.

## Trinity review (round 1 → round 2)

Round 1: GLM 9.4 PASS, MiniMax 9.2 PASS, DeepSeek 9.3 FIX. Fixes applied in round 2:
- **[blocking]** removed an accidentally-committed `transcript.jsonl` + gitignored it (DeepSeek+GLM)
- column-0 heading discipline so an indented `## Acceptance Criteria` isn't a false present (DeepSeek+GLM convergent)
- COR-1501 pointer gated to structural fails (AC#4 text-mode conformance) (GLM)
- `_render` raises on unknown rule instead of returning a dead string (MiniMax+GLM)
- CLAUDE.md description + docstring ordering contract; added edge tests

## Scope hints

CLI lint enhancement in one module + tests. Flag only: correctness of section/checkbox detection and fence-awareness, the `--root`/discovery activation path, and whether template-absent behavior is truly unchanged. Out of scope: the TBD-phrase rule itself, other commands.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)
