### PR TITLE
docs(fxa-2306): object→transformation design lens REF

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -1,8 +1,8 @@
 # REF-0000: Document Index
 
 **Applies to:** FXA project
-**Last updated:** 2026-06-17
-**Last reviewed:** 2026-06-17
+**Last updated:** 2026-06-20
+**Last reviewed:** 2026-06-20
 **Status:** Active
 
 ---
@@ -11,211 +11,212 @@
 |------|------|-------|
 | 1623 | SOP | PR Review Thread Watchdog |
 | 2100 | SOP | Leader Mediated Development |
-| 2101 | CHG | Multi Layer Scan |
+| 2101 | CHG | Multi Layer Scan (Approved) |
 | 2102 | SOP | Release To PyPI |
-| 2103 | CHG | Root Option And Spacing |
-| 2104 | PRP | AF Update Command |
-| 2105 | PRP | AF Rename Command |
-| 2106 | PRP | AF CLI Optimization v0.6 |
-| 2107 | CHG | Code Quality Refactoring |
+| 2103 | CHG | Root Option And Spacing (Approved) |
+| 2104 | PRP | AF Update Command (Implemented) |
+| 2105 | PRP | AF Rename Command (Rejected) |
+| 2106 | PRP | AF CLI Optimization v0.6 (Implemented) |
+| 2107 | CHG | Code Quality Refactoring (Completed) |
 | 2108 | REF | Session Retrospective 2026 03 19 D1 |
-| 2109 | CHG | DRY Scan Boilerplate |
-| 2110 | CHG | Lazy Command Loading |
-| 2111 | CHG | List Filtering |
-| 2112 | CHG | JSON Output |
+| 2109 | CHG | DRY Scan Boilerplate (Proposed) |
+| 2110 | CHG | Lazy Command Loading (Proposed) |
+| 2111 | CHG | List Filtering (Proposed) |
+| 2112 | CHG | JSON Output (Proposed) |
 | 2113 | REF | Discussion Tracker 2026 03 19 D2 |
-| 2114 | CHG | AF Search Command |
-| 2115 | CHG | AF Validate Command |
-| 2116 | PRP | Document Format Contract |
-| 2117 | PRP | AF Filter And Section Update |
+| 2114 | CHG | AF Search Command (Proposed) |
+| 2115 | CHG | AF Validate Command (Proposed) |
+| 2116 | PRP | Document Format Contract (Implemented) |
+| 2117 | PRP | AF Filter And Section Update (Draft) |
 | 2118 | REF | Session Retrospective 2026 03 19 D2 |
-| 2119 | PLN | Document Format Contract Implementation |
-| 2120 | CHG | Create Document Format Contract Reference |
-| 2121 | CHG | Update Create Templates To Format Contract |
-| 2122 | CHG | Enhance Validate Per Type Fields And Status |
-| 2123 | CHG | Migrate Existing Documents To Format Contract |
-| 2124 | CHG | Layered Workflow Routing AF Guide |
+| 2119 | PLN | Document Format Contract Implementation (Completed) |
+| 2120 | CHG | Create Document Format Contract Reference (Completed) |
+| 2121 | CHG | Update Create Templates To Format Contract (Completed) |
+| 2122 | CHG | Enhance Validate Per Type Fields And Status (Completed) |
+| 2123 | CHG | Migrate Existing Documents To Format Contract (Completed) |
+| 2124 | CHG | Layered Workflow Routing AF Guide (Completed) |
 | 2125 | SOP | Workflow Routing PRJ |
-| 2126 | PRP | AF Create Routing Shortcut |
-| 2127 | SOP | Commit Alfred Ops |
+| 2126 | PRP | AF Create Routing Shortcut (Rejected) |
+| 2127 | SOP | Commit Alfred Ops (Deprecated) |
 | 2128 | REF | Discussion Tracker 2026 03 20 |
-| 2129 | CHG | Implement Review Scoring Framework |
-| 2130 | CHG | Standardize SOP Section Structure |
-| 2131 | CHG | SOP Template And COR 1103 Reading Guide |
-| 2132 | CHG | AF Validate SOP Section Checking |
-| 2133 | CHG | Migrate All SOPs To Standard Structure |
-| 2134 | PRP | AF Plan Command Workflow Checklist |
-| 2135 | CHG | Implement AF Plan Command |
+| 2129 | CHG | Implement Review Scoring Framework (Completed) |
+| 2130 | CHG | Standardize SOP Section Structure (Rolled Back) |
+| 2131 | CHG | SOP Template And COR 1103 Reading Guide (Completed) |
+| 2132 | CHG | AF Validate SOP Section Checking (Completed) |
+| 2133 | CHG | Migrate All SOPs To Standard Structure (Completed) |
+| 2134 | PRP | AF Plan Command Workflow Checklist (Implemented) |
+| 2135 | CHG | Implement AF Plan Command (Completed) |
 | 2136 | SOP | Update README |
-| 2137 | CHG | AF Setup Guide Every Task Wording |
-| 2138 | PRP | Create Routing Document SOP |
-| 2139 | CHG | Implement COR 1004 Create Routing Document SOP |
-| 2140 | PRP | Core Python Schema Architecture |
-| 2141 | PRP | AF Fmt Command |
-| 2142 | CHG | JSON Output For Guide Plan Search Validate |
-| 2143 | CHG | Structured Spec Input For Create Update |
-| 2144 | CHG | AF Where Command |
-| 2145 | PRP | Auto Evolution SOP and CLI |
+| 2137 | CHG | AF Setup Guide Every Task Wording (Completed) |
+| 2138 | PRP | Create Routing Document SOP (Approved) |
+| 2139 | CHG | Implement COR 1004 Create Routing Document SOP (Completed) |
+| 2140 | PRP | Core Python Schema Architecture (Implemented) |
+| 2141 | PRP | AF Fmt Command (Implemented) |
+| 2142 | CHG | JSON Output For Guide Plan Search Validate (Completed) |
+| 2143 | CHG | Structured Spec Input For Create Update (Completed) |
+| 2144 | CHG | AF Where Command (Completed) |
+| 2145 | PRP | Auto Evolution SOP and CLI (Approved) |
 | 2146 | REF | Evolution Philosophy |
-| 2147 | CHG | Implement Auto Evolution SOPs REF Philosophy |
+| 2147 | CHG | Implement Auto Evolution SOPs REF Philosophy (Completed) |
 | 2148 | SOP | Evolve SOP |
 | 2149 | SOP | Evolve CLI |
 | 2150 | REF | Evolve Run 20260330 204515 |
-| 2151 | PRP | Translate FXA 2125 Decision Tree To English |
-| 2152 | PRP | Fix FXA 2100 Command Reference And Round Limit |
-| 2153 | CHG | Translate FXA 2125 Decision Tree To English |
-| 2154 | CHG | Fix FXA 2100 Command Reference And Round Limit |
+| 2151 | PRP | Translate FXA 2125 Decision Tree To English (Implemented) |
+| 2152 | PRP | Fix FXA 2100 Command Reference And Round Limit (Implemented) |
+| 2153 | CHG | Translate FXA 2125 Decision Tree To English (Completed) |
+| 2154 | CHG | Fix FXA 2100 Command Reference And Round Limit (Completed) |
 | 2155 | REF | Evolve Run 20260330 211109 |
-| 2156 | PRP | Extract Duplicated Helpers And Add Gate Detection Tests |
-| 2157 | CHG | Extract Duplicated Helpers And Add Gate Detection Tests |
+| 2156 | PRP | Extract Duplicated Helpers And Add Gate Detection Tests (Draft) |
+| 2157 | CHG | Extract Duplicated Helpers And Add Gate Detection Tests (Proposed) |
 | 2158 | REF | Evolve Run 20260330 221843 |
-| 2159 | PRP | Replace Assert With ClickException |
-| 2160 | CHG | Replace Assert With ClickException |
+| 2159 | PRP | Replace Assert With ClickException (Draft) |
+| 2160 | CHG | Replace Assert With ClickException (Proposed) |
 | 2161 | REF | Evolve Run 20260330 232601 |
-| 2162 | PRP | Extract Atomic Write Helper |
-| 2163 | CHG | Extract Atomic Write Helper |
+| 2162 | PRP | Extract Atomic Write Helper (Draft) |
+| 2163 | CHG | Extract Atomic Write Helper (Approved) |
 | 2164 | REF | Evolve Run 20260401 050827 |
-| 2165 | PRP | Extract Invoke Index Update Helper |
-| 2166 | CHG | Extract Invoke Index Update Helper |
+| 2165 | PRP | Extract Invoke Index Update Helper (Draft) |
+| 2166 | CHG | Extract Invoke Index Update Helper (Approved) |
 | 2167 | REF | Evolve Run 20260401 085641 |
-| 2168 | PRP | Deduplicate Plan Cmd Phase Formatters |
-| 2169 | CHG | Deduplicate Plan Cmd Phase Formatters |
-| 2170 | PRP | Evolve CLI Batch C3 C4 C5 |
-| 2171 | CHG | Evolve CLI Batch C3 C4 C5 |
+| 2168 | PRP | Deduplicate Plan Cmd Phase Formatters (Draft) |
+| 2169 | CHG | Deduplicate Plan Cmd Phase Formatters (Proposed) |
+| 2170 | PRP | Evolve CLI Batch C3 C4 C5 (Draft) |
+| 2171 | CHG | Evolve CLI Batch C3 C4 C5 (Proposed) |
 | 2172 | REF | Evolve SOP Run 20260401 154338 |
-| 2173 | PRP | Define Review Gate And Align Scoring |
-| 2174 | CHG | Define Review Gate And Align Scoring |
+| 2173 | PRP | Define Review Gate And Align Scoring (Draft) |
+| 2174 | CHG | Define Review Gate And Align Scoring (Proposed) |
 | 2175 | REF | Evolve Run 20260401 220000 |
-| 2176 | PRP | Fix Corrupted FXA 2166 CHG Document |
-| 2177 | PRP | Standardize Role Naming In FXA 2100 |
-| 2178 | PRP | Add AF Tool Context To Review Dispatch Template |
-| 2179 | CHG | Fix Corrupted FXA 2166 CHG Document |
-| 2180 | CHG | Standardize Role Naming In FXA 2100 |
-| 2181 | CHG | Add AF Tool Context To Review Dispatch Template |
-| 2182 | PRP | Add AF Tool Context To COR Workflow Dispatch Steps |
-| 2183 | CHG | Add AF Tool Context To COR Workflow Dispatch Steps |
+| 2176 | PRP | Fix Corrupted FXA 2166 CHG Document (Approved) |
+| 2177 | PRP | Standardize Role Naming In FXA 2100 (Approved) |
+| 2178 | PRP | Add AF Tool Context To Review Dispatch Template (Approved) |
+| 2179 | CHG | Fix Corrupted FXA 2166 CHG Document (Completed) |
+| 2180 | CHG | Standardize Role Naming In FXA 2100 (Completed) |
+| 2181 | CHG | Add AF Tool Context To Review Dispatch Template (Completed) |
+| 2182 | PRP | Add AF Tool Context To COR Workflow Dispatch Steps (Approved) |
+| 2183 | CHG | Add AF Tool Context To COR Workflow Dispatch Steps (Completed) |
 | 2184 | REF | Discussion Tracker 2026 04 03 |
-| 2185 | CHG | Add COR 1201 Discussion Tracker Step To AF Setup |
-| 2186 | CHG | Merge Alfred Ops Rules Into FX Alfred |
+| 2185 | CHG | Add COR 1201 Discussion Tracker Step To AF Setup (Completed) |
+| 2186 | CHG | Merge Alfred Ops Rules Into FX Alfred (Proposed) |
 | 2187 | REF | Evolve Run 20260404 001357 |
-| 2188 | PRP | Fix FXA 2125 Stale Alfred Ops Refs |
-| 2189 | PRP | Fix FXA 2185 Invalid CHG Status |
-| 2190 | CHG | Fix FXA 2125 Stale Alfred Ops Refs |
-| 2191 | CHG | Fix FXA 2185 Invalid CHG Status |
+| 2188 | PRP | Fix FXA 2125 Stale Alfred Ops Refs (Approved) |
+| 2189 | PRP | Fix FXA 2185 Invalid CHG Status (Approved) |
+| 2190 | CHG | Fix FXA 2125 Stale Alfred Ops Refs (Completed) |
+| 2191 | CHG | Fix FXA 2185 Invalid CHG Status (Completed) |
 | 2192 | REF | Evolve Run 20260404 082129 |
-| 2193 | PRP | Simplify Fmt Metadata Order Comparison |
-| 2194 | CHG | Simplify Fmt Metadata Order Comparison |
+| 2193 | PRP | Simplify Fmt Metadata Order Comparison (Draft) |
+| 2194 | CHG | Simplify Fmt Metadata Order Comparison (Proposed) |
 | 2195 | REF | Session Retrospective 2026 04 04 D1 |
-| 2196 | CHG | MkDocs Material PKG Documentation Site |
-| 2197 | CHG | Auto Deploy Docs On Push |
-| 2198 | PRP | COR Evolution Philosophy Reference |
-| 2199 | CHG | Implement COR 1800 REF Evolution Philosophy |
-| 2200 | PRP | Document Tags Metadata Field |
-| 2201 | CHG | Implement Document Tags Metadata Field |
-| 2202 | CHG | Add COR 1612 Respond To PR Review Comments SOP |
+| 2196 | CHG | MkDocs Material PKG Documentation Site (Proposed) |
+| 2197 | CHG | Auto Deploy Docs On Push (Proposed) |
+| 2198 | PRP | COR Evolution Philosophy Reference (Approved) |
+| 2199 | CHG | Implement COR 1800 REF Evolution Philosophy (Completed) |
+| 2200 | PRP | Document Tags Metadata Field (Approved) |
+| 2201 | CHG | Implement Document Tags Metadata Field (Completed) |
+| 2202 | CHG | Add COR 1612 Respond To PR Review Comments SOP (Completed) |
 | 2203 | REF | Discussion Tracker 2026 04 05 |
-| 2204 | CHG | Typed SOP Composition For AF Plan |
-| 2205 | PRP | AF Plan Auto Compose Todo And Graph |
-| 2206 | CHG | FXA 2205 Follow Ups ASCII Graph And SOP Metadata Backfills |
-| 2207 | CHG | Add COR 1202 Compose Session Plan SOP |
-| 2208 | CHG | Add Pyright To FXA 2102 Release Prerequisites |
+| 2204 | CHG | Typed SOP Composition For AF Plan (Proposed) |
+| 2205 | PRP | AF Plan Auto Compose Todo And Graph (Implemented) |
+| 2206 | CHG | FXA 2205 Follow Ups ASCII Graph And SOP Metadata Backfills (Completed) |
+| 2207 | CHG | Add COR 1202 Compose Session Plan SOP (Completed) |
+| 2208 | CHG | Add Pyright To FXA 2102 Release Prerequisites (Approved) |
 | 2209 | REF | Evolve Run 20260419 063843 |
-| 2210 | PRP | Close three edge arm coverage gaps with tests |
-| 2211 | CHG | Close three edge arm coverage gaps with tests |
+| 2210 | PRP | Close three edge arm coverage gaps with tests (Draft) |
+| 2211 | CHG | Close three edge arm coverage gaps with tests (Completed) |
 | 2212 | REF | Evolve Seed ASCII DAG Graph Layout |
 | 2213 | REF | Evolve Run 20260419 094124 |
-| 2214 | PRP | Bundle N2 N3 C4 plan cmd parser area int edges |
-| 2215 | CHG | Bundle N2 N3 plan cmd parser edge tests |
+| 2214 | PRP | Bundle N2 N3 C4 plan cmd parser area int edges (Draft) |
+| 2215 | CHG | Bundle N2 N3 plan cmd parser edge tests (Completed) |
 | 2216 | REF | Discussion Tracker 2026 04 19 |
-| 2217 | PRP | ASCII DAG nested graph layout for af plan graph |
-| 2218 | CHG | ASCII DAG nested graph layout implementation |
-| 2219 | CHG | Migrate ALF Prefix To FXA In PRJ Rules |
-| 2220 | PRP | Layered Workflow Routing USR And PRJ |
-| 2221 | PRP | Standardized Review Scoring Framework |
-| 2222 | PRP | Team Skill Session Resume |
-| 2223 | PRP | Standardized SOP Section Structure |
-| 2224 | PRP | Workflow Enforcement From Advisory To Mandatory |
-| 2225 | PRP | Branching ASCII In Plan Graph |
-| 2226 | CHG | Implement Branching ASCII Data Layer |
-| 2227 | CHG | Implement Branching ASCII Presentation Layer |
+| 2217 | PRP | ASCII DAG nested graph layout for af plan graph (Draft) |
+| 2218 | CHG | ASCII DAG nested graph layout implementation (Completed) |
+| 2219 | CHG | Migrate ALF Prefix To FXA In PRJ Rules (Approved) |
+| 2220 | PRP | Layered Workflow Routing USR And PRJ (Implemented) |
+| 2221 | PRP | Standardized Review Scoring Framework (Implemented) |
+| 2222 | PRP | Team Skill Session Resume (Rejected) |
+| 2223 | PRP | Standardized SOP Section Structure (Implemented) |
+| 2224 | PRP | Workflow Enforcement From Advisory To Mandatory (Approved) |
+| 2225 | PRP | Branching ASCII In Plan Graph (Approved) |
+| 2226 | CHG | Implement Branching ASCII Data Layer (Proposed) |
+| 2227 | CHG | Implement Branching ASCII Presentation Layer (Proposed) |
 | 2228 | SOP | CHG 2227 Remaining Work — Phases 8b, 9, 10 |
-| 2229 | PRP | Layered SOP Memory Model |
-| 2230 | PRP | Agent Activity Log Protocol |
-| 2231 | CHG | Agent Activity Log Protocol v1 Implementation |
-| 2232 | PRP | Quarkdown Documentation Rendering Layer |
-| 2233 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 |
-| 2234 | CHG | Promote GitHub App PR Review Bot Loop SOP |
-| 2235 | PRP | Agent Editable Helpers And Skills |
-| 2236 | CHG | Implement Agent Editable Helpers And Skills |
+| 2229 | PRP | Layered SOP Memory Model (Draft) |
+| 2230 | PRP | Agent Activity Log Protocol (Approved) |
+| 2231 | CHG | Agent Activity Log Protocol v1 Implementation (Proposed) |
+| 2232 | PRP | Quarkdown Documentation Rendering Layer (Draft) |
+| 2233 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 (Proposed) |
+| 2234 | CHG | Promote GitHub App PR Review Bot Loop SOP (Completed) |
+| 2235 | PRP | Agent Editable Helpers And Skills (Approved) |
+| 2236 | CHG | Implement Agent Editable Helpers And Skills (Completed) |
 | 2237 | REF | Agent Helpers And Skills Usage |
-| 2238 | CHG | Add COR 1615 Operator Checklist |
-| 2239 | CHG | Add COR 1801 Pattern Promotion SOP |
-| 2240 | PRP | Code Review Checklist v2.0 as Alfred SOP REF |
-| 2241 | CHG | Create Code Review Checklist COR 1705 1709 |
-| 2242 | CHG | Promote Multi Phase Execution Contract SOP |
-| 2243 | CHG | Add COR 1615 Pre Trigger Finalization Gate |
-| 2244 | PRP | Add Custom Pytest Markers for Test Categorization |
-| 2245 | PRP | Add Parametrized Tests for Repeated Assertions |
-| 2246 | PRP | Enforce Pytest Coverage Thresholds |
-| 2247 | CHG | Implement Pytest Test Governance Improvements |
-| 2248 | REF | SOP Outcome Notebook |
+| 2238 | CHG | Add COR 1615 Operator Checklist (Completed) |
+| 2239 | CHG | Add COR 1801 Pattern Promotion SOP (Completed) |
+| 2240 | PRP | Code Review Checklist v2.0 as Alfred SOP REF (Draft) |
+| 2241 | CHG | Create Code Review Checklist COR 1705 1709 (Proposed) |
+| 2242 | CHG | Promote Multi Phase Execution Contract SOP (Completed) |
+| 2243 | CHG | Add COR 1615 Pre Trigger Finalization Gate (Completed) |
+| 2244 | PRP | Add Custom Pytest Markers for Test Categorization (Draft) |
+| 2245 | PRP | Add Parametrized Tests for Repeated Assertions (Draft) |
+| 2246 | PRP | Enforce Pytest Coverage Thresholds (Draft) |
+| 2247 | CHG | Implement Pytest Test Governance Improvements (Completed) |
+| 2248 | REF | SOP Outcome Notebook (Draft) |
 | 2249 | REF | Evolve CLI Run 20260405 210018 |
-| 2250 | PRP | Extract H1 Extraction Regex To Parser |
-| 2251 | CHG | Consolidate H1 Regex Named Groups |
+| 2250 | PRP | Extract H1 Extraction Regex To Parser (Draft) |
+| 2251 | CHG | Consolidate H1 Regex Named Groups (Proposed) |
 | 2252 | REF | Evolve Run 20260405 225815 |
-| 2253 | PRP | Validate Status Flag In Update Cmd |
-| 2254 | CHG | Validate Status Flag In Update Cmd |
+| 2253 | PRP | Validate Status Flag In Update Cmd (Draft) |
+| 2254 | CHG | Validate Status Flag In Update Cmd (Proposed) |
 | 2255 | REF | Evolve Run 20260406 070318 |
-| 2256 | CHG | Add Completion Checklist To Evolve CLI SOP |
-| 2257 | PRP | Deduplicate Total Issues In Validate Cmd |
-| 2258 | CHG | Deduplicate Total Issues In Validate Cmd |
-| 2259 | CHG | Add Completion Checklist To Evolve SOP |
-| 2260 | CHG | Add Post Push Review Loop To Evolve SOPs |
-| 2261 | CHG | Reorder Review Loop To Process Comments Before CI Gate |
-| 2262 | PRP | COR 1613 Council Review Mechanism |
-| 2263 | CHG | COR 1103 Add Council Review Routing |
-| 2264 | CHG | COR 1602 Add Council Cross Reference |
-| 2265 | PRP | COR 1503 Diagnose Feedback Loop |
-| 2266 | CHG | COR 1103 Add Diagnose Routing |
-| 2267 | CHG | COR 1613 Add Half Diagnosed Fix Prohibition |
-| 2268 | CHG | COR 1504 REF Diagnose Phase Gates |
-| 2269 | PRP | COR 1203 Pre Task Alignment |
-| 2270 | CHG | COR 1103 Add Pre Task Alignment Routing |
+| 2256 | CHG | Add Completion Checklist To Evolve CLI SOP (Completed) |
+| 2257 | PRP | Deduplicate Total Issues In Validate Cmd (Draft) |
+| 2258 | CHG | Deduplicate Total Issues In Validate Cmd (Completed) |
+| 2259 | CHG | Add Completion Checklist To Evolve SOP (Completed) |
+| 2260 | CHG | Add Post Push Review Loop To Evolve SOPs (Completed) |
+| 2261 | CHG | Reorder Review Loop To Process Comments Before CI Gate (Proposed) |
+| 2262 | PRP | COR 1613 Council Review Mechanism (Approved) |
+| 2263 | CHG | COR 1103 Add Council Review Routing (Approved) |
+| 2264 | CHG | COR 1602 Add Council Cross Reference (Approved) |
+| 2265 | PRP | COR 1503 Diagnose Feedback Loop (Approved) |
+| 2266 | CHG | COR 1103 Add Diagnose Routing (Approved) |
+| 2267 | CHG | COR 1613 Add Half Diagnosed Fix Prohibition (Approved) |
+| 2268 | CHG | COR 1504 REF Diagnose Phase Gates (Proposed) |
+| 2269 | PRP | COR 1203 Pre Task Alignment (Approved) |
+| 2270 | CHG | COR 1103 Add Pre Task Alignment Routing (Approved) |
 | 2271 | CTX | Alfred Glossary |
-| 2272 | CHG | Merge fx_alfredrules Into Top Level rules |
-| 2273 | PRP | AF Tag Star Command And List Filter |
-| 2274 | PRP | AF Star Command Bookmark Documents |
-| 2275 | CHG | FXA 2102 Promote README Check To Numbered Step |
+| 2272 | CHG | Merge fx_alfredrules Into Top Level rules (Proposed) |
+| 2273 | PRP | AF Tag Star Command And List Filter (Rejected) |
+| 2274 | PRP | AF Star Command Bookmark Documents (Draft) |
+| 2275 | CHG | FXA 2102 Promote README Check To Numbered Step (Proposed) |
 | 2276 | REF | Multi Agent Loop Configuration |
-| 2277 | CHG | COR 1622 Schema Refinements For Heterogeneous Adopters |
-| 2278 | CHG | Add FXA 2276 Invocation Shorthand |
-| 2279 | CHG | Codify GitHub App PR Review Bot Scope Hint Technique In COR 1612 + COR 1615 |
-| 2280 | CHG | FXA 2276 Phase 10 Mergeable Trigger |
-| 2281 | CHG | Add COR 1802 Build Weighted Decision Matrix SOP |
-| 2282 | CHG | Add Scoring to COR 1200 Session Retrospective |
-| 2283 | CHG | Add Retrospective Phase to COR 1617 |
+| 2277 | CHG | COR 1622 Schema Refinements For Heterogeneous Adopters (Proposed) |
+| 2278 | CHG | Add FXA 2276 Invocation Shorthand (Proposed) |
+| 2279 | CHG | Codify GitHub App PR Review Bot Scope Hint Technique In COR 1612 + COR 1615 (Proposed) |
+| 2280 | CHG | FXA 2276 Phase 10 Mergeable Trigger (Proposed) |
+| 2281 | CHG | Add COR 1802 Build Weighted Decision Matrix SOP (Approved) |
+| 2282 | CHG | Add Scoring to COR 1200 Session Retrospective (Proposed) |
+| 2283 | CHG | Add Retrospective Phase to COR 1617 (Proposed) |
 | 2284 | REF | Discussion Tracker 2026 05 15 |
-| 2285 | CHG | Pre Merge GH Bot Review Sweep Gate |
-| 2286 | CHG | Explicit UTF 8 For Alfred Document IO |
-| 2287 | CHG | COR 1500 Phase 1 Worker Assignment Sub Section |
-| 2288 | CHG | COR 1500 Phase 2 Implementer Reading Constraint |
-| 2289 | CHG | COR 1619 Two Worker TDD Dispatch Sub Section |
-| 2290 | CHG | COR 1619 Decision Tree Two Worker Branch |
-| 2291 | CHG | COR 1622 Test Writer Worker Agent Schema Row |
-| 2292 | CHG | Alfred Opt In Two Worker TDD Split |
-| 2293 | PRP | 11 Star SOP Experience Review |
-| 2294 | CHG | Fence Aware Extract Section |
-| 2295 | CHG | Compose Domain Exceptions |
-| 2296 | CHG | Validate Unknown Type Warning |
-| 2297 | CHG | CLAUDE Md Refresh And Drift Guard |
-| 2298 | CHG | CI Python Matrix And Pyright Gate |
-| 2299 | CHG | Workflow Fence Loop Dedup |
-| 2300 | CHG | Root Auto Discovery |
-| 2301 | CHG | JSON Output And Exit Code Unification |
-| 2302 | CHG | Plan Cmd Decomposition |
-| 2303 | PRP | AF Export Single File Runbook |
-| 2304 | CHG | Export Repeatable Sources And File Includes |
-| 2305 | PRP | Cross Platform Agent Skill |
+| 2285 | CHG | Pre Merge GH Bot Review Sweep Gate (Completed) |
+| 2286 | CHG | Explicit UTF 8 For Alfred Document IO (Approved) |
+| 2287 | CHG | COR 1500 Phase 1 Worker Assignment Sub Section (Approved) |
+| 2288 | CHG | COR 1500 Phase 2 Implementer Reading Constraint (Approved) |
+| 2289 | CHG | COR 1619 Two Worker TDD Dispatch Sub Section (Approved) |
+| 2290 | CHG | COR 1619 Decision Tree Two Worker Branch (Approved) |
+| 2291 | CHG | COR 1622 Test Writer Worker Agent Schema Row (Approved) |
+| 2292 | CHG | Alfred Opt In Two Worker TDD Split (Approved) |
+| 2293 | PRP | 11 Star SOP Experience Review (Implemented) |
+| 2294 | CHG | Fence Aware Extract Section (Completed) |
+| 2295 | CHG | Compose Domain Exceptions (Completed) |
+| 2296 | CHG | Validate Unknown Type Warning (Completed) |
+| 2297 | CHG | CLAUDE Md Refresh And Drift Guard (Completed) |
+| 2298 | CHG | CI Python Matrix And Pyright Gate (Completed) |
+| 2299 | CHG | Workflow Fence Loop Dedup (Completed) |
+| 2300 | CHG | Root Auto Discovery (Completed) |
+| 2301 | CHG | JSON Output And Exit Code Unification (Completed) |
+| 2302 | CHG | Plan Cmd Decomposition (Completed) |
+| 2303 | PRP | AF Export Single File Runbook (Implemented) |
+| 2304 | CHG | Export Repeatable Sources And File Includes (Completed) |
+| 2305 | PRP | Cross Platform Agent Skill (Implemented) |
+| 2306 | REF | Object To Transformation Design Lens |
 
 ---
 
@@ -223,4 +224,4 @@
 
 | Date | Change | By |
 |------|--------|----|
-| 2026-06-17 | Auto-generated by af index | af CLI |
+| 2026-06-20 | Auto-generated by af index | af CLI |

--- a/rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md
+++ b/rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md
@@ -62,9 +62,11 @@ condition and an exit condition, not just a name.
 - **Evidence (real, not hypothetical):** FXA-2189 / FXA-2191 — "Fix invalid CHG
   status" — an illegal status value already shipped once and needed a corrective
   CHG. A transition graph would have rejected it at write time.
-- **Smallest honest fix (defer to PRP):** one adjacency table per `DocType`
-  (e.g. `Proposed → {Approved, Rejected}`), enforced in `af update --status`,
-  with a `--force` escape hatch for migrations. ~30 LoC + one TDD test.
+- **Smallest honest fix (defer to PRP):** one adjacency table per `DocType`,
+  built only from that type's own `ALLOWED_STATUSES` (e.g. for PRP,
+  `Draft → {Approved, Rejected}`; never an edge that mixes statuses across
+  types), enforced in `af update --status`, with a `--force` escape hatch for
+  migrations. ~30 LoC + one TDD test.
 
 ### 3. Gap B — morphism metadata exists but is mostly unused
 

--- a/rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md
+++ b/rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md
@@ -1,0 +1,112 @@
+# REF-2306: Object-To-Transformation-Design-Lens
+
+**Applies to:** FXA project
+**Last updated:** 2026-06-20
+**Last reviewed:** 2026-06-20
+**Status:** Active
+
+---
+
+## What Is It?
+
+A design lens, not a mandate. It reframes Alfred's model from "what objects exist
+and what fields do they have" to "what *transformations* (arrows) are legal between
+states, and is each arrow honest about its entry condition, exit condition,
+responsible party, and evidence."
+
+Source: the essay *从对象到转换：对 Agent 生命周期的新看法* (Freelemon, 2026-06-19).
+Engineering kernel of that essay, stripped of category-theory vocabulary:
+
+> An object is defined less by its fields than by the legal arrows in and out of
+> it. A `status = published` string is not a lifecycle event unless you can say
+> where it came from, who approved it, what it passed, and whether it can roll back.
+
+This REF records how that kernel maps onto Alfred **as it already exists**, and
+the two concrete gaps where the lens exposes real defects. It is the design basis
+for future evolve cycles (CLD-1801 / FXA-2148). It proposes no code change by
+itself — scope decisions go through PRP/CHG.
+
+---
+
+## Content
+
+### 1. The lens already fits — Alfred is ~70% an "arrows" system
+
+Alfred is not an object-CRUD system that needs converting. Its SOP-composition
+layer already models typed morphisms and their composition:
+
+| Essay concept | Alfred mechanism | Location |
+|---|---|---|
+| Object | `Document` / Agent | `core/document.py` |
+| Morphism with typed boundary | SOP `Workflow input/output/requires/provides` | `core/schema.py` (`_WORKFLOW_FIELDS`) |
+| Composition `A→B ∘ B→C ⇒ A→C` | `af plan --task` auto-chains SOPs by Task tags + requires/provides | `core/compose.py` |
+| Where does failure land / branch | `Workflow branches`, `Workflow loops` | `core/workflow.py` |
+| Who triggered / what evidence | COR-1402 Declare Active Process + COR-1206 Agent Activity Log | PKG |
+| State honesty (allowed states) | `ALLOWED_STATUSES` per `DocType` | `core/schema.py` |
+
+Conclusion: the essay validates the existing direction. It is **not** a reason to
+rewrite SOPs in category-theory terms. The essay itself says you do not need to
+"hold a category-theory meeting every time."
+
+### 2. Gap A — status is a flat *set*, not a *transition graph*
+
+`ALLOWED_STATUSES[CHG] = ["Proposed","Approved","In Progress","Completed","Rolled Back"]`
+is a membership set. `af update --status` (`commands/update_cmd.py` →
+`validate_spec_status`) checks only "is this a legal value", never "is this a legal
+move *from the current value*". Today `Completed → Proposed` and
+`Rolled Back → In Progress` are both accepted silently.
+
+This is exactly the essay's "state honesty" point: a state needs an entry
+condition and an exit condition, not just a name.
+
+- **Evidence (real, not hypothetical):** FXA-2189 / FXA-2191 — "Fix invalid CHG
+  status" — an illegal status value already shipped once and needed a corrective
+  CHG. A transition graph would have rejected it at write time.
+- **Smallest honest fix (defer to PRP):** one adjacency table per `DocType`
+  (e.g. `Proposed → {Approved, Rejected}`), enforced in `af update --status`,
+  with a `--force` escape hatch for migrations. ~30 LoC + one TDD test.
+
+### 3. Gap B — morphism metadata exists but is mostly unused
+
+The schema has supported typed SOP I/O since FXA-2204, but only **5 of ~80 SOPs**
+declare `Workflow input/output`. The remaining ~75 are "one big object described
+in prose" — the document-level version of the essay's anti-pattern (a wide `Order`
+propped up by a `status` string instead of `DraftOrder → PaidOrder → ShippedOrder`).
+
+- This matters **only for SOPs that actually enter `af plan` composition chains.**
+  Backfilling I/O on SOPs nobody composes is metadata nobody reads — YAGNI.
+- **Smallest honest fix (defer to PRP):** backfill `Workflow input/output` on the
+  composable SOPs only, and have `af validate` warn (not error) when a SOP
+  participates in routing/composition but declares no I/O.
+
+### 4. What this lens does NOT justify
+
+- ✗ Rewriting the 80 SOPs in category-theory vocabulary, or adding
+  Monad/Functor/Natural-Transformation names to documents. The value is the
+  *question set* ("which arrows are legal, what's the evidence"), not the jargon.
+- ✗ Mass backfill of morphism metadata onto non-composable SOPs.
+- ✗ Any change to `ALLOWED_STATUSES` semantics without a PRP — status transition
+  rules are a behavioral contract many docs depend on.
+
+### 5. The question set (reusable in design / review / evolve)
+
+When modeling or reviewing any Alfred surface, ask arrows before objects:
+
+1. What are the core states?
+2. From each state, which next states are legal?
+3. Which transitions are commands vs. events?
+4. Which transitions are pure vs. side-effecting?
+5. Which transitions require human approval?
+6. Which transitions must leave an audit trail / evidence?
+7. Which failures are retryable vs. blocking?
+8. Which states can roll back vs. append-only?
+
+Only after those: decide objects, tables, interfaces, UI.
+
+---
+
+## Change History
+
+| Date       | Change                                                                                                                                                              | By          |
+|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| 2026-06-20 | Initial version — maps "object→transformation" essay onto Alfred; records Gap A (status transition graph) + Gap B (unused morphism metadata) as evolve design basis | Claude Code |

--- a/rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md
+++ b/rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md
@@ -39,7 +39,7 @@ layer already models typed morphisms and their composition:
 |---|---|---|
 | Object | `Document` / Agent | `core/document.py` |
 | Morphism with typed boundary | SOP `Workflow input/output/requires/provides` | `core/schema.py` (`_WORKFLOW_FIELDS`) |
-| Composition `A→B ∘ B→C ⇒ A→C` | `af plan --task` auto-chains SOPs by Task tags + requires/provides | `core/compose.py` |
+| Composition `A→B ∘ B→C ⇒ A→C` | `af plan --task` auto-chains SOPs by Task tags + `Workflow input/output` (matching output→input; `requires/provides` are parsed but not used for chaining) | `core/compose.py` |
 | Where does failure land / branch | `Workflow branches`, `Workflow loops` | `core/workflow.py` |
 | Who triggered / what evidence | COR-1402 Declare Active Process + COR-1206 Agent Activity Log | PKG |
 | State honesty (allowed states) | `ALLOWED_STATUSES` per `DocType` | `core/schema.py` |

--- a/rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md
+++ b/rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md
@@ -59,9 +59,13 @@ move *from the current value*". Today `Completed → Proposed` and
 This is exactly the essay's "state honesty" point: a state needs an entry
 condition and an exit condition, not just a name.
 
-- **Evidence (real, not hypothetical):** FXA-2189 / FXA-2191 — "Fix invalid CHG
-  status" — an illegal status value already shipped once and needed a corrective
-  CHG. A transition graph would have rejected it at write time.
+- **Two layers, do not conflate them.** *Membership* (is the value in the set)
+  is already guarded: FXA-2189 / FXA-2191 fixed FXA-2185, a CHG carrying the
+  out-of-set value `Implemented`, and today's `validate_spec_status` membership
+  check would reject that at write time. That incident is **not** transition
+  evidence. *Transition ordering* (a valid value moving in an illegal order,
+  e.g. `Completed → Proposed`) is the actual Gap A — currently unguarded, no
+  logged incident yet, a latent gap rather than a past failure.
 - **Smallest honest fix (defer to PRP):** one adjacency table per `DocType`,
   built only from that type's own `ALLOWED_STATUSES` (e.g. for PRP,
   `Draft → {Approved, Rejected}`; never an edge that mixes statuses across


### PR DESCRIPTION
## What

Adds `rules/FXA-2306-REF-Object-To-Transformation-Design-Lens.md` (PRJ REF, Active) — a design lens that maps the essay *从对象到转换：对 Agent 生命周期的新看法* (Freelemon, 2026-06-19) onto Alfred as it already exists, and records two evidence-backed gaps as a design basis for future evolve cycles.

**No code change.** This is analysis/design groundwork; any implementation goes through PRP/CHG.

## Why

The essay's engineering kernel ("an object is defined by its legal arrows in/out, not its fields; a `status` string isn't a lifecycle event without entry/exit conditions and evidence") maps almost directly onto Alfred. Capturing the mapping prevents two failure modes: (a) over-reacting and rewriting SOPs in category-theory jargon, and (b) missing the two real gaps the lens exposes.

## Contents

- **§1** Essay ↔ Alfred mapping — Alfred is already ~70% an "arrows" system (SOP `Workflow input/output/requires/provides` = morphisms; `af plan --task` = composition).
- **§2 Gap A** — `ALLOWED_STATUSES` is a flat *set*, not a *transition graph*; `af update --status` validates membership only. Evidence: FXA-2189 / FXA-2191 (a real invalid-status incident).
- **§3 Gap B** — typed SOP I/O metadata is declared on only 5 of ~80 SOPs.
- **§4** YAGNI guard rails — no jargon, no mass backfill, no `ALLOWED_STATUSES` change without a PRP.
- **§5** Reusable "arrows before objects" question set for design / review / evolve.

## Scope hints

Docs-only PR (one new REF + auto-updated index). Review for: accuracy of the code references in §1–§3, correctness of the FXA-2189/2191 evidence claim, and whether the guard rails in §4 are appropriately conservative. No behavior change to validate against.

## Validation

- `af validate --root .` → 0 issues
- `af fmt FXA-2306 --check` → formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)