### PR TITLE
feat(index): render document Status as a dedicated column

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -1,221 +1,221 @@
 # REF-0000: Document Index
 
 **Applies to:** FXA project
-**Last updated:** 2026-06-17
-**Last reviewed:** 2026-06-17
+**Last updated:** 2026-06-20
+**Last reviewed:** 2026-06-20
 **Status:** Active
 
 ---
 
-| ACID | Type | Title |
-|------|------|-------|
-| 1623 | SOP | PR Review Thread Watchdog |
-| 2100 | SOP | Leader Mediated Development |
-| 2101 | CHG | Multi Layer Scan |
-| 2102 | SOP | Release To PyPI |
-| 2103 | CHG | Root Option And Spacing |
-| 2104 | PRP | AF Update Command |
-| 2105 | PRP | AF Rename Command |
-| 2106 | PRP | AF CLI Optimization v0.6 |
-| 2107 | CHG | Code Quality Refactoring |
-| 2108 | REF | Session Retrospective 2026 03 19 D1 |
-| 2109 | CHG | DRY Scan Boilerplate |
-| 2110 | CHG | Lazy Command Loading |
-| 2111 | CHG | List Filtering |
-| 2112 | CHG | JSON Output |
-| 2113 | REF | Discussion Tracker 2026 03 19 D2 |
-| 2114 | CHG | AF Search Command |
-| 2115 | CHG | AF Validate Command |
-| 2116 | PRP | Document Format Contract |
-| 2117 | PRP | AF Filter And Section Update |
-| 2118 | REF | Session Retrospective 2026 03 19 D2 |
-| 2119 | PLN | Document Format Contract Implementation |
-| 2120 | CHG | Create Document Format Contract Reference |
-| 2121 | CHG | Update Create Templates To Format Contract |
-| 2122 | CHG | Enhance Validate Per Type Fields And Status |
-| 2123 | CHG | Migrate Existing Documents To Format Contract |
-| 2124 | CHG | Layered Workflow Routing AF Guide |
-| 2125 | SOP | Workflow Routing PRJ |
-| 2126 | PRP | AF Create Routing Shortcut |
-| 2127 | SOP | Commit Alfred Ops |
-| 2128 | REF | Discussion Tracker 2026 03 20 |
-| 2129 | CHG | Implement Review Scoring Framework |
-| 2130 | CHG | Standardize SOP Section Structure |
-| 2131 | CHG | SOP Template And COR 1103 Reading Guide |
-| 2132 | CHG | AF Validate SOP Section Checking |
-| 2133 | CHG | Migrate All SOPs To Standard Structure |
-| 2134 | PRP | AF Plan Command Workflow Checklist |
-| 2135 | CHG | Implement AF Plan Command |
-| 2136 | SOP | Update README |
-| 2137 | CHG | AF Setup Guide Every Task Wording |
-| 2138 | PRP | Create Routing Document SOP |
-| 2139 | CHG | Implement COR 1004 Create Routing Document SOP |
-| 2140 | PRP | Core Python Schema Architecture |
-| 2141 | PRP | AF Fmt Command |
-| 2142 | CHG | JSON Output For Guide Plan Search Validate |
-| 2143 | CHG | Structured Spec Input For Create Update |
-| 2144 | CHG | AF Where Command |
-| 2145 | PRP | Auto Evolution SOP and CLI |
-| 2146 | REF | Evolution Philosophy |
-| 2147 | CHG | Implement Auto Evolution SOPs REF Philosophy |
-| 2148 | SOP | Evolve SOP |
-| 2149 | SOP | Evolve CLI |
-| 2150 | REF | Evolve Run 20260330 204515 |
-| 2151 | PRP | Translate FXA 2125 Decision Tree To English |
-| 2152 | PRP | Fix FXA 2100 Command Reference And Round Limit |
-| 2153 | CHG | Translate FXA 2125 Decision Tree To English |
-| 2154 | CHG | Fix FXA 2100 Command Reference And Round Limit |
-| 2155 | REF | Evolve Run 20260330 211109 |
-| 2156 | PRP | Extract Duplicated Helpers And Add Gate Detection Tests |
-| 2157 | CHG | Extract Duplicated Helpers And Add Gate Detection Tests |
-| 2158 | REF | Evolve Run 20260330 221843 |
-| 2159 | PRP | Replace Assert With ClickException |
-| 2160 | CHG | Replace Assert With ClickException |
-| 2161 | REF | Evolve Run 20260330 232601 |
-| 2162 | PRP | Extract Atomic Write Helper |
-| 2163 | CHG | Extract Atomic Write Helper |
-| 2164 | REF | Evolve Run 20260401 050827 |
-| 2165 | PRP | Extract Invoke Index Update Helper |
-| 2166 | CHG | Extract Invoke Index Update Helper |
-| 2167 | REF | Evolve Run 20260401 085641 |
-| 2168 | PRP | Deduplicate Plan Cmd Phase Formatters |
-| 2169 | CHG | Deduplicate Plan Cmd Phase Formatters |
-| 2170 | PRP | Evolve CLI Batch C3 C4 C5 |
-| 2171 | CHG | Evolve CLI Batch C3 C4 C5 |
-| 2172 | REF | Evolve SOP Run 20260401 154338 |
-| 2173 | PRP | Define Review Gate And Align Scoring |
-| 2174 | CHG | Define Review Gate And Align Scoring |
-| 2175 | REF | Evolve Run 20260401 220000 |
-| 2176 | PRP | Fix Corrupted FXA 2166 CHG Document |
-| 2177 | PRP | Standardize Role Naming In FXA 2100 |
-| 2178 | PRP | Add AF Tool Context To Review Dispatch Template |
-| 2179 | CHG | Fix Corrupted FXA 2166 CHG Document |
-| 2180 | CHG | Standardize Role Naming In FXA 2100 |
-| 2181 | CHG | Add AF Tool Context To Review Dispatch Template |
-| 2182 | PRP | Add AF Tool Context To COR Workflow Dispatch Steps |
-| 2183 | CHG | Add AF Tool Context To COR Workflow Dispatch Steps |
-| 2184 | REF | Discussion Tracker 2026 04 03 |
-| 2185 | CHG | Add COR 1201 Discussion Tracker Step To AF Setup |
-| 2186 | CHG | Merge Alfred Ops Rules Into FX Alfred |
-| 2187 | REF | Evolve Run 20260404 001357 |
-| 2188 | PRP | Fix FXA 2125 Stale Alfred Ops Refs |
-| 2189 | PRP | Fix FXA 2185 Invalid CHG Status |
-| 2190 | CHG | Fix FXA 2125 Stale Alfred Ops Refs |
-| 2191 | CHG | Fix FXA 2185 Invalid CHG Status |
-| 2192 | REF | Evolve Run 20260404 082129 |
-| 2193 | PRP | Simplify Fmt Metadata Order Comparison |
-| 2194 | CHG | Simplify Fmt Metadata Order Comparison |
-| 2195 | REF | Session Retrospective 2026 04 04 D1 |
-| 2196 | CHG | MkDocs Material PKG Documentation Site |
-| 2197 | CHG | Auto Deploy Docs On Push |
-| 2198 | PRP | COR Evolution Philosophy Reference |
-| 2199 | CHG | Implement COR 1800 REF Evolution Philosophy |
-| 2200 | PRP | Document Tags Metadata Field |
-| 2201 | CHG | Implement Document Tags Metadata Field |
-| 2202 | CHG | Add COR 1612 Respond To PR Review Comments SOP |
-| 2203 | REF | Discussion Tracker 2026 04 05 |
-| 2204 | CHG | Typed SOP Composition For AF Plan |
-| 2205 | PRP | AF Plan Auto Compose Todo And Graph |
-| 2206 | CHG | FXA 2205 Follow Ups ASCII Graph And SOP Metadata Backfills |
-| 2207 | CHG | Add COR 1202 Compose Session Plan SOP |
-| 2208 | CHG | Add Pyright To FXA 2102 Release Prerequisites |
-| 2209 | REF | Evolve Run 20260419 063843 |
-| 2210 | PRP | Close three edge arm coverage gaps with tests |
-| 2211 | CHG | Close three edge arm coverage gaps with tests |
-| 2212 | REF | Evolve Seed ASCII DAG Graph Layout |
-| 2213 | REF | Evolve Run 20260419 094124 |
-| 2214 | PRP | Bundle N2 N3 C4 plan cmd parser area int edges |
-| 2215 | CHG | Bundle N2 N3 plan cmd parser edge tests |
-| 2216 | REF | Discussion Tracker 2026 04 19 |
-| 2217 | PRP | ASCII DAG nested graph layout for af plan graph |
-| 2218 | CHG | ASCII DAG nested graph layout implementation |
-| 2219 | CHG | Migrate ALF Prefix To FXA In PRJ Rules |
-| 2220 | PRP | Layered Workflow Routing USR And PRJ |
-| 2221 | PRP | Standardized Review Scoring Framework |
-| 2222 | PRP | Team Skill Session Resume |
-| 2223 | PRP | Standardized SOP Section Structure |
-| 2224 | PRP | Workflow Enforcement From Advisory To Mandatory |
-| 2225 | PRP | Branching ASCII In Plan Graph |
-| 2226 | CHG | Implement Branching ASCII Data Layer |
-| 2227 | CHG | Implement Branching ASCII Presentation Layer |
-| 2228 | SOP | CHG 2227 Remaining Work — Phases 8b, 9, 10 |
-| 2229 | PRP | Layered SOP Memory Model |
-| 2230 | PRP | Agent Activity Log Protocol |
-| 2231 | CHG | Agent Activity Log Protocol v1 Implementation |
-| 2232 | PRP | Quarkdown Documentation Rendering Layer |
-| 2233 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 |
-| 2234 | CHG | Promote GitHub App PR Review Bot Loop SOP |
-| 2235 | PRP | Agent Editable Helpers And Skills |
-| 2236 | CHG | Implement Agent Editable Helpers And Skills |
-| 2237 | REF | Agent Helpers And Skills Usage |
-| 2238 | CHG | Add COR 1615 Operator Checklist |
-| 2239 | CHG | Add COR 1801 Pattern Promotion SOP |
-| 2240 | PRP | Code Review Checklist v2.0 as Alfred SOP REF |
-| 2241 | CHG | Create Code Review Checklist COR 1705 1709 |
-| 2242 | CHG | Promote Multi Phase Execution Contract SOP |
-| 2243 | CHG | Add COR 1615 Pre Trigger Finalization Gate |
-| 2244 | PRP | Add Custom Pytest Markers for Test Categorization |
-| 2245 | PRP | Add Parametrized Tests for Repeated Assertions |
-| 2246 | PRP | Enforce Pytest Coverage Thresholds |
-| 2247 | CHG | Implement Pytest Test Governance Improvements |
-| 2248 | REF | SOP Outcome Notebook |
-| 2249 | REF | Evolve CLI Run 20260405 210018 |
-| 2250 | PRP | Extract H1 Extraction Regex To Parser |
-| 2251 | CHG | Consolidate H1 Regex Named Groups |
-| 2252 | REF | Evolve Run 20260405 225815 |
-| 2253 | PRP | Validate Status Flag In Update Cmd |
-| 2254 | CHG | Validate Status Flag In Update Cmd |
-| 2255 | REF | Evolve Run 20260406 070318 |
-| 2256 | CHG | Add Completion Checklist To Evolve CLI SOP |
-| 2257 | PRP | Deduplicate Total Issues In Validate Cmd |
-| 2258 | CHG | Deduplicate Total Issues In Validate Cmd |
-| 2259 | CHG | Add Completion Checklist To Evolve SOP |
-| 2260 | CHG | Add Post Push Review Loop To Evolve SOPs |
-| 2261 | CHG | Reorder Review Loop To Process Comments Before CI Gate |
-| 2262 | PRP | COR 1613 Council Review Mechanism |
-| 2263 | CHG | COR 1103 Add Council Review Routing |
-| 2264 | CHG | COR 1602 Add Council Cross Reference |
-| 2265 | PRP | COR 1503 Diagnose Feedback Loop |
-| 2266 | CHG | COR 1103 Add Diagnose Routing |
-| 2267 | CHG | COR 1613 Add Half Diagnosed Fix Prohibition |
-| 2268 | CHG | COR 1504 REF Diagnose Phase Gates |
-| 2269 | PRP | COR 1203 Pre Task Alignment |
-| 2270 | CHG | COR 1103 Add Pre Task Alignment Routing |
-| 2271 | CTX | Alfred Glossary |
-| 2272 | CHG | Merge fx_alfredrules Into Top Level rules |
-| 2273 | PRP | AF Tag Star Command And List Filter |
-| 2274 | PRP | AF Star Command Bookmark Documents |
-| 2275 | CHG | FXA 2102 Promote README Check To Numbered Step |
-| 2276 | REF | Multi Agent Loop Configuration |
-| 2277 | CHG | COR 1622 Schema Refinements For Heterogeneous Adopters |
-| 2278 | CHG | Add FXA 2276 Invocation Shorthand |
-| 2279 | CHG | Codify GitHub App PR Review Bot Scope Hint Technique In COR 1612 + COR 1615 |
-| 2280 | CHG | FXA 2276 Phase 10 Mergeable Trigger |
-| 2281 | CHG | Add COR 1802 Build Weighted Decision Matrix SOP |
-| 2282 | CHG | Add Scoring to COR 1200 Session Retrospective |
-| 2283 | CHG | Add Retrospective Phase to COR 1617 |
-| 2284 | REF | Discussion Tracker 2026 05 15 |
-| 2285 | CHG | Pre Merge GH Bot Review Sweep Gate |
-| 2286 | CHG | Explicit UTF 8 For Alfred Document IO |
-| 2287 | CHG | COR 1500 Phase 1 Worker Assignment Sub Section |
-| 2288 | CHG | COR 1500 Phase 2 Implementer Reading Constraint |
-| 2289 | CHG | COR 1619 Two Worker TDD Dispatch Sub Section |
-| 2290 | CHG | COR 1619 Decision Tree Two Worker Branch |
-| 2291 | CHG | COR 1622 Test Writer Worker Agent Schema Row |
-| 2292 | CHG | Alfred Opt In Two Worker TDD Split |
-| 2293 | PRP | 11 Star SOP Experience Review |
-| 2294 | CHG | Fence Aware Extract Section |
-| 2295 | CHG | Compose Domain Exceptions |
-| 2296 | CHG | Validate Unknown Type Warning |
-| 2297 | CHG | CLAUDE Md Refresh And Drift Guard |
-| 2298 | CHG | CI Python Matrix And Pyright Gate |
-| 2299 | CHG | Workflow Fence Loop Dedup |
-| 2300 | CHG | Root Auto Discovery |
-| 2301 | CHG | JSON Output And Exit Code Unification |
-| 2302 | CHG | Plan Cmd Decomposition |
-| 2303 | PRP | AF Export Single File Runbook |
-| 2304 | CHG | Export Repeatable Sources And File Includes |
-| 2305 | PRP | Cross Platform Agent Skill |
+| ACID | Type | Title | Status |
+|------|------|-------|--------|
+| 1623 | SOP | PR Review Thread Watchdog | Active |
+| 2100 | SOP | Leader Mediated Development | Active |
+| 2101 | CHG | Multi Layer Scan | Approved |
+| 2102 | SOP | Release To PyPI | Active |
+| 2103 | CHG | Root Option And Spacing | Approved |
+| 2104 | PRP | AF Update Command | Implemented |
+| 2105 | PRP | AF Rename Command | Rejected |
+| 2106 | PRP | AF CLI Optimization v0.6 | Implemented |
+| 2107 | CHG | Code Quality Refactoring | Completed |
+| 2108 | REF | Session Retrospective 2026 03 19 D1 | Active |
+| 2109 | CHG | DRY Scan Boilerplate | Proposed |
+| 2110 | CHG | Lazy Command Loading | Proposed |
+| 2111 | CHG | List Filtering | Proposed |
+| 2112 | CHG | JSON Output | Proposed |
+| 2113 | REF | Discussion Tracker 2026 03 19 D2 | Active |
+| 2114 | CHG | AF Search Command | Proposed |
+| 2115 | CHG | AF Validate Command | Proposed |
+| 2116 | PRP | Document Format Contract | Implemented |
+| 2117 | PRP | AF Filter And Section Update | Draft |
+| 2118 | REF | Session Retrospective 2026 03 19 D2 | Active |
+| 2119 | PLN | Document Format Contract Implementation | Completed |
+| 2120 | CHG | Create Document Format Contract Reference | Completed |
+| 2121 | CHG | Update Create Templates To Format Contract | Completed |
+| 2122 | CHG | Enhance Validate Per Type Fields And Status | Completed |
+| 2123 | CHG | Migrate Existing Documents To Format Contract | Completed |
+| 2124 | CHG | Layered Workflow Routing AF Guide | Completed |
+| 2125 | SOP | Workflow Routing PRJ | Active |
+| 2126 | PRP | AF Create Routing Shortcut | Rejected |
+| 2127 | SOP | Commit Alfred Ops | Deprecated |
+| 2128 | REF | Discussion Tracker 2026 03 20 | Active |
+| 2129 | CHG | Implement Review Scoring Framework | Completed |
+| 2130 | CHG | Standardize SOP Section Structure | Rolled Back |
+| 2131 | CHG | SOP Template And COR 1103 Reading Guide | Completed |
+| 2132 | CHG | AF Validate SOP Section Checking | Completed |
+| 2133 | CHG | Migrate All SOPs To Standard Structure | Completed |
+| 2134 | PRP | AF Plan Command Workflow Checklist | Implemented |
+| 2135 | CHG | Implement AF Plan Command | Completed |
+| 2136 | SOP | Update README | Active |
+| 2137 | CHG | AF Setup Guide Every Task Wording | Completed |
+| 2138 | PRP | Create Routing Document SOP | Approved |
+| 2139 | CHG | Implement COR 1004 Create Routing Document SOP | Completed |
+| 2140 | PRP | Core Python Schema Architecture | Implemented |
+| 2141 | PRP | AF Fmt Command | Implemented |
+| 2142 | CHG | JSON Output For Guide Plan Search Validate | Completed |
+| 2143 | CHG | Structured Spec Input For Create Update | Completed |
+| 2144 | CHG | AF Where Command | Completed |
+| 2145 | PRP | Auto Evolution SOP and CLI | Approved |
+| 2146 | REF | Evolution Philosophy | Active |
+| 2147 | CHG | Implement Auto Evolution SOPs REF Philosophy | Completed |
+| 2148 | SOP | Evolve SOP | Active |
+| 2149 | SOP | Evolve CLI | Active |
+| 2150 | REF | Evolve Run 20260330 204515 | Active |
+| 2151 | PRP | Translate FXA 2125 Decision Tree To English | Implemented |
+| 2152 | PRP | Fix FXA 2100 Command Reference And Round Limit | Implemented |
+| 2153 | CHG | Translate FXA 2125 Decision Tree To English | Completed |
+| 2154 | CHG | Fix FXA 2100 Command Reference And Round Limit | Completed |
+| 2155 | REF | Evolve Run 20260330 211109 | Active |
+| 2156 | PRP | Extract Duplicated Helpers And Add Gate Detection Tests | Draft |
+| 2157 | CHG | Extract Duplicated Helpers And Add Gate Detection Tests | Proposed |
+| 2158 | REF | Evolve Run 20260330 221843 | Active |
+| 2159 | PRP | Replace Assert With ClickException | Draft |
+| 2160 | CHG | Replace Assert With ClickException | Proposed |
+| 2161 | REF | Evolve Run 20260330 232601 | Active |
+| 2162 | PRP | Extract Atomic Write Helper | Draft |
+| 2163 | CHG | Extract Atomic Write Helper | Approved |
+| 2164 | REF | Evolve Run 20260401 050827 | Active |
+| 2165 | PRP | Extract Invoke Index Update Helper | Draft |
+| 2166 | CHG | Extract Invoke Index Update Helper | Approved |
+| 2167 | REF | Evolve Run 20260401 085641 | Active |
+| 2168 | PRP | Deduplicate Plan Cmd Phase Formatters | Draft |
+| 2169 | CHG | Deduplicate Plan Cmd Phase Formatters | Proposed |
+| 2170 | PRP | Evolve CLI Batch C3 C4 C5 | Draft |
+| 2171 | CHG | Evolve CLI Batch C3 C4 C5 | Proposed |
+| 2172 | REF | Evolve SOP Run 20260401 154338 | Active |
+| 2173 | PRP | Define Review Gate And Align Scoring | Draft |
+| 2174 | CHG | Define Review Gate And Align Scoring | Proposed |
+| 2175 | REF | Evolve Run 20260401 220000 | Active |
+| 2176 | PRP | Fix Corrupted FXA 2166 CHG Document | Approved |
+| 2177 | PRP | Standardize Role Naming In FXA 2100 | Approved |
+| 2178 | PRP | Add AF Tool Context To Review Dispatch Template | Approved |
+| 2179 | CHG | Fix Corrupted FXA 2166 CHG Document | Completed |
+| 2180 | CHG | Standardize Role Naming In FXA 2100 | Completed |
+| 2181 | CHG | Add AF Tool Context To Review Dispatch Template | Completed |
+| 2182 | PRP | Add AF Tool Context To COR Workflow Dispatch Steps | Approved |
+| 2183 | CHG | Add AF Tool Context To COR Workflow Dispatch Steps | Completed |
+| 2184 | REF | Discussion Tracker 2026 04 03 | Active |
+| 2185 | CHG | Add COR 1201 Discussion Tracker Step To AF Setup | Completed |
+| 2186 | CHG | Merge Alfred Ops Rules Into FX Alfred | Proposed |
+| 2187 | REF | Evolve Run 20260404 001357 | Active |
+| 2188 | PRP | Fix FXA 2125 Stale Alfred Ops Refs | Approved |
+| 2189 | PRP | Fix FXA 2185 Invalid CHG Status | Approved |
+| 2190 | CHG | Fix FXA 2125 Stale Alfred Ops Refs | Completed |
+| 2191 | CHG | Fix FXA 2185 Invalid CHG Status | Completed |
+| 2192 | REF | Evolve Run 20260404 082129 | Active |
+| 2193 | PRP | Simplify Fmt Metadata Order Comparison | Draft |
+| 2194 | CHG | Simplify Fmt Metadata Order Comparison | Proposed |
+| 2195 | REF | Session Retrospective 2026 04 04 D1 | Active |
+| 2196 | CHG | MkDocs Material PKG Documentation Site | Proposed |
+| 2197 | CHG | Auto Deploy Docs On Push | Proposed |
+| 2198 | PRP | COR Evolution Philosophy Reference | Approved |
+| 2199 | CHG | Implement COR 1800 REF Evolution Philosophy | Completed |
+| 2200 | PRP | Document Tags Metadata Field | Approved |
+| 2201 | CHG | Implement Document Tags Metadata Field | Completed |
+| 2202 | CHG | Add COR 1612 Respond To PR Review Comments SOP | Completed |
+| 2203 | REF | Discussion Tracker 2026 04 05 | Active |
+| 2204 | CHG | Typed SOP Composition For AF Plan | Proposed |
+| 2205 | PRP | AF Plan Auto Compose Todo And Graph | Implemented |
+| 2206 | CHG | FXA 2205 Follow Ups ASCII Graph And SOP Metadata Backfills | Completed |
+| 2207 | CHG | Add COR 1202 Compose Session Plan SOP | Completed |
+| 2208 | CHG | Add Pyright To FXA 2102 Release Prerequisites | Approved |
+| 2209 | REF | Evolve Run 20260419 063843 | Active |
+| 2210 | PRP | Close three edge arm coverage gaps with tests | Draft |
+| 2211 | CHG | Close three edge arm coverage gaps with tests | Completed |
+| 2212 | REF | Evolve Seed ASCII DAG Graph Layout | Active |
+| 2213 | REF | Evolve Run 20260419 094124 | Active |
+| 2214 | PRP | Bundle N2 N3 C4 plan cmd parser area int edges | Draft |
+| 2215 | CHG | Bundle N2 N3 plan cmd parser edge tests | Completed |
+| 2216 | REF | Discussion Tracker 2026 04 19 | Active |
+| 2217 | PRP | ASCII DAG nested graph layout for af plan graph | Draft |
+| 2218 | CHG | ASCII DAG nested graph layout implementation | Completed |
+| 2219 | CHG | Migrate ALF Prefix To FXA In PRJ Rules | Approved |
+| 2220 | PRP | Layered Workflow Routing USR And PRJ | Implemented |
+| 2221 | PRP | Standardized Review Scoring Framework | Implemented |
+| 2222 | PRP | Team Skill Session Resume | Rejected |
+| 2223 | PRP | Standardized SOP Section Structure | Implemented |
+| 2224 | PRP | Workflow Enforcement From Advisory To Mandatory | Approved |
+| 2225 | PRP | Branching ASCII In Plan Graph | Approved |
+| 2226 | CHG | Implement Branching ASCII Data Layer | Proposed |
+| 2227 | CHG | Implement Branching ASCII Presentation Layer | Proposed |
+| 2228 | SOP | CHG 2227 Remaining Work — Phases 8b, 9, 10 | Active |
+| 2229 | PRP | Layered SOP Memory Model | Draft |
+| 2230 | PRP | Agent Activity Log Protocol | Approved |
+| 2231 | CHG | Agent Activity Log Protocol v1 Implementation | Proposed |
+| 2232 | PRP | Quarkdown Documentation Rendering Layer | Draft |
+| 2233 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 | Proposed |
+| 2234 | CHG | Promote GitHub App PR Review Bot Loop SOP | Completed |
+| 2235 | PRP | Agent Editable Helpers And Skills | Approved |
+| 2236 | CHG | Implement Agent Editable Helpers And Skills | Completed |
+| 2237 | REF | Agent Helpers And Skills Usage | Active |
+| 2238 | CHG | Add COR 1615 Operator Checklist | Completed |
+| 2239 | CHG | Add COR 1801 Pattern Promotion SOP | Completed |
+| 2240 | PRP | Code Review Checklist v2.0 as Alfred SOP REF | Draft |
+| 2241 | CHG | Create Code Review Checklist COR 1705 1709 | Proposed |
+| 2242 | CHG | Promote Multi Phase Execution Contract SOP | Completed |
+| 2243 | CHG | Add COR 1615 Pre Trigger Finalization Gate | Completed |
+| 2244 | PRP | Add Custom Pytest Markers for Test Categorization | Draft |
+| 2245 | PRP | Add Parametrized Tests for Repeated Assertions | Draft |
+| 2246 | PRP | Enforce Pytest Coverage Thresholds | Draft |
+| 2247 | CHG | Implement Pytest Test Governance Improvements | Completed |
+| 2248 | REF | SOP Outcome Notebook | Draft |
+| 2249 | REF | Evolve CLI Run 20260405 210018 | Active |
+| 2250 | PRP | Extract H1 Extraction Regex To Parser | Draft |
+| 2251 | CHG | Consolidate H1 Regex Named Groups | Proposed |
+| 2252 | REF | Evolve Run 20260405 225815 | Active |
+| 2253 | PRP | Validate Status Flag In Update Cmd | Draft |
+| 2254 | CHG | Validate Status Flag In Update Cmd | Proposed |
+| 2255 | REF | Evolve Run 20260406 070318 | Active |
+| 2256 | CHG | Add Completion Checklist To Evolve CLI SOP | Completed |
+| 2257 | PRP | Deduplicate Total Issues In Validate Cmd | Draft |
+| 2258 | CHG | Deduplicate Total Issues In Validate Cmd | Completed |
+| 2259 | CHG | Add Completion Checklist To Evolve SOP | Completed |
+| 2260 | CHG | Add Post Push Review Loop To Evolve SOPs | Completed |
+| 2261 | CHG | Reorder Review Loop To Process Comments Before CI Gate | Proposed |
+| 2262 | PRP | COR 1613 Council Review Mechanism | Approved |
+| 2263 | CHG | COR 1103 Add Council Review Routing | Approved |
+| 2264 | CHG | COR 1602 Add Council Cross Reference | Approved |
+| 2265 | PRP | COR 1503 Diagnose Feedback Loop | Approved |
+| 2266 | CHG | COR 1103 Add Diagnose Routing | Approved |
+| 2267 | CHG | COR 1613 Add Half Diagnosed Fix Prohibition | Approved |
+| 2268 | CHG | COR 1504 REF Diagnose Phase Gates | Proposed |
+| 2269 | PRP | COR 1203 Pre Task Alignment | Approved |
+| 2270 | CHG | COR 1103 Add Pre Task Alignment Routing | Approved |
+| 2271 | CTX | Alfred Glossary | Active |
+| 2272 | CHG | Merge fx_alfredrules Into Top Level rules | Proposed |
+| 2273 | PRP | AF Tag Star Command And List Filter | Rejected |
+| 2274 | PRP | AF Star Command Bookmark Documents | Draft |
+| 2275 | CHG | FXA 2102 Promote README Check To Numbered Step | Proposed |
+| 2276 | REF | Multi Agent Loop Configuration | Active |
+| 2277 | CHG | COR 1622 Schema Refinements For Heterogeneous Adopters | Proposed |
+| 2278 | CHG | Add FXA 2276 Invocation Shorthand | Proposed |
+| 2279 | CHG | Codify GitHub App PR Review Bot Scope Hint Technique In COR 1612 + COR 1615 | Proposed |
+| 2280 | CHG | FXA 2276 Phase 10 Mergeable Trigger | Proposed |
+| 2281 | CHG | Add COR 1802 Build Weighted Decision Matrix SOP | Approved |
+| 2282 | CHG | Add Scoring to COR 1200 Session Retrospective | Proposed |
+| 2283 | CHG | Add Retrospective Phase to COR 1617 | Proposed |
+| 2284 | REF | Discussion Tracker 2026 05 15 | Active |
+| 2285 | CHG | Pre Merge GH Bot Review Sweep Gate | Completed |
+| 2286 | CHG | Explicit UTF 8 For Alfred Document IO | Approved |
+| 2287 | CHG | COR 1500 Phase 1 Worker Assignment Sub Section | Approved |
+| 2288 | CHG | COR 1500 Phase 2 Implementer Reading Constraint | Approved |
+| 2289 | CHG | COR 1619 Two Worker TDD Dispatch Sub Section | Approved |
+| 2290 | CHG | COR 1619 Decision Tree Two Worker Branch | Approved |
+| 2291 | CHG | COR 1622 Test Writer Worker Agent Schema Row | Approved |
+| 2292 | CHG | Alfred Opt In Two Worker TDD Split | Approved |
+| 2293 | PRP | 11 Star SOP Experience Review | Implemented |
+| 2294 | CHG | Fence Aware Extract Section | Completed |
+| 2295 | CHG | Compose Domain Exceptions | Completed |
+| 2296 | CHG | Validate Unknown Type Warning | Completed |
+| 2297 | CHG | CLAUDE Md Refresh And Drift Guard | Completed |
+| 2298 | CHG | CI Python Matrix And Pyright Gate | Completed |
+| 2299 | CHG | Workflow Fence Loop Dedup | Completed |
+| 2300 | CHG | Root Auto Discovery | Completed |
+| 2301 | CHG | JSON Output And Exit Code Unification | Completed |
+| 2302 | CHG | Plan Cmd Decomposition | Completed |
+| 2303 | PRP | AF Export Single File Runbook | Implemented |
+| 2304 | CHG | Export Repeatable Sources And File Includes | Completed |
+| 2305 | PRP | Cross Platform Agent Skill | Implemented |
 
 ---
 
@@ -223,4 +223,4 @@
 
 | Date | Change | By |
 |------|--------|----|
-| 2026-06-17 | Auto-generated by af index | af CLI |
+| 2026-06-20 | Auto-generated by af index | af CLI |

--- a/src/fx_alfred/commands/index_cmd.py
+++ b/src/fx_alfred/commands/index_cmd.py
@@ -8,21 +8,6 @@ from fx_alfred.context import get_root, root_option
 from fx_alfred.core.document import Document
 
 
-# Active documents are the only rows that appear without an index marker.
-# Every other authored status is surfaced so the index cannot make a
-# non-active document look live.
-_UNMARKED_STATUS = "Active"
-
-
-def _status_marker(doc: Document) -> str:
-    """Return a status annotation string for *doc*, or ``""`` if the status is
-    a default/working state that needs no marker."""
-    status = doc.status
-    if not status or status == _UNMARKED_STATUS:
-        return ""
-    return f" ({status})"
-
-
 def _build_index(title: str, docs: list[Document], prefix: str) -> str:
     today = date.today().isoformat()
 
@@ -38,12 +23,12 @@ def _build_index(title: str, docs: list[Document], prefix: str) -> str:
         "",
     ]
 
-    lines.append("| ACID | Type | Title |")
-    lines.append("|------|------|-------|")
+    lines.append("| ACID | Type | Title | Status |")
+    lines.append("|------|------|-------|--------|")
     sorted_docs = sorted(docs, key=lambda d: d.acid)
     for doc in sorted_docs:
-        marker = _status_marker(doc)
-        lines.append(f"| {doc.acid} | {doc.type_code} | {doc.title}{marker} |")
+        status = doc.status or "—"
+        lines.append(f"| {doc.acid} | {doc.type_code} | {doc.title} | {status} |")
 
     lines.append("")
     lines.append("---")

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -166,7 +166,7 @@ def test_index_multiple_prefixes_compliant(tmp_path):
     assert nrv_content.startswith("# REF-0000: Document Index\n")
 
 
-# --- Part B: Status marker tests ---
+# --- Part B: Status column tests ---
 
 
 def _make_doc_with_status(
@@ -189,32 +189,43 @@ def _make_doc_with_status(
     return path
 
 
-def test_index_omits_marker_for_active_status(tmp_path):
-    """Active SOP doc has no status marker in its index row."""
+def test_index_has_status_column_header(tmp_path):
+    """Generated index table has a dedicated Status column."""
     rules_dir = tmp_path / "rules"
     rules_dir.mkdir()
     _make_doc_with_status(rules_dir, "2100", "SOP", "Active")
     runner = CliRunner()
     runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
     content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | SOP | Doc 2100 |" in content
-    assert "(Active)" not in content
+    assert "| ACID | Type | Title | Status |" in content
 
 
-def test_index_shows_approved_marker(tmp_path):
-    """Approved PRP doc shows (Approved) marker in its index row."""
+def test_index_shows_active_in_status_column(tmp_path):
+    """Active status is rendered in the Status column, not hidden."""
     rules_dir = tmp_path / "rules"
     rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "PRP", "Approved")
+    _make_doc_with_status(rules_dir, "2100", "SOP", "Active")
     runner = CliRunner()
     runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
     content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | PRP | Doc 2100 (Approved) |" in content
+    assert "| 2100 | SOP | Doc 2100 | Active |" in content
+
+
+def test_index_renders_em_dash_when_status_missing(tmp_path):
+    """A doc with no Status field renders an em dash in the Status column."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    (rules_dir / "TST-2100-SOP-Doc-2100.md").write_text("# SOP-2100: Doc 2100\n")
+    runner = CliRunner()
+    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
+    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
+    assert "| 2100 | SOP | Doc 2100 | — |" in content
 
 
 @pytest.mark.parametrize(
     ("type_code", "status"),
     [
+        ("SOP", "Active"),
         ("SOP", "Draft"),
         ("SOP", "Deprecated"),
         ("PRP", "Draft"),
@@ -230,6 +241,7 @@ def test_index_shows_approved_marker(tmp_path):
         ("ADR", "Accepted"),
         ("ADR", "Superseded"),
         ("ADR", "Deprecated"),
+        ("REF", "Active"),
         ("REF", "Draft"),
         ("REF", "Deprecated"),
         ("PLN", "Draft"),
@@ -240,107 +252,19 @@ def test_index_shows_approved_marker(tmp_path):
         ("INC", "Monitoring"),
     ],
 )
-def test_index_shows_all_allowed_non_active_status_markers(tmp_path, type_code, status):
-    """Every allowed non-Active status is visible in the generated index."""
+def test_index_shows_status_in_column(tmp_path, type_code, status):
+    """Every allowed status is rendered verbatim in the Status column."""
     rules_dir = tmp_path / "rules"
     rules_dir.mkdir()
     _make_doc_with_status(rules_dir, "2100", type_code, status)
     runner = CliRunner()
     runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
     content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert f"| 2100 | {type_code} | Doc 2100 ({status}) |" in content
-
-
-def test_index_shows_withdrawn_marker_when_authored(tmp_path):
-    """A Withdrawn status marker is derived when a document carries it."""
-    rules_dir = tmp_path / "rules"
-    rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "PRP", "Withdrawn")
-    runner = CliRunner()
-    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
-    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | PRP | Doc 2100 (Withdrawn) |" in content
-
-
-def test_index_shows_rejected_marker(tmp_path):
-    """Rejected PRP doc shows (Rejected) marker in its index row."""
-    rules_dir = tmp_path / "rules"
-    rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "PRP", "Rejected")
-    runner = CliRunner()
-    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
-    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | PRP | Doc 2100 (Rejected) |" in content
-
-
-def test_index_shows_draft_marker(tmp_path):
-    """Draft SOP doc shows (Draft) marker in its index row."""
-    rules_dir = tmp_path / "rules"
-    rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "SOP", "Draft")
-    runner = CliRunner()
-    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
-    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | SOP | Doc 2100 (Draft) |" in content
-
-
-def test_index_shows_deprecated_marker(tmp_path):
-    """Deprecated SOP doc shows (Deprecated) marker in its index row."""
-    rules_dir = tmp_path / "rules"
-    rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "SOP", "Deprecated")
-    runner = CliRunner()
-    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
-    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | SOP | Doc 2100 (Deprecated) |" in content
-
-
-def test_index_shows_superseded_marker(tmp_path):
-    """Superseded ADR doc shows (Superseded) marker in its index row."""
-    rules_dir = tmp_path / "rules"
-    rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "ADR", "Superseded")
-    runner = CliRunner()
-    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
-    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | ADR | Doc 2100 (Superseded) |" in content
-
-
-def test_index_shows_implemented_marker(tmp_path):
-    """Implemented PRP doc shows (Implemented) marker in its index row."""
-    rules_dir = tmp_path / "rules"
-    rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "PRP", "Implemented")
-    runner = CliRunner()
-    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
-    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | PRP | Doc 2100 (Implemented) |" in content
-
-
-def test_index_shows_completed_marker(tmp_path):
-    """Completed PLN doc shows (Completed) marker in its index row."""
-    rules_dir = tmp_path / "rules"
-    rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "PLN", "Completed")
-    runner = CliRunner()
-    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
-    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | PLN | Doc 2100 (Completed) |" in content
-
-
-def test_index_shows_cancelled_marker(tmp_path):
-    """Cancelled PLN doc shows (Cancelled) marker in its index row."""
-    rules_dir = tmp_path / "rules"
-    rules_dir.mkdir()
-    _make_doc_with_status(rules_dir, "2100", "PLN", "Cancelled")
-    runner = CliRunner()
-    runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
-    content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | PLN | Doc 2100 (Cancelled) |" in content
+    assert f"| 2100 | {type_code} | Doc 2100 | {status} |" in content
 
 
 def test_index_handles_mixed_statuses(tmp_path):
-    """Multiple docs with different statuses each show correct markers."""
+    """Multiple docs with different statuses each show their own column value."""
     rules_dir = tmp_path / "rules"
     rules_dir.mkdir()
     _make_doc_with_status(rules_dir, "2100", "SOP", "Active")
@@ -350,9 +274,7 @@ def test_index_handles_mixed_statuses(tmp_path):
     runner = CliRunner()
     runner.invoke(cli, ["index", "--root", str(tmp_path)], catch_exceptions=False)
     content = (rules_dir / "TST-0000-REF-Document-Index.md").read_text()
-    assert "| 2100 | SOP | Doc 2100 |" in content
-    assert "| 2101 | PRP | Doc 2101 (Rejected) |" in content
-    assert "| 2102 | SOP | Doc 2102 (Draft) |" in content
-    assert "| 2103 | SOP | Doc 2103 (Deprecated) |" in content
-    # Verify no false positives
-    assert "(Active)" not in content
+    assert "| 2100 | SOP | Doc 2100 | Active |" in content
+    assert "| 2101 | PRP | Doc 2101 | Rejected |" in content
+    assert "| 2102 | SOP | Doc 2102 | Draft |" in content
+    assert "| 2103 | SOP | Doc 2103 | Deprecated |" in content


### PR DESCRIPTION
## What

`af index` now renders document lifecycle status in its **own `Status` column** instead of gluing it onto the Title as `Title (Approved)`.

Before:
```
| ACID | Type | Title |
| 2104 | PRP  | AF Update Command (Implemented) |
```
After:
```
| ACID | Type | Title             | Status      |
| 2104 | PRP  | AF Update Command | Implemented |
```

## Why

- Uniform layout — status is structured data, so it belongs in a column, not parenthesised inside the title.
- Honest visibility — every row now shows its lifecycle state, including `Active` (previously hidden).
- Net simplification — deletes the `_status_marker` / `_UNMARKED_STATUS` special-casing.

The per-document `**Status:**` field is unchanged; this only changes how the generated index *renders* it.

## Changes

- `commands/index_cmd.py` — 4-column table; missing status renders as `—`.
- `tests/test_index_cmd.py` — Part B rewritten to assert the column format (covers all allowed statuses + missing-status + mixed).
- `rules/FXA-0000-REF-Document-Index.md` — regenerated.

## Scope hints

Cosmetic index-rendering change. Review for: the em-dash fallback on missing status, and that no other test/consumer pins the old 3-column `| ACID | Type | Title |` header. No behavior change to document content.

## Validation

- `pytest` → 1125 passed
- `ruff check` clean, `pyright` clean on changed file
- `af index` regenerated; `af validate` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)