### PR TITLE
feat(render): af render — Markdown file to standalone HTML document

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,7 @@ af plan --task "DESC" [SOP_ID ...]          # auto-compose SOPs via Task tags
 af setup                                    # suggested prompts for agent config
 af list [--type TYPE] [--prefix PREFIX] [--source SOURCE] [--tag TAG] [--json]
 af read IDENTIFIER [--json]                 # read by PREFIX-ACID or ACID only
+af render FILE.md [-o OUT.html] [--title T] # render a Markdown file to a standalone HTML document
 af create [TYPE] --prefix PREFIX --acid ACID|--area AREA --title TITLE [--layer project|user] [--subdir] [--spec FILE] [--dry-run]
 af update IDENTIFIER [--status] [--field KEY VALUE] [--history TEXT] [--by TEXT] [--title TEXT] [--dry-run] [-y] [--spec FILE]
 af where IDENTIFIER [--json]               # print absolute file path of a document
@@ -60,6 +61,7 @@ src/fx_alfred/
 │   ├── log_validate_cmd.py # Phase 0 scaffolding (CHG-2231) — NOT wired into cli.py
 │   ├── plan_cmd.py     # workflow checklist from SOPs (text/JSON/todo/graph modes)
 │   ├── read_cmd.py     # read + --json
+│   ├── render_cmd.py   # af render — Markdown file -> standalone HTML document
 │   ├── search_cmd.py   # content search
 │   ├── setup_cmd.py    # agent configuration prompts
 │   ├── skill_cmd.py    # skill document discovery/read
@@ -77,6 +79,7 @@ src/fx_alfred/
 │   ├── compose.py         # af plan --task auto-composition; raises CompositionError
 │   ├── dag_graph.py       # nested phase-box DAG renderer
 │   ├── document.py        # Document dataclass, FILENAME_PATTERN
+│   ├── markdown_render.py # minimal zero-dep Markdown -> HTML renderer (af render)
 │   ├── mermaid.py         # Mermaid diagram renderer
 │   ├── normalize.py       # slugify(), sort_metadata(), normalize_date(), strip_trailing_whitespace()
 │   ├── parser.py          # parse_metadata(), render_document(), extract_section(), fence-state iterator

--- a/src/fx_alfred/cli.py
+++ b/src/fx_alfred/cli.py
@@ -44,6 +44,7 @@ Quick Start:
         "list": "fx_alfred.commands.list_cmd:list_cmd",
         "plan": "fx_alfred.commands.plan_cmd:plan_cmd",
         "read": "fx_alfred.commands.read_cmd:read_cmd",
+        "render": "fx_alfred.commands.render_cmd:render_cmd",
         "setup": "fx_alfred.commands.setup_cmd:setup_cmd",
         "search": "fx_alfred.commands.search_cmd:search_cmd",
         "skill": "fx_alfred.commands.skill_cmd:skill_cmd",

--- a/src/fx_alfred/commands/render_cmd.py
+++ b/src/fx_alfred/commands/render_cmd.py
@@ -10,9 +10,13 @@ from fx_alfred.core.markdown_render import render_document
 
 
 def _derive_title(md: str, file: Path) -> str:
-    """Title = the first ATX H1 if present, else the file stem."""
+    """Title = the first ATX H1 *outside* code fences, else the file stem."""
+    in_fence = False
     for line in md.splitlines():
-        if line.startswith("# "):
+        if line.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
+        if not in_fence and line.startswith("# "):
             return line[2:].strip()
     return file.stem
 
@@ -35,6 +39,8 @@ def render_cmd(file: Path, output: Path | None, title: str | None) -> None:
     """
     if not file.exists():
         raise click.ClickException(f"File not found: {file}")
+    if file.is_dir():
+        raise click.ClickException(f"Not a file: {file}")
     md = file.read_text(encoding="utf-8")
     html_doc = render_document(md, title or _derive_title(md, file))
     if output is not None:

--- a/src/fx_alfred/commands/render_cmd.py
+++ b/src/fx_alfred/commands/render_cmd.py
@@ -6,45 +6,38 @@ from pathlib import Path
 
 import click
 
-from fx_alfred.core.markdown_render import render_document
+from fx_alfred.core.markdown_render import first_h1, render_document
 
 
 def _derive_title(md: str, file: Path) -> str:
-    """Title = the first ATX H1 *outside* code fences, else the file stem."""
-    in_fence = False
-    for line in md.splitlines():
-        if line.strip().startswith("```"):
-            in_fence = not in_fence
-            continue
-        if not in_fence and line.startswith("# "):
-            return line[2:].strip()
-    return file.stem
+    """Title = the first ATX H1 outside code fences (shared fence rules), else the file stem."""
+    return first_h1(md) or file.stem
 
 
 @click.command("render")
-@click.argument("file", type=click.Path(path_type=Path))
+@click.argument("file")
 @click.option(
     "-o",
     "--output",
-    type=click.Path(path_type=Path),
     help="Write the HTML document to this file instead of stdout.",
 )
 @click.option(
     "--title", help="Document <title> (default: first H1, else the file stem)."
 )
-def render_cmd(file: Path, output: Path | None, title: str | None) -> None:
+def render_cmd(file: str, output: str | None, title: str | None) -> None:
     """Render a Markdown FILE to a standalone HTML document.
 
     With no --output, the HTML is printed to stdout.
     """
-    if not file.exists():
-        raise click.ClickException(f"File not found: {file}")
-    if file.is_dir():
-        raise click.ClickException(f"Not a file: {file}")
-    md = file.read_text(encoding="utf-8")
-    html_doc = render_document(md, title or _derive_title(md, file))
+    path = Path(file)
+    if not path.exists():
+        raise click.ClickException(f"File not found: {path}")
+    if path.is_dir():
+        raise click.ClickException(f"Not a file: {path}")
+    md = path.read_text(encoding="utf-8")
+    html_doc = render_document(md, title or _derive_title(md, path))
     if output is not None:
-        output.write_text(html_doc, encoding="utf-8")
+        Path(output).write_text(html_doc, encoding="utf-8")
         click.echo(f"Wrote {output}")
     else:
         click.echo(html_doc, nl=False)

--- a/src/fx_alfred/commands/render_cmd.py
+++ b/src/fx_alfred/commands/render_cmd.py
@@ -1,0 +1,44 @@
+"""af render command — render a Markdown file to a standalone HTML document."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import click
+
+from fx_alfred.core.markdown_render import render_document
+
+
+def _derive_title(md: str, file: Path) -> str:
+    """Title = the first ATX H1 if present, else the file stem."""
+    for line in md.splitlines():
+        if line.startswith("# "):
+            return line[2:].strip()
+    return file.stem
+
+
+@click.command("render")
+@click.argument("file", type=click.Path(path_type=Path))
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(path_type=Path),
+    help="Write the HTML document to this file instead of stdout.",
+)
+@click.option(
+    "--title", help="Document <title> (default: first H1, else the file stem)."
+)
+def render_cmd(file: Path, output: Path | None, title: str | None) -> None:
+    """Render a Markdown FILE to a standalone HTML document.
+
+    With no --output, the HTML is printed to stdout.
+    """
+    if not file.exists():
+        raise click.ClickException(f"File not found: {file}")
+    md = file.read_text(encoding="utf-8")
+    html_doc = render_document(md, title or _derive_title(md, file))
+    if output is not None:
+        output.write_text(html_doc, encoding="utf-8")
+        click.echo(f"Wrote {output}")
+    else:
+        click.echo(html_doc, nl=False)

--- a/src/fx_alfred/core/markdown_render.py
+++ b/src/fx_alfred/core/markdown_render.py
@@ -33,12 +33,36 @@ _DEFAULT_CSS = (
 
 
 def _inline(text: str) -> str:
-    """Render inline Markdown (emphasis, code, links) over HTML-escaped text."""
+    """Render inline Markdown (emphasis, code, links) to HTML.
+
+    Code spans and links are extracted to placeholders *before* escaping and
+    emphasis run, so emphasis markup never leaks into code/link content and the
+    link target is quote-escaped into the ``href`` attribute.
+    """
+    stash: list[str] = []
+
+    def _hold(replacement: str) -> str:
+        stash.append(replacement)
+        return f"\x00{len(stash) - 1}\x00"
+
+    # Code spans first: content is escaped and protected from emphasis/links.
+    text = _CODE.sub(
+        lambda m: _hold(f"<code>{html.escape(m.group(1), quote=False)}</code>"), text
+    )
+    # Links next: text is escaped; the URL is quote-escaped into href (no injection).
+    text = _LINK.sub(
+        lambda m: _hold(
+            f'<a href="{html.escape(m.group(2), quote=True)}">'
+            f"{html.escape(m.group(1), quote=False)}</a>"
+        ),
+        text,
+    )
+    # Escape the remaining text, then apply emphasis (placeholders are inert).
     out = html.escape(text, quote=False)
-    out = _CODE.sub(lambda m: f"<code>{m.group(1)}</code>", out)
     out = _BOLD.sub(lambda m: f"<strong>{m.group(1)}</strong>", out)
     out = _ITALIC.sub(lambda m: f"<em>{m.group(1) or m.group(2)}</em>", out)
-    out = _LINK.sub(lambda m: f'<a href="{m.group(2)}">{m.group(1)}</a>', out)
+    for idx, replacement in enumerate(stash):  # restore protected spans
+        out = out.replace(f"\x00{idx}\x00", replacement)
     return out
 
 

--- a/src/fx_alfred/core/markdown_render.py
+++ b/src/fx_alfred/core/markdown_render.py
@@ -15,12 +15,22 @@ import re
 _HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
 _UL = re.compile(r"^[-*]\s+(.*)$")
 _OL = re.compile(r"^\d+\.\s+(.*)$")
-_FENCE = re.compile(r"^```")
+_FENCE = re.compile(r"^(`{3,})")  # captures the opening backtick run
 
 _LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _BOLD = re.compile(r"\*\*([^*]+)\*\*")
-_ITALIC = re.compile(r"(?<!\*)\*([^*]+)\*(?!\*)|_([^_]+)_")
+# Underscore emphasis must be at word boundaries (no intraword: ALFRED_AGENT_TOOLS).
+_ITALIC = re.compile(
+    r"(?<!\*)\*([^*]+)\*(?!\*)|(?<![A-Za-z0-9_])_([^_]+)_(?![A-Za-z0-9_])"
+)
 _CODE = re.compile(r"`([^`]+)`")
+
+
+def _is_closing_fence(stripped: str, opener: str) -> bool:
+    """A closing fence is a run of >= len(opener) backticks and nothing else."""
+    s = stripped.rstrip()
+    return bool(s) and set(s) == {"`"} and len(s) >= len(opener)
+
 
 _DEFAULT_CSS = (
     "body{max-width:48rem;margin:2rem auto;padding:0 1rem;"
@@ -76,10 +86,12 @@ def render_body(md: str) -> str:
         if not line.strip():
             i += 1
             continue
-        if _FENCE.match(line.strip()):  # fenced code block (verbatim)
+        fence_open = _FENCE.match(line.strip())  # fenced code block (verbatim)
+        if fence_open:
+            opener = fence_open.group(1)
             i += 1
             code: list[str] = []
-            while i < n and not _FENCE.match(lines[i].strip()):
+            while i < n and not _is_closing_fence(lines[i].strip(), opener):
                 code.append(lines[i])
                 i += 1
             i += 1  # consume closing fence

--- a/src/fx_alfred/core/markdown_render.py
+++ b/src/fx_alfred/core/markdown_render.py
@@ -17,8 +17,17 @@ _UL = re.compile(r"^[-*]\s+(.*)$")
 _OL = re.compile(r"^\d+\.\s+(.*)$")
 _FENCE = re.compile(r"^(`{3,})")  # captures the opening backtick run
 
-_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+# Link target allows one level of balanced parens, e.g. /wiki/C_(programming_language).
+_LINK = re.compile(r"\[([^\]]+)\]\(((?:[^()]|\([^()]*\))*)\)")
+_UNSAFE_SCHEME = re.compile(r"^\s*(?:javascript|data|vbscript):", re.IGNORECASE)
 _BOLD = re.compile(r"\*\*([^*]+)\*\*")
+
+
+def _safe_href(url: str) -> str:
+    """Neutralize javascript:/data:/vbscript: targets — the output is opened in a browser."""
+    return "#" if _UNSAFE_SCHEME.match(url) else url
+
+
 # Underscore emphasis must be at word boundaries (no intraword: ALFRED_AGENT_TOOLS).
 _ITALIC = re.compile(
     r"(?<!\*)\*([^*]+)\*(?!\*)|(?<![A-Za-z0-9_])_([^_]+)_(?![A-Za-z0-9_])"
@@ -62,7 +71,7 @@ def _inline(text: str) -> str:
     # Links next: text is escaped; the URL is quote-escaped into href (no injection).
     text = _LINK.sub(
         lambda m: _hold(
-            f'<a href="{html.escape(m.group(2), quote=True)}">'
+            f'<a href="{html.escape(_safe_href(m.group(2)), quote=True)}">'
             f"{html.escape(m.group(1), quote=False)}</a>"
         ),
         text,
@@ -71,13 +80,21 @@ def _inline(text: str) -> str:
     out = html.escape(text, quote=False)
     out = _BOLD.sub(lambda m: f"<strong>{m.group(1)}</strong>", out)
     out = _ITALIC.sub(lambda m: f"<em>{m.group(1) or m.group(2)}</em>", out)
-    for idx, replacement in enumerate(stash):  # restore protected spans
-        out = out.replace(f"\x00{idx}\x00", replacement)
+    # Restore protected spans; repeat so a span nested in link text (a placeholder
+    # held inside another stash entry) is resolved too.
+    for _ in range(len(stash) + 1):
+        if "\x00" not in out:
+            break
+        for idx, replacement in enumerate(stash):
+            out = out.replace(f"\x00{idx}\x00", replacement)
     return out
 
 
 def render_body(md: str) -> str:
     """Render Markdown source into an HTML body fragment (no document wrapper)."""
+    md = md.replace(
+        "\x00", ""
+    )  # NUL is our placeholder sentinel; never accept it from input
     lines = md.splitlines()
     parts: list[str] = []
     i, n = 0, len(lines)

--- a/src/fx_alfred/core/markdown_render.py
+++ b/src/fx_alfred/core/markdown_render.py
@@ -15,17 +15,27 @@ import re
 _HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
 _UL = re.compile(r"^[-*]\s+(.*)$")
 _OL = re.compile(r"^\d+\.\s+(.*)$")
-_FENCE = re.compile(r"^(`{3,})")  # captures the opening backtick run
+_FENCE = re.compile(
+    r"^(`{3,}|~{3,})"
+)  # captures the opening fence (backtick or tilde run)
 
 # Link target allows one level of balanced parens, e.g. /wiki/C_(programming_language).
 _LINK = re.compile(r"\[([^\]]+)\]\(((?:[^()]|\([^()]*\))*)\)")
-_UNSAFE_SCHEME = re.compile(r"^\s*(?:javascript|data|vbscript):", re.IGNORECASE)
+_UNSAFE_SCHEME = re.compile(r"^(?:javascript|data|vbscript):", re.IGNORECASE)
+_URL_CONTROL = re.compile(
+    r"[\x00-\x20]"
+)  # browsers ignore C0 controls/spaces in the scheme
 _BOLD = re.compile(r"\*\*([^*]+)\*\*")
 
 
 def _safe_href(url: str) -> str:
-    """Neutralize javascript:/data:/vbscript: targets — the output is opened in a browser."""
-    return "#" if _UNSAFE_SCHEME.match(url) else url
+    """Neutralize javascript:/data:/vbscript: targets — the output is opened in a browser.
+
+    Strip C0 controls/spaces before the scheme check, since browsers ignore an
+    embedded tab/newline (``java\\tscript:``) when resolving the protocol.
+    """
+    probe = _URL_CONTROL.sub("", url)
+    return "#" if _UNSAFE_SCHEME.match(probe) else url
 
 
 # Underscore emphasis must be at word boundaries (no intraword: ALFRED_AGENT_TOOLS).
@@ -36,9 +46,33 @@ _CODE = re.compile(r"`([^`]+)`")
 
 
 def _is_closing_fence(stripped: str, opener: str) -> bool:
-    """A closing fence is a run of >= len(opener) backticks and nothing else."""
+    """A closing fence: a run of the opener's char (` or ~), length >= the opener."""
     s = stripped.rstrip()
-    return bool(s) and set(s) == {"`"} and len(s) >= len(opener)
+    return bool(s) and set(s) == {opener[0]} and len(s) >= len(opener)
+
+
+def first_h1(md: str) -> str | None:
+    """The first ATX H1 *outside* fenced code blocks (opener-length aware), else None.
+
+    Shared by ``af render``'s title derivation so it honors the same fence rules
+    as ``render_body`` (a ``#`` line inside a fence is not a heading).
+    """
+    md = md.replace("\x00", "")
+    lines = md.splitlines()
+    i, n = 0, len(lines)
+    while i < n:
+        fence_open = _FENCE.match(lines[i].strip())
+        if fence_open:
+            opener = fence_open.group(1)
+            i += 1
+            while i < n and not _is_closing_fence(lines[i].strip(), opener):
+                i += 1
+            i += 1
+            continue
+        if lines[i].startswith("# "):
+            return lines[i][2:].strip()
+        i += 1
+    return None
 
 
 _DEFAULT_CSS = (

--- a/src/fx_alfred/core/markdown_render.py
+++ b/src/fx_alfred/core/markdown_render.py
@@ -1,0 +1,118 @@
+"""Minimal, dependency-free Markdown -> HTML rendering for ``af render``.
+
+Framework-agnostic (no Click). Covers the core Markdown the ``af render``
+command documents: ATX headings, unordered/ordered lists, fenced code blocks,
+inline code, links, bold/italic emphasis, and paragraphs. This is intentionally
+small and zero-dependency, consistent with Alfred's lean-deps posture — not a
+full CommonMark implementation.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+
+_HEADING = re.compile(r"^(#{1,6})\s+(.*)$")
+_UL = re.compile(r"^[-*]\s+(.*)$")
+_OL = re.compile(r"^\d+\.\s+(.*)$")
+_FENCE = re.compile(r"^```")
+
+_LINK = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_BOLD = re.compile(r"\*\*([^*]+)\*\*")
+_ITALIC = re.compile(r"(?<!\*)\*([^*]+)\*(?!\*)|_([^_]+)_")
+_CODE = re.compile(r"`([^`]+)`")
+
+_DEFAULT_CSS = (
+    "body{max-width:48rem;margin:2rem auto;padding:0 1rem;"
+    "font:16px/1.6 system-ui,sans-serif;color:#222}"
+    "pre{background:#f4f4f4;padding:1rem;overflow:auto;border-radius:6px}"
+    "code{background:#f4f4f4;padding:.1rem .3rem;border-radius:3px}"
+    "pre code{background:none;padding:0}"
+    "a{color:#0066cc}"
+)
+
+
+def _inline(text: str) -> str:
+    """Render inline Markdown (emphasis, code, links) over HTML-escaped text."""
+    out = html.escape(text, quote=False)
+    out = _CODE.sub(lambda m: f"<code>{m.group(1)}</code>", out)
+    out = _BOLD.sub(lambda m: f"<strong>{m.group(1)}</strong>", out)
+    out = _ITALIC.sub(lambda m: f"<em>{m.group(1) or m.group(2)}</em>", out)
+    out = _LINK.sub(lambda m: f'<a href="{m.group(2)}">{m.group(1)}</a>', out)
+    return out
+
+
+def render_body(md: str) -> str:
+    """Render Markdown source into an HTML body fragment (no document wrapper)."""
+    lines = md.splitlines()
+    parts: list[str] = []
+    i, n = 0, len(lines)
+    while i < n:
+        line = lines[i]
+        if not line.strip():
+            i += 1
+            continue
+        if _FENCE.match(line.strip()):  # fenced code block (verbatim)
+            i += 1
+            code: list[str] = []
+            while i < n and not _FENCE.match(lines[i].strip()):
+                code.append(lines[i])
+                i += 1
+            i += 1  # consume closing fence
+            escaped = html.escape("\n".join(code), quote=False)
+            parts.append(f"<pre><code>{escaped}</code></pre>")
+            continue
+        heading = _HEADING.match(line)
+        if heading:
+            level = len(heading.group(1))
+            parts.append(f"<h{level}>{_inline(heading.group(2))}</h{level}>")
+            i += 1
+            continue
+        if _UL.match(line):
+            items: list[str] = []
+            while i < n and (m := _UL.match(lines[i])):
+                items.append(f"<li>{_inline(m.group(1))}</li>")
+                i += 1
+            parts.append("<ul>" + "".join(items) + "</ul>")
+            continue
+        if _OL.match(line):
+            items = []
+            while i < n and (m := _OL.match(lines[i])):
+                items.append(f"<li>{_inline(m.group(1))}</li>")
+                i += 1
+            parts.append("<ol>" + "".join(items) + "</ol>")
+            continue
+        para: list[str] = []  # paragraph: gather until a blank line or block start
+        while (
+            i < n
+            and lines[i].strip()
+            and not (
+                _HEADING.match(lines[i])
+                or _UL.match(lines[i])
+                or _OL.match(lines[i])
+                or _FENCE.match(lines[i].strip())
+            )
+        ):
+            para.append(lines[i].strip())
+            i += 1
+        parts.append(f"<p>{_inline(' '.join(para))}</p>")
+    return "\n".join(parts)
+
+
+def render_document(md: str, title: str = "Document") -> str:
+    """Render Markdown source into a complete, standalone HTML document string."""
+    body = render_body(md)
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        f"<title>{html.escape(title)}</title>\n"
+        f"<style>{_DEFAULT_CSS}</style>\n"
+        "</head>\n"
+        "<body>\n"
+        f"{body}\n"
+        "</body>\n"
+        "</html>\n"
+    )

--- a/tests/test_markdown_render.py
+++ b/tests/test_markdown_render.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from fx_alfred.core.markdown_render import render_body, render_document
+from fx_alfred.core.markdown_render import first_h1, render_body, render_document
 
 pytestmark = pytest.mark.unit
 
@@ -85,6 +85,26 @@ def test_data_url_is_neutralized():
     html = render_body("[x](data:text/html,alert(1))")
     assert "data:text/html" not in html
     assert 'href="#"' in html
+
+
+def test_scheme_with_embedded_control_is_neutralized():
+    # browsers ignore a tab inside the scheme, so java<TAB>script: still executes
+    html = render_body("[x](java\tscript:alert(1))")
+    assert 'href="#"' in html
+    assert "script:" not in html
+
+
+def test_tilde_fence_is_a_code_block():
+    html = render_body("~~~\n# example\n~~~")
+    assert "<pre><code>" in html
+    assert "<h1>" not in html
+    assert "# example" in html
+
+
+def test_first_h1_honors_longer_fence():
+    # a 4-backtick fence containing a literal ``` and a # must not become the title
+    assert first_h1("````\n```\n# fake\n````\n\n# Real") == "Real"
+    assert first_h1("no heading") is None
 
 
 def test_parens_in_url_are_preserved():

--- a/tests/test_markdown_render.py
+++ b/tests/test_markdown_render.py
@@ -1,6 +1,10 @@
 """Tests for the dependency-free Markdown -> HTML renderer (FXA af render)."""
 
+import pytest
+
 from fx_alfred.core.markdown_render import render_body, render_document
+
+pytestmark = pytest.mark.unit
 
 
 def test_headings():
@@ -17,7 +21,9 @@ def test_ordered_list():
 
 
 def test_fenced_code_is_escaped_verbatim():
-    assert "<pre><code>&lt;x&gt; &amp; y</code></pre>" in render_body("```\n<x> & y\n```")
+    assert "<pre><code>&lt;x&gt; &amp; y</code></pre>" in render_body(
+        "```\n<x> & y\n```"
+    )
 
 
 def test_link_and_emphasis():
@@ -29,6 +35,19 @@ def test_link_and_emphasis():
 
 def test_inline_code():
     assert "<code>af render</code>" in render_body("`af render`")
+
+
+def test_inline_code_with_markup_stays_literal():
+    # underscores/asterisks inside a code span must NOT become emphasis
+    assert "<code>ALFRED_AGENT_TOOLS</code>" in render_body("`ALFRED_AGENT_TOOLS`")
+    assert "<code>**literal**</code>" in render_body("`**literal**`")
+
+
+def test_link_target_is_quote_escaped():
+    # a double quote in the URL must not break out of the href attribute
+    html = render_body('[x](https://e/?q=" onmouseover="alert(1))')
+    assert 'onmouseover="alert(1)"' not in html
+    assert "&quot;" in html
 
 
 def test_paragraph_escapes_html():

--- a/tests/test_markdown_render.py
+++ b/tests/test_markdown_render.py
@@ -1,0 +1,43 @@
+"""Tests for the dependency-free Markdown -> HTML renderer (FXA af render)."""
+
+from fx_alfred.core.markdown_render import render_body, render_document
+
+
+def test_headings():
+    assert "<h1>Title</h1>" in render_body("# Title")
+    assert "<h3>Sub</h3>" in render_body("### Sub")
+
+
+def test_unordered_list():
+    assert "<ul><li>a</li><li>b</li></ul>" in render_body("- a\n- b")
+
+
+def test_ordered_list():
+    assert "<ol><li>a</li><li>b</li></ol>" in render_body("1. a\n2. b")
+
+
+def test_fenced_code_is_escaped_verbatim():
+    assert "<pre><code>&lt;x&gt; &amp; y</code></pre>" in render_body("```\n<x> & y\n```")
+
+
+def test_link_and_emphasis():
+    assert '<a href="https://x.com">x</a>' in render_body("[x](https://x.com)")
+    assert "<strong>b</strong>" in render_body("**b**")
+    assert "<em>i</em>" in render_body("*i*")
+    assert "<em>u</em>" in render_body("_u_")
+
+
+def test_inline_code():
+    assert "<code>af render</code>" in render_body("`af render`")
+
+
+def test_paragraph_escapes_html():
+    assert "<p>plain &lt;text&gt; &amp;</p>" in render_body("plain <text> &")
+
+
+def test_document_is_standalone():
+    doc = render_document("# Hi", title="T")
+    assert doc.startswith("<!DOCTYPE html>")
+    assert "<title>T</title>" in doc
+    assert "<h1>Hi</h1>" in doc
+    assert doc.rstrip().endswith("</html>")

--- a/tests/test_markdown_render.py
+++ b/tests/test_markdown_render.py
@@ -54,6 +54,22 @@ def test_paragraph_escapes_html():
     assert "<p>plain &lt;text&gt; &amp;</p>" in render_body("plain <text> &")
 
 
+def test_intraword_underscore_is_not_emphasis():
+    html = render_body("ALFRED_AGENT_TOOLS and foo_bar_baz in prose")
+    assert "<em>" not in html
+    assert "ALFRED_AGENT_TOOLS" in html
+    assert "foo_bar_baz" in html
+
+
+def test_longer_fence_keeps_inner_triple_backticks_literal():
+    # a 4-backtick fence containing a literal ``` and a # line: must stay verbatim
+    html = render_body("````\n```\n# not a heading\n````")
+    assert "<h1>" not in html
+    assert "<pre><code>" in html
+    assert "# not a heading" in html
+    assert "```" in html
+
+
 def test_document_is_standalone():
     doc = render_document("# Hi", title="T")
     assert doc.startswith("<!DOCTYPE html>")

--- a/tests/test_markdown_render.py
+++ b/tests/test_markdown_render.py
@@ -61,6 +61,37 @@ def test_intraword_underscore_is_not_emphasis():
     assert "foo_bar_baz" in html
 
 
+def test_nul_in_input_does_not_corrupt_output():
+    # a literal NUL placeholder sequence must not alias a real stash slot
+    html = render_body("\x000\x00 and `realcode`")
+    assert "<code>realcode</code>" in html
+    assert "\x00" not in html
+
+
+def test_code_span_inside_link_text():
+    # the project's own README link style: [`code`](url) must not leak \x00
+    html = render_body("See [`af render`](README.md)")
+    assert '<a href="README.md"><code>af render</code></a>' in html
+    assert "\x00" not in html
+
+
+def test_javascript_url_is_neutralized():
+    html = render_body("[x](javascript:alert(1))")
+    assert "javascript:" not in html
+    assert 'href="#"' in html
+
+
+def test_data_url_is_neutralized():
+    html = render_body("[x](data:text/html,alert(1))")
+    assert "data:text/html" not in html
+    assert 'href="#"' in html
+
+
+def test_parens_in_url_are_preserved():
+    html = render_body("[wiki](https://en.wikipedia.org/wiki/C_(programming_language))")
+    assert 'href="https://en.wikipedia.org/wiki/C_(programming_language)"' in html
+
+
 def test_longer_fence_keeps_inner_triple_backticks_literal():
     # a 4-backtick fence containing a literal ``` and a # line: must stay verbatim
     html = render_body("````\n```\n# not a heading\n````")

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -1,8 +1,11 @@
 """Tests for the `af render` command."""
 
+import pytest
 from click.testing import CliRunner
 
 from fx_alfred.cli import cli
+
+pytestmark = pytest.mark.cli
 
 
 def test_render_to_stdout(tmp_path):
@@ -37,3 +40,17 @@ def test_title_defaults_to_first_h1(tmp_path):
     md.write_text("# My Doc\n\ntext")
     result = CliRunner().invoke(cli, ["render", str(md)])
     assert "<title>My Doc</title>" in result.output
+
+
+def test_title_falls_back_to_file_stem(tmp_path):
+    md = tmp_path / "notes.md"
+    md.write_text("no heading here")
+    result = CliRunner().invoke(cli, ["render", str(md)])
+    assert "<title>notes</title>" in result.output
+
+
+def test_title_option_overrides(tmp_path):
+    md = tmp_path / "a.md"
+    md.write_text("# Heading")
+    result = CliRunner().invoke(cli, ["render", str(md), "--title", "Custom"])
+    assert "<title>Custom</title>" in result.output

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -1,0 +1,39 @@
+"""Tests for the `af render` command."""
+
+from click.testing import CliRunner
+
+from fx_alfred.cli import cli
+
+
+def test_render_to_stdout(tmp_path):
+    md = tmp_path / "a.md"
+    md.write_text("# Title\n\nHello")
+    result = CliRunner().invoke(cli, ["render", str(md)])
+    assert result.exit_code == 0
+    assert "<!DOCTYPE html>" in result.output
+    assert "<h1>Title</h1>" in result.output
+
+
+def test_render_to_output_file(tmp_path):
+    md = tmp_path / "a.md"
+    md.write_text("# Title")
+    out = tmp_path / "a.html"
+    result = CliRunner().invoke(cli, ["render", str(md), "-o", str(out)])
+    assert result.exit_code == 0
+    assert out.exists()
+    html = out.read_text()
+    assert "<!DOCTYPE html>" in html
+    assert "<h1>Title</h1>" in html
+
+
+def test_missing_file_errors(tmp_path):
+    result = CliRunner().invoke(cli, ["render", str(tmp_path / "nope.md")])
+    assert result.exit_code != 0
+    assert "not found" in result.output.lower()
+
+
+def test_title_defaults_to_first_h1(tmp_path):
+    md = tmp_path / "a.md"
+    md.write_text("# My Doc\n\ntext")
+    result = CliRunner().invoke(cli, ["render", str(md)])
+    assert "<title>My Doc</title>" in result.output

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -54,3 +54,18 @@ def test_title_option_overrides(tmp_path):
     md.write_text("# Heading")
     result = CliRunner().invoke(cli, ["render", str(md), "--title", "Custom"])
     assert "<title>Custom</title>" in result.output
+
+
+def test_directory_input_errors(tmp_path):
+    d = tmp_path / "adir"
+    d.mkdir()
+    result = CliRunner().invoke(cli, ["render", str(d)])
+    assert result.exit_code != 0
+    assert "not a file" in result.output.lower()
+
+
+def test_title_ignores_heading_inside_code_fence(tmp_path):
+    md = tmp_path / "a.md"
+    md.write_text("```\n# fake title\n```\n\n# Real Title")
+    result = CliRunner().invoke(cli, ["render", str(md)])
+    assert "<title>Real Title</title>" in result.output


### PR DESCRIPTION
## What

Adds **`af render FILE.md [-o OUT.html] [--title T]`** — a one-command Markdown → standalone HTML document renderer. Closes #230.

## How
- `core/markdown_render.py` — minimal **zero-dependency** renderer (headings, ordered/unordered lists, fenced + inline code, links, bold/italic, paragraphs; HTML-escaped), consistent with Alfred's lean-deps posture.
- `commands/render_cmd.py` — Click command (FILE arg, `-o/--output` with stdout fallback, `--title` defaulting to first H1 or file stem, non-zero on missing file).
- `cli.py` — wired into the LazyGroup; `CLAUDE.md` command list + module inventory updated (docs-drift guard).

## Tests
25 pass — core renderer (12) + command (4) covering structure, stdout, core-Markdown, missing-file error, title derivation; plus drift + architecture guards. `ruff check`/`format` + `pyright` clean.

## Note
Built end-to-end as a live **COR-1617 multi-agent workflow loop** demo: auto-pick #230 → branch → plan → implement (TDD) → verify → PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)