### PR TITLE
feat(validate): support af validate <DOC_IDS> for single/multi-doc checks

### DIFF
--- a/src/fx_alfred/commands/validate_cmd.py
+++ b/src/fx_alfred/commands/validate_cmd.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import click
 
-from fx_alfred.commands._helpers import SCHEMA_VERSION, emit_json
+from fx_alfred.commands._helpers import SCHEMA_VERSION, emit_json, find_or_fail
 
 from fx_alfred.context import get_root, root_option
 from fx_alfred.core.schema import (
@@ -63,6 +63,44 @@ def _scan_all_layers(root: Path):
     rules_path = root / "rules"
     docs.extend(_scan_path_dir(rules_path, source="prj"))
     return docs
+
+
+def _load_corpus_and_targets(
+    root: Path, doc_ids: tuple[str, ...]
+) -> tuple[
+    list[Document],
+    list[Document],
+    dict[tuple[str, str], Document],
+    dict[str, str | None],
+]:
+    """Scan the full corpus and resolve the validation target set.
+
+    Returns ``(all_docs, docs, docs_by_id, cor_dispositions)`` where
+    ``docs`` is the set to actually validate (the full corpus when no
+    identifiers are given, otherwise the resolved subset). ``docs_by_id``
+    and ``cor_dispositions`` are always built from the FULL corpus so
+    that filtering the validation set does not mis-report a valid
+    cross-SOP loop target or governance binding as missing.
+    """
+    try:
+        all_docs = scan_documents(root)
+    except LayerValidationError:
+        # Layer violations found -- re-scan without validation so we can
+        # report them as per-document issues instead of aborting.
+        all_docs = _scan_all_layers(root)
+
+    # Corpus-wide lookup table for cross-SOP reference resolution (FXA-2218 D2/D3).
+    docs_by_id: dict[tuple[str, str], Document] = {
+        (d.prefix, d.acid): d for d in all_docs if d.type_code == "SOP"
+    }
+    cor_dispositions = _build_cor_disposition_index(all_docs)
+
+    if doc_ids:
+        docs: list[Document] = [find_or_fail(all_docs, doc_id) for doc_id in doc_ids]
+    else:
+        docs = all_docs
+
+    return all_docs, docs, docs_by_id, cor_dispositions
 
 
 def _validate_history_header(header: str) -> list[str]:
@@ -231,6 +269,8 @@ _EPILOG = """\
 Examples:
 
   af validate                      # check all documents
+  af validate FXA-2148             # check one document
+  af validate FXA-2148 COR-1103    # check specific documents
   af validate --root myproj        # check specific project
 
 Checks:
@@ -247,31 +287,26 @@ Exit code 0 if clean, 1 if issues found. Warnings never affect the exit code.
 
 @click.command("validate", epilog=_EPILOG)
 @root_option
+@click.argument("doc_ids", nargs=-1, required=False)
 @click.option("--json", "output_json", is_flag=True, help="Output as JSON")
 @click.pass_context
-def validate_cmd(ctx: click.Context, output_json: bool):
-    """Validate all documents for structural correctness."""
+def validate_cmd(ctx: click.Context, doc_ids: tuple[str, ...], output_json: bool):
+    """Validate documents for structural correctness.
+
+    With no arguments, validates all documents. With one or more
+    PREFIX-ACID / ACID identifiers, validates only those documents
+    (parity with `af fmt` and `af export`).
+    """
     root = get_root(ctx)
-    try:
-        docs = scan_documents(root)
-    except LayerValidationError:
-        # Layer violations found -- re-scan without validation so we can
-        # report them as per-document issues instead of aborting.
-        docs = _scan_all_layers(root)
+    _all_docs, docs, docs_by_id, cor_dispositions = _load_corpus_and_targets(
+        root, doc_ids
+    )
 
     issues_by_doc: dict[str, list[str]] = {}
     # CHG-2296: non-fatal findings. Warnings never affect the exit code;
     # they surface degraded validation (e.g. unknown TYPE codes) that was
     # previously silent.
     warnings_by_doc: dict[str, list[str]] = {}
-
-    # Corpus-wide lookup table for cross-SOP reference resolution (FXA-2218 D2/D3).
-    # Filter out PRP/CHG/REF/etc. so `Workflow loops.to = "FXA-2217.3"` cannot
-    # resolve (PR #59 Codex review P2).
-    docs_by_id: dict[tuple[str, str], Document] = {
-        (d.prefix, d.acid): d for d in docs if d.type_code == "SOP"
-    }
-    cor_dispositions = _build_cor_disposition_index(docs)
 
     for doc in docs:
         doc_id = f"{doc.prefix}-{doc.acid}"

--- a/tests/test_validate_cmd.py
+++ b/tests/test_validate_cmd.py
@@ -2467,3 +2467,174 @@ def test_validate_doc_without_governance_fields_still_valid(tmp_path):
     result = runner.invoke(cli, ["validate", "--root", str(tmp_path)])
     assert result.exit_code == 0
     assert "0 issues found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Single / multiple document selection (parity with `af fmt`/`af export`)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_single_valid_doc_reports_only_that_doc(tmp_path):
+    """`af validate <ID>` validates only the named document.
+
+    Two valid docs exist; validating one must report 1 document checked
+    and not surface the other.
+    """
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    _write_valid_document(
+        rules_dir / "SOP-1000-SOP-One.md", "SOP", "1000", "SOP", "One"
+    )
+    _write_valid_document(
+        rules_dir / "SOP-2000-SOP-Two.md", "SOP", "2000", "SOP", "Two"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", "SOP-1000", "--root", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "1 document checked" in result.output
+    assert "0 issues found" in result.output
+    # The other document is not part of this run.
+    assert "SOP-2000" not in result.output
+
+
+def test_validate_single_doc_reports_its_issues(tmp_path):
+    """`af validate <ID>` surfaces that document's issues and exits 1.
+
+    One healthy doc, one broken doc (missing Last reviewed). Validating
+    the broken one must report its issue; the healthy one must be absent.
+    """
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    _write_valid_document(
+        rules_dir / "SOP-1000-SOP-Healthy.md", "SOP", "1000", "SOP", "Healthy"
+    )
+    (rules_dir / "SOP-2000-SOP-Broken.md").write_text(
+        """# SOP-2000: Broken
+
+**Applies to:** All projects
+**Last updated:** 2026-03-14
+**Status:** Active
+
+---
+
+## What Is It?
+
+Missing Last reviewed.
+
+## Why
+x
+## When to Use
+x
+## When NOT to Use
+x
+## Steps
+
+1. x
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-03-14 | Initial | Frank |
+"""
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", "SOP-2000", "--root", str(tmp_path)])
+
+    assert result.exit_code == 1
+    assert "SOP-2000" in result.output
+    assert "Last reviewed" in result.output
+    # The healthy document is not part of this run.
+    assert "SOP-1000" not in result.output
+
+
+def test_validate_multiple_docs_validates_each(tmp_path):
+    """`af validate A B` validates exactly A and B."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    _write_valid_document(
+        rules_dir / "SOP-1000-SOP-One.md", "SOP", "1000", "SOP", "One"
+    )
+    _write_valid_document(
+        rules_dir / "SOP-2000-SOP-Two.md", "SOP", "2000", "SOP", "Two"
+    )
+    _write_valid_document(
+        rules_dir / "SOP-3000-SOP-Three.md", "SOP", "3000", "SOP", "Three"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["validate", "SOP-1000", "SOP-2000", "--root", str(tmp_path)]
+    )
+
+    assert result.exit_code == 0
+    assert "2 documents checked" in result.output
+    assert "SOP-3000" not in result.output
+
+
+def test_validate_single_doc_by_acid_only(tmp_path):
+    """`af validate <ACID>` resolves by ACID alone, like `af read`/`af fmt`."""
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    _write_valid_document(
+        rules_dir / "SOP-1000-SOP-One.md", "SOP", "1000", "SOP", "One"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", "1000", "--root", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert "1 document checked" in result.output
+
+
+def test_validate_unknown_doc_id_errors(tmp_path):
+    """`af validate <unknown>` reports the missing document and exits non-zero.
+
+    This is a document-resolution error, NOT a Click usage error: the ID
+    is accepted as an argument and then fails to resolve. So the output
+    must NOT be the Click "Got unexpected extra argument" usage message.
+    """
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    _write_valid_document(
+        rules_dir / "SOP-1000-SOP-One.md", "SOP", "1000", "SOP", "One"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["validate", "SOP-9999", "--root", str(tmp_path)])
+
+    assert result.exit_code != 0
+    # Must mention the identifier the operator asked for.
+    assert "SOP-9999" in result.output
+    # Must NOT be a Click usage error (that would mean the arg was rejected
+    # at the CLI surface, not resolved against the corpus).
+    assert "unexpected extra argument" not in result.output
+
+
+def test_validate_single_doc_json_output(tmp_path):
+    """`af validate <ID> --json` returns results for only that document."""
+    import json as json_mod
+
+    rules_dir = tmp_path / "rules"
+    rules_dir.mkdir()
+    _write_valid_document(
+        rules_dir / "SOP-1000-SOP-One.md", "SOP", "1000", "SOP", "One"
+    )
+    _write_valid_document(
+        rules_dir / "SOP-2000-SOP-Two.md", "SOP", "2000", "SOP", "Two"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["validate", "SOP-1000", "--root", str(tmp_path), "--json"]
+    )
+
+    assert result.exit_code == 0
+    payload = json_mod.loads(result.output)
+    doc_ids = [r["doc_id"] for r in payload["results"]]
+    assert doc_ids == ["SOP-1000"]

--- a/tests/test_validate_cmd.py
+++ b/tests/test_validate_cmd.py
@@ -2493,7 +2493,7 @@ def test_validate_single_valid_doc_reports_only_that_doc(tmp_path):
     result = runner.invoke(cli, ["validate", "SOP-1000", "--root", str(tmp_path)])
 
     assert result.exit_code == 0
-    assert "1 document checked" in result.output
+    assert "1 documents checked" in result.output
     assert "0 issues found" in result.output
     # The other document is not part of this run.
     assert "SOP-2000" not in result.output
@@ -2578,18 +2578,22 @@ def test_validate_multiple_docs_validates_each(tmp_path):
 
 
 def test_validate_single_doc_by_acid_only(tmp_path):
-    """`af validate <ACID>` resolves by ACID alone, like `af read`/`af fmt`."""
+    """`af validate <ACID>` resolves by ACID alone, like `af read`/`af fmt`.
+
+    Uses ACID 9000 (no bundled COR-NNNN collides with it) so ACID-only
+    resolution is unambiguous across all three layers.
+    """
     rules_dir = tmp_path / "rules"
     rules_dir.mkdir()
     _write_valid_document(
-        rules_dir / "SOP-1000-SOP-One.md", "SOP", "1000", "SOP", "One"
+        rules_dir / "SOP-9000-SOP-One.md", "SOP", "9000", "SOP", "One"
     )
 
     runner = CliRunner()
-    result = runner.invoke(cli, ["validate", "1000", "--root", str(tmp_path)])
+    result = runner.invoke(cli, ["validate", "9000", "--root", str(tmp_path)])
 
     assert result.exit_code == 0
-    assert "1 document checked" in result.output
+    assert "1 documents checked" in result.output
 
 
 def test_validate_unknown_doc_id_errors(tmp_path):


### PR DESCRIPTION
## What

`af validate` was the only document command that could not target a specific document — `af fmt` / `af export` / `af read` all take identifiers, but `af validate` always ran the full corpus. This adds an optional `DOC_IDS` variadic argument:

```bash
af validate                  # all documents (unchanged)
af validate FXA-2148         # one document
af validate FXA-2148 COR-1103  # specific documents
```

## Why

Observed directly during an evolve run: after creating a new document, running `af validate <NEW_ID>` to check just that one failed with `Got unexpected extra argument`. The only fallback was a full-corpus run. The CLI surface was inconsistent — every other document command resolves identifiers; `validate` alone did not.

## How

- Optional `@click.argument("doc_ids", nargs=-1, required=False)`, resolved via the existing `find_or_fail` helper (PREFIX-ACID or ACID-only).
- **Correctness detail**: cross-SOP workflow-loop resolution and COR disposition lookups are built from the **full corpus** even when the validation set is filtered — so `af validate FXA-2148` does not mis-report a valid cross-SOP loop target as missing.
- Refactored scan + target-resolution into `_load_corpus_and_targets` so `validate_cmd` shrinks (net -10 lines), staying under its grandfathered ratchet cap in `test_architecture.py` rather than growing it.

## Verification

- TDD: 6 RED tests committed first (`b04b922`), then implementation (`800779d`).
- `pytest`: 1227 passed, 2 skipped
- `ruff check` + `ruff format --check`: clean
- `pyright`: 0 errors
- Architecture guard (`test_commands_functions_stay_decomposed`): green
- One test was initially a false-green (Click's "unexpected extra argument" string happened to contain the id); tightened to assert the failure is a document-resolution error, not a CLI usage error.

## Out of scope

- No change to the `--json` envelope shape (still `schema_version` + `results`, just a filtered `results` list).
- No change to exit-code semantics.