### PR TITLE
feat(plan): emit COR-1402 active process declarations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ af list --type PRP --root /Users/frank/Projects/alfred
 ## Workflow
 
 - **Session start:** Run COR-1208 (Session Startup Sanity Check — `pwd`, `git status`/`log`, smoke test, load tracker, surface anomalies) before anything else. Then `af guide --root /Users/frank/Projects/alfred`. Smoke for this project: `.venv/bin/pytest -v --tb=short` and `af validate --root /Users/frank/Projects/alfred`.
-- **Before every task:** Declare active SOP per COR-1402 before starting work (or flag if none exist)
+- **Before every task:** Declare the active SOP per COR-1402 as the **first line of every reply** (including quick chat answers — use the no-formal-SOP form `📋 COR-1402 Declare Active Process → no formal task SOP` when nothing else applies). Never skip it because a task is short.
 - **Workflow checklist:** `af plan <SOP_IDs>` (LLM-optimized, follow each phase)
 - **First time:** `af setup` (suggested prompts for agent config)
 - **Workflow branches:** SOPs can declare `Workflow branches:` metadata to express branching task flows (e.g., "do EITHER A or B"). `af plan --graph` renders these as ASCII/Mermaid branch diagrams. Branch targets use step indices; sub-steps use `{phase}.{step}{letter}` notation (e.g., `3.1a`).

--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -222,6 +222,7 @@
 | 2309 | SOP | Evolve Engine | Active |
 | 2310 | CHG | Implement Evolve Engine SOP Refactor | Proposed |
 | 2311 | CHG | Strengthen L2 PR Readiness Loop Gates | Proposed |
+| 2312 | CHG | COR 1402 Active Process Output | Completed |
 
 ---
 

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -4,6 +4,7 @@
 **Last updated:** 2026-05-07
 **Last reviewed:** 2026-03-17
 **Status:** Active
+**Task tags:** release, pypi, publish, version, changelog
 
 ---
 
@@ -166,3 +167,4 @@ pipx upgrade fx-alfred                        # verify on PyPI
 | 2026-03-21 | Added Examples section + release notes template | Claude Code |
 | 2026-04-18 | Add pyright to Prerequisites + Step 1 per CHG-FXA-2208 (post v1.6.0 publish incident). | Frank + Claude Code |
 | 2026-05-07 | FXA-2275: promote README check from Prerequisites to a numbered Step (new Step 2). Renumbered subsequent steps 3-7. Reason: README updates were silently skipped twice during v1.12.0 and v1.13.0 release work because the check sat in Prerequisites and was easy to miss when reading top-down. | Claude Code |
+| 2026-06-26 | Add task tags so COR-1202 can compose release plans from natural-language tasks. | Moth |

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -4,7 +4,7 @@
 **Last updated:** 2026-05-07
 **Last reviewed:** 2026-03-17
 **Status:** Active
-**Task tags:** release, pypi, publish
+**Task tags:** release, pypi
 
 ---
 
@@ -168,3 +168,4 @@ pipx upgrade fx-alfred                        # verify on PyPI
 | 2026-04-18 | Add pyright to Prerequisites + Step 1 per CHG-FXA-2208 (post v1.6.0 publish incident).                                                                                                                                                                                                            | Frank + Claude Code |
 | 2026-05-07 | FXA-2275: promote README check from Prerequisites to a numbered Step (new Step 2). Renumbered subsequent steps 3-7. Reason: README updates were silently skipped twice during v1.12.0 and v1.13.0 release work because the check sat in Prerequisites and was easy to miss when reading top-down. | Claude Code         |
 | 2026-06-26 | Add task tags so COR-1202 can compose release plans from natural-language tasks.                                                                                                                                                                                                                  | Claude Code         |
+| 2026-06-26 | Drop bare `publish` task tag — too generic; `publish docs` etc. wrongly routed to PyPI release (Codex review).                                                                                                                                                                                    | Claude Code         |

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -160,11 +160,11 @@ pipx upgrade fx-alfred                        # verify on PyPI
 
 ## Change History
 
-| Date       | Change                                                                                 | By                  |
-|------------|----------------------------------------------------------------------------------------|---------------------|
-| 2026-03-17 | Initial version | Claude Code |
-| 2026-03-20 | FXA-2133: Add Why, When to Use, When NOT to Use sections (5W1H migration) | Claude Code |
-| 2026-03-21 | Added Examples section + release notes template | Claude Code |
-| 2026-04-18 | Add pyright to Prerequisites + Step 1 per CHG-FXA-2208 (post v1.6.0 publish incident). | Frank + Claude Code |
-| 2026-05-07 | FXA-2275: promote README check from Prerequisites to a numbered Step (new Step 2). Renumbered subsequent steps 3-7. Reason: README updates were silently skipped twice during v1.12.0 and v1.13.0 release work because the check sat in Prerequisites and was easy to miss when reading top-down. | Claude Code |
-| 2026-06-26 | Add task tags so COR-1202 can compose release plans from natural-language tasks. | Moth |
+| Date       | Change                                                                                                                                                                                                                                                                                            | By                  |
+|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| 2026-03-17 | Initial version                                                                                                                                                                                                                                                                                   | Claude Code         |
+| 2026-03-20 | FXA-2133: Add Why, When to Use, When NOT to Use sections (5W1H migration)                                                                                                                                                                                                                         | Claude Code         |
+| 2026-03-21 | Added Examples section + release notes template                                                                                                                                                                                                                                                   | Claude Code         |
+| 2026-04-18 | Add pyright to Prerequisites + Step 1 per CHG-FXA-2208 (post v1.6.0 publish incident).                                                                                                                                                                                                            | Frank + Claude Code |
+| 2026-05-07 | FXA-2275: promote README check from Prerequisites to a numbered Step (new Step 2). Renumbered subsequent steps 3-7. Reason: README updates were silently skipped twice during v1.12.0 and v1.13.0 release work because the check sat in Prerequisites and was easy to miss when reading top-down. | Claude Code         |
+| 2026-06-26 | Add task tags so COR-1202 can compose release plans from natural-language tasks.                                                                                                                                                                                                                  | Claude Code         |

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -4,7 +4,7 @@
 **Last updated:** 2026-05-07
 **Last reviewed:** 2026-03-17
 **Status:** Active
-**Task tags:** release, pypi, publish, version, changelog
+**Task tags:** release, pypi, publish
 
 ---
 

--- a/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
+++ b/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
@@ -32,6 +32,8 @@ Make COR-1402 declarations a generated, visible output of Alfred plans so agents
 - Wire the project `CLAUDE.md` Workflow section to require the first-line declaration.
 - Align bundled active-instruction surfaces that cited the old COR-1402 cadence (af plan's LLM RULES block, COR-1616 Step 1, COR-1202 execute step, the skill bundle, af setup, COR-1103 cheat-sheet and Golden Rules, INIT.md bootstrap) to the first-line/every-reply rule — all shipped active-instruction surfaces that teach the cadence — packaged rules (incl. INIT.md), CLI output, and the repo skill bundle — are covered; historical PRP/CHG records and review-packs are intentionally left as-is.
 
+- Reconcile the first-line mandate with SOPs that mandate a different opening (COR-1208 sanity-check, COR-1207 unfamiliarity statement) via a generic exception in COR-1402, cross-referenced from those SOPs. A repo sweep confirms no other SOP currently mandates a competing reply-opening. The restating surfaces (skill bundle, `CLAUDE.md`, `af setup`/`af guide`/plan RULES, INIT.md) intentionally defer to COR-1402 as the authority for this exception rather than duplicating it — they say "first line of every reply, per COR-1402", and the exception lives in the canonical SOP they point to.
+
 Out of scope:
 
 - Enforcing declarations in external chat surfaces.
@@ -64,3 +66,4 @@ Out of scope:
 | 2026-06-26 | Extend scope: align af plan RULES block + COR-1616/COR-1202 + skill bundle + af setup to every-reply cadence | Claude Code |
 | 2026-06-26 | Add COR-1103 cheat-sheet/Golden-Rules alignment + exhaustiveness note                                        | Claude Code |
 | 2026-06-26 | Add INIT.md bootstrap to aligned-surfaces list (Codex finding)                                               | Claude Code |
+| 2026-06-26 | Add startup/zoom-out reconciliation exception.                                                               | Claude Code |

--- a/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
+++ b/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
@@ -27,6 +27,9 @@ Make COR-1402 declarations a generated, visible output of Alfred plans so agents
 - Tighten `COR-1402` so every user-visible task emits an active-process line, including no-formal-SOP quick tasks.
 - Tighten `COR-1202` so executing a composed plan means emitting the generated COR-1402 declaration at task start and phase transitions.
 - Add task tags to `FXA-2102` so release tasks can be composed by `COR-1202`.
+- Harden `COR-1402` so the active-process declaration must be the first line of every chat/conversational reply, not only plan-driven phases.
+- Add an `af guide` closing reminder so the routing output itself nudges agents to open every reply with a COR-1402 line.
+- Wire the project `CLAUDE.md` Workflow section to require the first-line declaration.
 
 Out of scope:
 
@@ -41,6 +44,8 @@ Out of scope:
 - [x] `COR-1402` covers every user-visible task, not only tasks with a task-specific SOP.
 - [x] `COR-1202` tells executors to emit the generated declaration at task start and phase transitions.
 - [x] `af plan --task "release fx-alfred to pypi"` can resolve `FXA-2102` via task tags.
+- [x] `COR-1402` mandates the active-process line as the first line of every chat reply.
+- [x] `af guide` text output ends with a COR-1402 active-process reminder.
 
 ## Validation
 
@@ -52,3 +57,4 @@ Out of scope:
 | Date       | Change                                      | By   |
 |------------|---------------------------------------------|------|
 | 2026-06-26 | Initial CHG for generated COR-1402 output   | Moth |
+| 2026-06-26 | Extend scope: chat-surface first-line mandate + `af guide` reminder + CLAUDE.md wiring | Claude Code |

--- a/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
+++ b/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
@@ -30,7 +30,7 @@ Make COR-1402 declarations a generated, visible output of Alfred plans so agents
 - Harden `COR-1402` so the active-process declaration must be the first line of every chat/conversational reply, not only plan-driven phases.
 - Add an `af guide` closing reminder so the routing output itself nudges agents to open every reply with a COR-1402 line.
 - Wire the project `CLAUDE.md` Workflow section to require the first-line declaration.
-- Align bundled active-instruction surfaces that cited the old COR-1402 cadence (af plan's LLM RULES block, COR-1616 Step 1, COR-1202 execute step, the skill bundle, af setup, COR-1103 cheat-sheet and Golden Rules) to the first-line/every-reply rule — all bundled active-instruction surfaces that teach the cadence are covered; historical PRP/CHG records and review-packs are intentionally left as-is.
+- Align bundled active-instruction surfaces that cited the old COR-1402 cadence (af plan's LLM RULES block, COR-1616 Step 1, COR-1202 execute step, the skill bundle, af setup, COR-1103 cheat-sheet and Golden Rules, INIT.md bootstrap) to the first-line/every-reply rule — all shipped active-instruction surfaces that teach the cadence — packaged rules (incl. INIT.md), CLI output, and the repo skill bundle — are covered; historical PRP/CHG records and review-packs are intentionally left as-is.
 
 Out of scope:
 
@@ -63,3 +63,4 @@ Out of scope:
 | 2026-06-26 | Extend scope: chat-surface first-line mandate + `af guide` reminder + CLAUDE.md wiring                       | Claude Code |
 | 2026-06-26 | Extend scope: align af plan RULES block + COR-1616/COR-1202 + skill bundle + af setup to every-reply cadence | Claude Code |
 | 2026-06-26 | Add COR-1103 cheat-sheet/Golden-Rules alignment + exhaustiveness note                                        | Claude Code |
+| 2026-06-26 | Add INIT.md bootstrap to aligned-surfaces list (Codex finding)                                               | Claude Code |

--- a/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
+++ b/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
@@ -37,6 +37,7 @@ Out of scope:
 - Creating a new runtime hook or bot.
 - Releasing a new package version.
 
+
 ## Acceptance Criteria
 
 - [x] `af plan <SOP> --todo` prints an `Active Process — COR-1402` section before the flat TODO.
@@ -47,6 +48,7 @@ Out of scope:
 - [x] `COR-1402` mandates the active-process line as the first line of every chat reply.
 - [x] `af guide` text output ends with a COR-1402 active-process reminder.
 
+
 ## Validation
 
 - `uv run pytest tests/test_plan_cmd.py -q`
@@ -54,7 +56,7 @@ Out of scope:
 
 ## Change History
 
-| Date       | Change                                      | By   |
-|------------|---------------------------------------------|------|
-| 2026-06-26 | Initial CHG for generated COR-1402 output   | Moth |
+| Date       | Change                                                                                 | By          |
+|------------|----------------------------------------------------------------------------------------|-------------|
+| 2026-06-26 | Initial CHG for generated COR-1402 output                                              | Claude Code |
 | 2026-06-26 | Extend scope: chat-surface first-line mandate + `af guide` reminder + CLAUDE.md wiring | Claude Code |

--- a/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
+++ b/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
@@ -30,6 +30,7 @@ Make COR-1402 declarations a generated, visible output of Alfred plans so agents
 - Harden `COR-1402` so the active-process declaration must be the first line of every chat/conversational reply, not only plan-driven phases.
 - Add an `af guide` closing reminder so the routing output itself nudges agents to open every reply with a COR-1402 line.
 - Wire the project `CLAUDE.md` Workflow section to require the first-line declaration.
+- Align bundled active-instruction surfaces that cited the old COR-1402 cadence (af plan's LLM RULES block, COR-1616 Step 1, COR-1202 execute step, the skill bundle, af setup, COR-1103 cheat-sheet and Golden Rules) to the first-line/every-reply rule — all bundled active-instruction surfaces that teach the cadence are covered; historical PRP/CHG records and review-packs are intentionally left as-is.
 
 Out of scope:
 
@@ -56,7 +57,9 @@ Out of scope:
 
 ## Change History
 
-| Date       | Change                                                                                 | By          |
-|------------|----------------------------------------------------------------------------------------|-------------|
-| 2026-06-26 | Initial CHG for generated COR-1402 output                                              | Claude Code |
-| 2026-06-26 | Extend scope: chat-surface first-line mandate + `af guide` reminder + CLAUDE.md wiring | Claude Code |
+| Date       | Change                                                                                                       | By          |
+|------------|--------------------------------------------------------------------------------------------------------------|-------------|
+| 2026-06-26 | Initial CHG for generated COR-1402 output                                                                    | Claude Code |
+| 2026-06-26 | Extend scope: chat-surface first-line mandate + `af guide` reminder + CLAUDE.md wiring                       | Claude Code |
+| 2026-06-26 | Extend scope: align af plan RULES block + COR-1616/COR-1202 + skill bundle + af setup to every-reply cadence | Claude Code |
+| 2026-06-26 | Add COR-1103 cheat-sheet/Golden-Rules alignment + exhaustiveness note                                        | Claude Code |

--- a/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
+++ b/rules/FXA-2312-CHG-COR-1402-Active-Process-Output.md
@@ -1,0 +1,54 @@
+# CHG-2312: COR-1402 Active Process Output
+
+**Applies to:** FXA project
+**Last updated:** 2026-06-26
+**Last reviewed:** 2026-06-26
+**Status:** Completed
+**Related:** COR-1202, COR-1402, FXA-2102
+
+---
+
+## What Is It?
+
+Make COR-1402 declarations a generated, visible output of Alfred plans so agents can start every user-visible task with an active-process line instead of relying on memory.
+
+---
+
+## Why
+
+`COR-1402` already requires active-process declaration, and `COR-1202` already composes it into task plans as an always-included SOP. The weak spot was execution ergonomics: plan output told the operator to declare the active process, but did not provide a copyable declaration per phase. That left agents to remember and format the declaration manually, which is easy to skip in chat.
+
+---
+
+## Scope
+
+- Update `af plan` text output to include an `Active Process — COR-1402` section with one copyable declaration per phase.
+- Add `active_process` to `--todo --json` output.
+- Tighten `COR-1402` so every user-visible task emits an active-process line, including no-formal-SOP quick tasks.
+- Tighten `COR-1202` so executing a composed plan means emitting the generated COR-1402 declaration at task start and phase transitions.
+- Add task tags to `FXA-2102` so release tasks can be composed by `COR-1202`.
+
+Out of scope:
+
+- Enforcing declarations in external chat surfaces.
+- Creating a new runtime hook or bot.
+- Releasing a new package version.
+
+## Acceptance Criteria
+
+- [x] `af plan <SOP> --todo` prints an `Active Process — COR-1402` section before the flat TODO.
+- [x] `af plan <SOP> --todo --json` includes a structured `active_process` list.
+- [x] `COR-1402` covers every user-visible task, not only tasks with a task-specific SOP.
+- [x] `COR-1202` tells executors to emit the generated declaration at task start and phase transitions.
+- [x] `af plan --task "release fx-alfred to pypi"` can resolve `FXA-2102` via task tags.
+
+## Validation
+
+- `uv run pytest tests/test_plan_cmd.py -q`
+- `uv run af validate --root /Users/frank/Projects/alfred-1402-active-process-output`
+
+## Change History
+
+| Date       | Change                                      | By   |
+|------------|---------------------------------------------|------|
+| 2026-06-26 | Initial CHG for generated COR-1402 output   | Moth |

--- a/skills/alfred/README.md
+++ b/skills/alfred/README.md
@@ -2,7 +2,7 @@
 
 Drop-in instructions that teach an AI coding agent to use the **`af` CLI**
 (Alfred — Agent Runbook) as its workflow runbook: route with `af guide`, plan
-with `af plan`, declare the active SOP, and review before committing.
+with `af plan`, declare the active SOP on every reply, and review before committing.
 
 This bundle is **CLI-dynamic** — it assumes `af` is installed and contains
 **instructions only, no scripts**. The agent calls `af` through its own shell.

--- a/skills/alfred/agents/AGENTS.md
+++ b/skills/alfred/agents/AGENTS.md
@@ -38,8 +38,10 @@ printed steps in order and do not skip any.
 ## 4. Execute
 
 - Work through the checklist one step at a time.
-- At each phase transition, declare the active SOP — state its ACID, the plan
-  ACID if any, and the current phase/step — per COR-1402.
+- Open every reply with a COR-1402 active-process line as its first line — state
+  the active SOP's ACID, the plan ACID if any, and the current phase/step. Re-state
+  it on every turn; when no task SOP applies use
+  `📋 COR-1402 Declare Active Process → no formal task SOP`.
 - Do not commit code before completing the review steps the plan lists.
 
 ## 5. Session end

--- a/skills/alfred/alfred-contract.md
+++ b/skills/alfred/alfred-contract.md
@@ -37,8 +37,10 @@ printed steps in order and do not skip any.
 ## 4. Execute
 
 - Work through the checklist one step at a time.
-- At each phase transition, declare the active SOP — state its ACID, the plan
-  ACID if any, and the current phase/step — per COR-1402.
+- Open every reply with a COR-1402 active-process line as its first line — state
+  the active SOP's ACID, the plan ACID if any, and the current phase/step. Re-state
+  it on every turn; when no task SOP applies use
+  `📋 COR-1402 Declare Active Process → no formal task SOP`.
 - Do not commit code before completing the review steps the plan lists.
 
 ## 5. Session end

--- a/skills/alfred/claude/SKILL.md
+++ b/skills/alfred/claude/SKILL.md
@@ -43,8 +43,10 @@ printed steps in order and do not skip any.
 ## 4. Execute
 
 - Work through the checklist one step at a time.
-- At each phase transition, declare the active SOP — state its ACID, the plan
-  ACID if any, and the current phase/step — per COR-1402.
+- Open every reply with a COR-1402 active-process line as its first line — state
+  the active SOP's ACID, the plan ACID if any, and the current phase/step. Re-state
+  it on every turn; when no task SOP applies use
+  `📋 COR-1402 Declare Active Process → no formal task SOP`.
 - Do not commit code before completing the review steps the plan lists.
 
 ## 5. Session end

--- a/skills/alfred/copilot/copilot-instructions.md
+++ b/skills/alfred/copilot/copilot-instructions.md
@@ -38,8 +38,10 @@ printed steps in order and do not skip any.
 ## 4. Execute
 
 - Work through the checklist one step at a time.
-- At each phase transition, declare the active SOP — state its ACID, the plan
-  ACID if any, and the current phase/step — per COR-1402.
+- Open every reply with a COR-1402 active-process line as its first line — state
+  the active SOP's ACID, the plan ACID if any, and the current phase/step. Re-state
+  it on every turn; when no task SOP applies use
+  `📋 COR-1402 Declare Active Process → no formal task SOP`.
 - Do not commit code before completing the review steps the plan lists.
 
 ## 5. Session end

--- a/src/fx_alfred/commands/guide_cmd.py
+++ b/src/fx_alfred/commands/guide_cmd.py
@@ -128,3 +128,8 @@ def guide_cmd(ctx: click.Context, output_json: bool):
             " Then run `af plan <SOP_IDs>` before each task."
             " First time? Run `af setup` to configure your agent."
         )
+        click.echo(
+            "Open every reply with a COR-1402 active-process line"
+            " (use `📋 COR-1402 Declare Active Process → no formal task SOP`"
+            " when no task SOP applies)."
+        )

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -120,7 +120,7 @@ def _build_active_process_declarations(phase_info: list[_PhaseInfo]) -> list[dic
         phase_info, start=1
     ):
         doc_id = f"{doc.prefix}-{doc.acid}"
-        declaration = f"📋 {doc_id} {doc.title}"
+        declaration = f"📋 {doc_id} {doc.title} ▶ Phase {phase_num}"
         declarations.append(
             {
                 "phase": phase_num,
@@ -140,7 +140,7 @@ def _emit_active_process_text(phase_info: list[_PhaseInfo]) -> None:
     click.echo("# Active Process — COR-1402")
     click.echo()
     for item in declarations:
-        click.echo(f"- Phase {item['phase']}: {item['declaration']}")
+        click.echo(f"- {item['declaration']}")
     click.echo()
 
 

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -113,6 +113,37 @@ def _format_composed_from_header(provenance: dict[str, list[str]]) -> str:
     return "Composed from: " + " → ".join(parts)
 
 
+def _build_active_process_declarations(phase_info: list[_PhaseInfo]) -> list[dict]:
+    """Build COR-1402 active-process declarations for each composed phase."""
+    declarations: list[dict] = []
+    for phase_num, (_sop_id, doc, _parsed, _sig, _loops) in enumerate(
+        phase_info, start=1
+    ):
+        doc_id = f"{doc.prefix}-{doc.acid}"
+        declaration = f"📋 {doc_id} {doc.title}"
+        declarations.append(
+            {
+                "phase": phase_num,
+                "sop": doc_id,
+                "title": doc.title,
+                "declaration": declaration,
+            }
+        )
+    return declarations
+
+
+def _emit_active_process_text(phase_info: list[_PhaseInfo]) -> None:
+    """Emit copyable COR-1402 declarations for text plan modes."""
+    declarations = _build_active_process_declarations(phase_info)
+    if not declarations:
+        return
+    click.echo("# Active Process — COR-1402")
+    click.echo()
+    for item in declarations:
+        click.echo(f"- Phase {item['phase']}: {item['declaration']}")
+    click.echo()
+
+
 _LLM_RULES = """\
 ## RULES
 - Complete each checkbox before moving to the next phase
@@ -725,6 +756,7 @@ def _emit_todo_text(
         header = _format_composed_from_header(composed_from_provenance)
         click.echo(f"# {header}")
         click.echo()
+    _emit_active_process_text(phase_info)
     click.echo("# Flat TODO — Follow each item in order")
     click.echo()
     click.echo("\n".join(todo_items))
@@ -829,6 +861,7 @@ def _emit_json_output(
     if output_todo:
         result["todo"] = todo_json
         result["loops"] = loops_json
+        result["active_process"] = _build_active_process_declarations(phase_info)
 
     if output_graph:
         provenance_map = _build_provenance_map(composed_from_provenance)
@@ -889,6 +922,7 @@ def _emit_phased_text(
         header = _format_composed_from_header(composed_from_provenance)
         click.echo(f"# {header}")
         click.echo()
+    _emit_active_process_text(phase_info)
     if human:
         click.echo("\n".join(phases_text))
     else:

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -147,7 +147,7 @@ def _emit_active_process_text(phase_info: list[_PhaseInfo]) -> None:
 _LLM_RULES = """\
 ## RULES
 - Complete each checkbox before moving to the next phase
-- Declare active SOP per COR-1402: before starting, at every phase transition, flag if none exist, and confirm at completion
+- Declare the COR-1402 active-process line as the first line of EVERY reply — re-state it each turn (continuation, clarification, quick answers); use `📋 COR-1402 Declare Active Process → no formal task SOP` when no task SOP applies, and flag the gap (suggest creating an SOP); confirm SOPs used at completion
 - ⚠️ marks hard stops — do not proceed until condition is met
 - If stuck, ask one clarifying question before proceeding
 """

--- a/src/fx_alfred/commands/setup_cmd.py
+++ b/src/fx_alfred/commands/setup_cmd.py
@@ -13,7 +13,7 @@ Add ONE of the following to your agent's instruction file
 At session start, run COR-1208 (Session Startup Sanity Check: pwd, git status --short --branch, git log -5, project smoke test, load tracker per COR-1201, surface anomalies).
 Then run `af guide` to see routing.
 Before every task, run `af plan <SOP_IDs>` and follow the output.
-Declare active SOP per COR-1402 before starting work (or flag if none exist).
+Declare the active SOP per COR-1402 as the first line of EVERY reply (use the no-formal-SOP form `📋 COR-1402 Declare Active Process → no formal task SOP` when none applies).
 
 ## Option B: With routing
 
@@ -24,7 +24,7 @@ At session start:
 Before every task:
 3. From the decision tree, identify which SOPs apply
 4. Run `af plan <SOP_IDs>` to generate workflow instructions
-5. Declare active SOP per COR-1402 before starting work (or flag if none exist)
+5. Declare the active SOP per COR-1402 as the first line of every reply (use the no-formal-SOP form when none applies)
 6. Follow each step. At every SOP transition, declare the new active SOP.
 7. Do not skip review gates.
 
@@ -37,7 +37,7 @@ At session start:
 Before every task:
 3. From the decision tree, identify which SOPs apply to this task
 4. Run `af plan <SOP_IDs>` to generate step-by-step workflow
-5. Declare active SOP per COR-1402 before starting work (or flag if none exist)
+5. Declare the active SOP per COR-1402 as the first line of every reply (use the no-formal-SOP form when none applies)
 6. Follow each step. At every SOP transition, declare the new active SOP.
 7. Do not commit code without completing review steps
 8. When task is done, confirm which SOPs were used and use the plan output as completion checklist
@@ -45,7 +45,7 @@ Before every task:
 COR-1208 = first action of every active session (state-recovery ritual; wraps COR-1201 as step 4).
 af guide = once per session (routing context).
 af plan  = before EVERY task (checklist from SOPs).
-COR-1402 = declare active SOP before work, at every transition, flag if none exist, confirm at completion.
+COR-1402 = open EVERY reply with the active-process line (use `📋 COR-1402 Declare Active Process → no formal task SOP` when none applies); re-declare at every transition; confirm at completion.
 """
 
 

--- a/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
+++ b/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
@@ -81,7 +81,7 @@ Commit ────────────► af validate → Session End
 
 • COR-1208: First action of every active session — `pwd` + `git status --short --branch` + `git log --oneline -5` + project smoke test + load tracker + surface anomalies (stop until operator acknowledges). Wraps the COR-1201 tracker load as its step 4.
 • COR-1201: Discussion Tracker mechanism — search for today's file, read max DN, auto-increment on new topics. Invoked from COR-1208 step 4; can also be invoked standalone for tracker-only operations.
-• COR-1402: Declare 📋 active SOP before work and on every transition
+• COR-1402: Declare 📋 active SOP as the first line of every reply (re-state on every transition)
 • COR-1103: Route the task before reading detailed SOPs (skip if caller already provides explicit SOP — but still offer COR-1203 alignment for PRPs and non-trivial code changes when the mandatory threshold is met)
 • af plan: Before every response — decide if task needs a checklist. For a manual, targeted checklist from specific SOPs: `af plan <SOP_IDs>`.
 • COR-1202 (Compose Session Plan): for the full session-workflow plan — use when the user says "show me the plan" / "compose session plan" / "follow COR-1202", or when the task spans multiple SOPs and you want auto-composition (ASCII + Mermaid + flat TODO) rather than hand-picking SOP IDs.
@@ -136,7 +136,7 @@ like PRP, CHG, ADR, PLN, INC. Those match branches 2-6.
 • PRP approval              → COR-1602 strict (both reviewers >= 9)
 • New SOP/doc created       → Review via COR-1600 (Direct Review) at minimum
 • Before any multi-agent work → COR-1606 (select review or implementation workflow)
-• Compound task (A AND B)   → Split into sub-routes, COR-1402 each transition
+• Compound task (A AND B)   → Split into sub-routes, COR-1402 every reply
 • Confidence < 90%          → Ask one clarifying question before proceeding
 • Background agents running → Proactively report progress on every user message (check output file sizes, show line counts)
 • Review scoring rubric    → COR-1608 (PRP) / COR-1609 (CHG) / COR-1610 (Code) + COR-1611 (calibration)
@@ -158,7 +158,7 @@ like PRP, CHG, ADR, PLN, INC. Those match branches 2-6.
 Essential rules from COR SOPs. Read these at session start; only read the full SOP when executing that specific workflow.
 
 ```
-COR-1402: Always declare 📋 active SOP before work and when switching
+COR-1402: Always declare 📋 active SOP as the first line of every reply (and when switching)
 COR-1102: New capability/design → PRP; no implementation until COR-1602 strict approval
 COR-1606: Before any multi-agent work → select workflow (COR-1600–1605) based on task characteristics
 COR-1101: Existing system/config change → CHG with What, Why, Impact, Plan; Standard changes are pre-approved (no review)
@@ -179,7 +179,7 @@ COR-1616: Reviewed delivery slice → contract first (PRP/CHG/PLN), plan review 
 COR-1503: Diagnose bug/perf regression → build feedback loop → reproduce → hypothesise (3-5 ranked) → instrument (one variable/round) → fix → regression-test (hand off to COR-1500)
 COR-1203: Pre-task alignment → before PRP/non-trivial code, offer 7-step Socratic interview; challenge against glossary (COR-1204 CTX), sharpen terms, stop when crisp or user-declined; record one-line outcome
 COR-1801: Pattern promotion → evaluate PRJ pattern contract and evidence before creating or amending PKG/COR documents
-Reading an SOP: af read → What + Why → When to Use → When NOT → Prerequisites → Pitfalls → Steps (COR-1402 each step)
+Reading an SOP: af read → What + Why → When to Use → When NOT → Prerequisites → Pitfalls → Steps (COR-1402 every reply)
 ```
 
 ---
@@ -259,3 +259,4 @@ To create a routing document, follow **COR-1004** (Create Routing Document).
 | 2026-05-06 | Add COR-1614 routing entries for approved multi-phase continuous execution contracts. | Codex |
 | 2026-05-07 | Add COR-1616 routing entries (OVERLAY + Golden Rule) for Contract-First Delivery Workflow promoted from BAB-1503 per issue #106. | Claude Code |
 | 2026-06-19 | Add COR-1508 routing entries (OVERLAYS line + Golden Rule) for the Minimal Code Ladder write-time gate, adapted from the Ponytail ruleset. | Claude Code |
+| 2026-06-26 | Align COR-1402 declaration cadence in cheat-sheet / Golden Rules to first-line-of-every-reply. | Claude Code |

--- a/src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md
+++ b/src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md
@@ -177,4 +177,4 @@ Now exits 0 with `COR-1500(explicit)` in the `Composed from:` header.
 | Date       | Change          | By              |
 |------------|-----------------|-----------------|
 | 2026-04-18 | Initial version (per CHG-FXA-2207). | Frank + Claude |
-| 2026-06-26 | Require plan execution to emit COR-1402 active-process declarations at task start and phase transitions | Moth |
+| 2026-06-26 | Require plan execution to emit COR-1402 active-process declarations at task start and phase transitions | Claude Code |

--- a/src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md
+++ b/src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md
@@ -1,8 +1,8 @@
 # SOP-1202: Compose Session Plan
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-04-18
-**Last reviewed:** 2026-04-18
+**Last updated:** 2026-06-26
+**Last reviewed:** 2026-06-26
 **Status:** Active
 **Related:** COR-1103, COR-1402, COR-1200
 **Disposition:** inherit-only
@@ -56,7 +56,7 @@ Run:
 af plan --root . --task "<description>" --todo --graph
 ```
 
-The default `--graph-format=both` emits ASCII + Mermaid together. Use `--graph-format=ascii` or `--graph-format=mermaid` to pick one. Use `--json` when a programmatic consumer is downstream.
+The default `--graph-format=both` emits ASCII + Mermaid together. Use `--graph-format=ascii` or `--graph-format=mermaid` to pick one. Use `--json` when a programmatic consumer is downstream. The plan output includes a COR-1402 active-process section with copyable declarations for each phase.
 
 ### 4. Review provenance
 
@@ -73,7 +73,7 @@ Copy the flat TODO into the session's working surface: issue / Discussion Tracke
 
 ### 6. Execute
 
-Execute step by step. At each phase transition the executor (agent or human running the plan) declares the active SOP per COR-1402 and honours any `Workflow loops` `max N` bound rendered in the plan. (A `Workflow loops` entry is SOP metadata declaring a bounded retry — e.g. review loop "max 3". In the ASCII/Mermaid output it appears as a dashed back-edge; in the flat TODO it appears as `🔁 back to N.M (max K)` on the loop's `from` step. Stop the loop when `max K` is reached; escalate per the SOP's own rules.)
+Execute step by step. Before starting the task and at each phase transition, the executor (agent or human running the plan) emits the matching active-process declaration from the plan's COR-1402 section, then honours any `Workflow loops` `max N` bound rendered in the plan. (A `Workflow loops` entry is SOP metadata declaring a bounded retry — e.g. review loop "max 3". In the ASCII/Mermaid output it appears as a dashed back-edge; in the flat TODO it appears as `🔁 back to N.M (max K)` on the loop's `from` step. Stop the loop when `max K` is reached; escalate per the SOP's own rules.)
 
 ### 7. Close and compare
 
@@ -96,6 +96,12 @@ Expected output (abbreviated — header + flat TODO first):
 ```text
 # Composed from: COR-1103(always) → COR-1402(always) → COR-1500(auto)
                 → COR-1602(auto) → COR-1608(auto) → COR-1610(auto)
+
+# Active Process — COR-1402
+
+- Phase 1: 📋 COR-1103 Session Routing
+- Phase 2: 📋 COR-1402 Declare Active Process
+- Phase 3: 📋 COR-1500 TDD Development Workflow
 
 # Flat TODO — Follow each item in order
 - [ ] 1.1 [COR-1103] (session routing)
@@ -169,3 +175,4 @@ Now exits 0 with `COR-1500(explicit)` in the `Composed from:` header.
 | Date       | Change          | By              |
 |------------|-----------------|-----------------|
 | 2026-04-18 | Initial version (per CHG-FXA-2207). | Frank + Claude |
+| 2026-06-26 | Require plan execution to emit COR-1402 active-process declarations at task start and phase transitions | Moth |

--- a/src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md
+++ b/src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md
@@ -73,7 +73,7 @@ Copy the flat TODO into the session's working surface: issue / Discussion Tracke
 
 ### 6. Execute
 
-Execute step by step. Before starting the task and at each phase transition, the executor (agent or human running the plan) emits the matching active-process declaration from the plan's COR-1402 section, then honours any `Workflow loops` `max N` bound rendered in the plan. (A `Workflow loops` entry is SOP metadata declaring a bounded retry — e.g. review loop "max 3". In the ASCII/Mermaid output it appears as a dashed back-edge; in the flat TODO it appears as `🔁 back to N.M (max K)` on the loop's `from` step. Stop the loop when `max K` is reached; escalate per the SOP's own rules.)
+Execute step by step. Open every reply with the matching active-process declaration from the plan's COR-1402 section — re-selecting it at each phase transition — then honour any `Workflow loops` `max N` bound rendered in the plan. (A `Workflow loops` entry is SOP metadata declaring a bounded retry — e.g. review loop "max 3". In the ASCII/Mermaid output it appears as a dashed back-edge; in the flat TODO it appears as `🔁 back to N.M (max K)` on the loop's `from` step. Stop the loop when `max K` is reached; escalate per the SOP's own rules.)
 
 ### 7. Close and compare
 
@@ -177,4 +177,4 @@ Now exits 0 with `COR-1500(explicit)` in the `Composed from:` header.
 | Date       | Change          | By              |
 |------------|-----------------|-----------------|
 | 2026-04-18 | Initial version (per CHG-FXA-2207). | Frank + Claude |
-| 2026-06-26 | Require plan execution to emit COR-1402 active-process declarations at task start and phase transitions | Claude Code |
+| 2026-06-26 | Require plan execution to emit the COR-1402 active-process declaration on every reply, re-selecting it at phase transitions | Claude Code |

--- a/src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md
+++ b/src/fx_alfred/rules/COR-1202-SOP-Compose-Session-Plan.md
@@ -99,9 +99,9 @@ Expected output (abbreviated — header + flat TODO first):
 
 # Active Process — COR-1402
 
-- Phase 1: 📋 COR-1103 Session Routing
-- Phase 2: 📋 COR-1402 Declare Active Process
-- Phase 3: 📋 COR-1500 TDD Development Workflow
+- 📋 COR-1103 Session Routing ▶ Phase 1
+- 📋 COR-1402 Declare Active Process ▶ Phase 2
+- 📋 COR-1500 TDD Development Workflow ▶ Phase 3
 
 # Flat TODO — Follow each item in order
 - [ ] 1.1 [COR-1103] (session routing)
@@ -109,6 +109,8 @@ Expected output (abbreviated — header + flat TODO first):
 - [ ] 3.1 [COR-1500] (TDD)
   ...
 ```
+
+> Note: the generated active-process lines intentionally use the compact `▶ Phase N` form (the phase's SOP title already precedes the `▶`), rather than COR-1402's full canonical `<PLN-ACID> Phase N <Name>` form — there is no persisted PLN document in a composed plan to reference.
 
 Then the fenced Mermaid block (for GitHub / Obsidian rendering):
 

--- a/src/fx_alfred/rules/COR-1207-SOP-Zoom-Out.md
+++ b/src/fx_alfred/rules/COR-1207-SOP-Zoom-Out.md
@@ -46,7 +46,7 @@ Zoom-out costs ~30 seconds of model time. Fixing the consequences of skipping it
 
 ## Steps
 
-1. **State the unfamiliarity explicitly.** Open with: *"I don't know this area well. Zooming out before diving in."* The declaration is for the operator's record per COR-1402.
+1. **State the unfamiliarity explicitly.** Open with: *"I don't know this area well. Zooming out before diving in."* The declaration is for the operator's record per COR-1402. Per COR-1402's chat-surface exception, this unfamiliarity statement is the mandated opening; the COR-1402 active-process line immediately follows it.
 
 2. **Load the project glossary.** If a CTX document exists per COR-1204-REF, read it before mapping. The glossary supplies the vocabulary the map will use. If no CTX exists, note *"no glossary loaded — using inferred vocabulary"* in the map header.
 

--- a/src/fx_alfred/rules/COR-1208-SOP-Session-Startup-Sanity-Check.md
+++ b/src/fx_alfred/rules/COR-1208-SOP-Session-Startup-Sanity-Check.md
@@ -66,7 +66,7 @@ The startup ritual is also Anthropic's empirical finding: *"Established consiste
 
    The agent does NOT proceed past this step until anomalies are resolved or explicitly accepted. Resolution is recorded in the active session's Discussion Tracker entry per COR-1201.
 
-6. **Declare the active process.** Only after anomalies are resolved or accepted, declare the next SOP per COR-1402 (typically COR-1103 routing leading to a task-specific SOP). The declaration line should briefly note the sanity-check outcome: *"Tree clean, tests green, no tracker blockers — declaring COR-1103."*
+6. **Declare the active process.** Only after anomalies are resolved or accepted, declare the next SOP per COR-1402 (typically COR-1103 routing leading to a task-specific SOP). The declaration line should briefly note the sanity-check outcome: *"Tree clean, tests green, no tracker blockers — declaring COR-1103."* This sanity-check report is the COR-1208-mandated opening that precedes the session's first COR-1402 line, per COR-1402's chat-surface exception.
 
 ---
 

--- a/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
+++ b/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
@@ -1,8 +1,8 @@
 # SOP-1402: Declare Active Process
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-03-20
-**Last reviewed:** 2026-03-15
+**Last updated:** 2026-06-26
+**Last reviewed:** 2026-06-26
 **Status:** Active
 **Always included:** true
 **Disposition:** inherit-only
@@ -11,7 +11,7 @@
 
 ## What Is It?
 
-A rule requiring the agent to explicitly declare which SOP is being followed at every step of a task. This ensures traceability, helps the user understand what process is driving the work, and surfaces gaps where no SOP exists.
+A rule requiring the agent to explicitly declare the active process for every user-visible task. The declaration names the SOP being followed, or states that no formal SOP applies. This ensures traceability, helps the user understand what process is driving the work, and surfaces gaps where no SOP exists.
 
 ---
 
@@ -25,6 +25,7 @@ A rule requiring the agent to explicitly declare which SOP is being followed at 
 
 ## When to Use
 
+- At the start of every user-visible task
 - At the start of every task that follows a documented SOP
 - When switching from one SOP to another mid-task
 - When executing a plan-driven workflow (SOP + PLN + Phase)
@@ -33,14 +34,14 @@ A rule requiring the agent to explicitly declare which SOP is being followed at 
 
 ## When NOT to Use
 
-- For trivial actions that do not follow any formal process (e.g., answering a quick question)
+- For private/internal sub-steps that do not produce user-visible work
 - When the user explicitly asks to skip process declarations
 
 ---
 
 ## Rule
 
-### 1. Before starting any task, declare the active process
+### 1. Before starting any user-visible task, declare the active process
 
 **Simple task** (single SOP, no plan):
 ```
@@ -57,6 +58,11 @@ Example:
 📋 COR-1500-SOP (TDD Workflow) ▶ ALF-2200-PLN Phase 3 API Integration
 ```
 
+**No formal SOP applies** (quick answer or uncovered task):
+```
+📋 COR-1402 Declare Active Process → no formal task SOP
+```
+
 The declaration must include all applicable dimensions:
 
 | Dimension | When to include | Example |
@@ -64,6 +70,8 @@ The declaration must include all applicable dimensions:
 | **SOP** (process) | Always | `COR-1500-SOP` |
 | **PLN** (plan) | When executing a plan | `NRV-2207-PLN` |
 | **Phase / Step** | When the plan has phases | `Phase 2.5 BDD + Coverage` |
+
+For compact chat surfaces, the declaration may be one line. Do not skip it only because the task is short; use the no-formal-SOP form instead.
 
 ### 2. When switching processes, declare each transition
 
@@ -79,6 +87,8 @@ The declaration must include all applicable dimensions:
 
 ### 4. When the task is complete, confirm which SOPs were used
 
+If the task produced a checklist or release/PR handoff, include whether the COR-1402 declaration was emitted and updated at phase transitions.
+
 ---
 
 ## Change History
@@ -88,3 +98,4 @@ The declaration must include all applicable dimensions:
 | 2026-03-15 | Initial version | Claude Code |
 | 2026-03-16 | Added plan-driven declaration format (SOP + PLN + Phase) based on field usage | Claude Code |
 | 2026-03-20 | Added When to Use/When NOT to Use sections, reordered Why section per FXA-2223 | Claude Code |
+| 2026-06-26 | Require active-process content for every user-visible task, including no-formal-SOP cases | Moth |

--- a/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
+++ b/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
@@ -71,7 +71,7 @@ The declaration must include all applicable dimensions:
 | **PLN** (plan) | When executing a plan | `NRV-2207-PLN` |
 | **Phase / Step** | When the plan has phases | `Phase 2.5 BDD + Coverage` |
 
-For compact chat surfaces, the declaration may be one line. Do not skip it only because the task is short; use the no-formal-SOP form instead.
+**Chat surface (mandatory).** In conversational/chat surfaces, emit the active-process declaration as the **first line of every reply**, before any other content. Re-state it on every turn — including continuation, clarification, and quick-answer turns — so the active process is always visible. Keep it to one line when space is tight, but never omit it; for quick answers or uncovered tasks use the one-line no-formal-SOP form `📋 COR-1402 Declare Active Process → no formal task SOP`.
 
 ### 2. When switching processes, declare each transition
 
@@ -99,3 +99,4 @@ If the task produced a checklist or release/PR handoff, include whether the COR-
 | 2026-03-16 | Added plan-driven declaration format (SOP + PLN + Phase) based on field usage | Claude Code |
 | 2026-03-20 | Added When to Use/When NOT to Use sections, reordered Why section per FXA-2223 | Claude Code |
 | 2026-06-26 | Require active-process content for every user-visible task, including no-formal-SOP cases | Moth |
+| 2026-06-26 | Mandate active-process line as first line of every chat reply (chat-surface hardening) | Claude Code |

--- a/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
+++ b/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
@@ -98,5 +98,5 @@ If the task produced a checklist or release/PR handoff, include whether the COR-
 | 2026-03-15 | Initial version | Claude Code |
 | 2026-03-16 | Added plan-driven declaration format (SOP + PLN + Phase) based on field usage | Claude Code |
 | 2026-03-20 | Added When to Use/When NOT to Use sections, reordered Why section per FXA-2223 | Claude Code |
-| 2026-06-26 | Require active-process content for every user-visible task, including no-formal-SOP cases | Moth |
+| 2026-06-26 | Require active-process content for every user-visible task, including no-formal-SOP cases | Claude Code |
 | 2026-06-26 | Mandate active-process line as first line of every chat reply (chat-surface hardening) | Claude Code |

--- a/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
+++ b/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
@@ -71,7 +71,7 @@ The declaration must include all applicable dimensions:
 | **PLN** (plan) | When executing a plan | `NRV-2207-PLN` |
 | **Phase / Step** | When the plan has phases | `Phase 2.5 BDD + Coverage` |
 
-**Chat surface (mandatory).** In conversational/chat surfaces, emit the active-process declaration as the **first line of every reply**, before any other content. Re-state it on every turn — including continuation, clarification, and quick-answer turns — so the active process is always visible. Keep it to one line when space is tight, but never omit it; for quick answers or uncovered tasks use the one-line no-formal-SOP form `📋 COR-1402 Declare Active Process → no formal task SOP`.
+**Chat surface (mandatory).** In conversational/chat surfaces, emit the active-process declaration as the **first line of every reply**, before any other content — unless a declared SOP mandates a specific opening (e.g. COR-1208's session-startup sanity-check report, or COR-1207's unfamiliarity statement), in which case the COR-1402 line immediately follows that mandated preamble. Re-state it on every turn — including continuation, clarification, and quick-answer turns — so the active process is always visible. Keep it to one line when space is tight, but never omit it; for quick answers or uncovered tasks use the one-line no-formal-SOP form `📋 COR-1402 Declare Active Process → no formal task SOP`.
 
 ### 2. When switching processes, declare each transition
 
@@ -100,3 +100,4 @@ If the task produced a checklist or release/PR handoff, include whether the COR-
 | 2026-03-20 | Added When to Use/When NOT to Use sections, reordered Why section per FXA-2223 | Claude Code |
 | 2026-06-26 | Require active-process content for every user-visible task, including no-formal-SOP cases | Claude Code |
 | 2026-06-26 | Mandate active-process line as first line of every chat reply (chat-surface hardening) | Claude Code |
+| 2026-06-26 | Add session-start/zoom-out exception: COR-1402 line follows a SOP-mandated opening preamble. | Claude Code |

--- a/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
+++ b/src/fx_alfred/rules/COR-1402-SOP-Declare-Active-Process.md
@@ -87,7 +87,7 @@ The declaration must include all applicable dimensions:
 
 ### 4. When the task is complete, confirm which SOPs were used
 
-If the task produced a checklist or release/PR handoff, include whether the COR-1402 declaration was emitted and updated at phase transitions.
+If the task produced a checklist or release/PR handoff, include whether the COR-1402 declaration opened every reply and was updated at phase transitions.
 
 ---
 

--- a/src/fx_alfred/rules/COR-1616-SOP-Contract-First-Delivery-Workflow.md
+++ b/src/fx_alfred/rules/COR-1616-SOP-Contract-First-Delivery-Workflow.md
@@ -96,7 +96,7 @@ flowchart TD
 ## Steps
 
 1. **Route the work.**
-   Read the project routing SOP and identify whether the slice needs a new PRP, CHG, PLN, ADR, or fits an existing contract. Declare the active SOP before starting and at major transitions (per COR-1402).
+   Read the project routing SOP and identify whether the slice needs a new PRP, CHG, PLN, ADR, or fits an existing contract. Declare the active SOP as the first line of every reply, re-stating it at major transitions (per COR-1402).
 
 2. **Load slice context.**
    Read the roadmap / phase document, relevant ADRs, recent discussion-tracker entries, and any prior contracts the slice continues. State the current objective, deferred items, and explicit out-of-scope items.
@@ -247,3 +247,4 @@ The adapter declares "Inherits from: COR-1616" in its metadata and only override
 | 2026-05-07 | Initial version — promoted from BAB-1503 (Babs phase delivery workflow) into a project-neutral SOP per issue #106 | Claude Code |
 | 2026-05-07 | Trinity review round 1: Gemini 10.0 PASS, GLM 9.05 PASS, Codex 9.20 CONCERNS (1 blocking), DeepSeek 9.00 PASS. Fix Codex blocker (de-Babs Example 3: drop literal `BAB-2300`/`FXA-21xx`/`babs.gate_a`); fix convergent advisory (Step 7 fallback when no validation stack declared); fold in Pitfalls section, COR-1614 boundary line, Chrome-version softening | Claude Code |
 | 2026-05-07 | Trinity review round 2: Gemini 9.35 PASS, GLM 9.28 PASS, Codex 9.70 PASS, DeepSeek 9.45 PASS — all four reviewers PASS, zero blocking. Fix 2/4-convergent advisory (Gemini + DeepSeek): drop self-referential `BAB-1503` parenthetical from Example 3 line 238. Fix single-reviewer ambiguity (Gemini): clarify Step 3 PLN guidance vs. COR-1614 multi-PR territory | Claude Code |
+| 2026-06-26 | Align Step 1 declaration cadence with hardened COR-1402 (first line of every reply) | Claude Code |

--- a/src/fx_alfred/rules/INIT.md
+++ b/src/fx_alfred/rules/INIT.md
@@ -16,7 +16,7 @@ If a `*-0000-REF-*.md` file appears in the PRJ layer, read it too — that's the
 
 ## Step 3: Follow the rules
 
-- **COR-1402**: Always declare which SOP you are following before starting a task.
+- **COR-1402**: Declare the active SOP as the first line of every reply — re-state it each turn; use `📋 COR-1402 Declare Active Process → no formal task SOP` when no task SOP applies.
 - **COR-1400**: Every SOP does exactly one thing.
 - **COR-1401**: All documents must be written in English.
 

--- a/tests/test_cor1402_literal_drift.py
+++ b/tests/test_cor1402_literal_drift.py
@@ -1,0 +1,71 @@
+"""Drift guard for the COR-1402 no-formal-SOP canonical literal (FXA-2312).
+
+Pins the exact declaration string across every surface that teaches the
+COR-1402 cadence so a wording change on any one surface immediately fails CI,
+preventing the class of silent regression that caused a 6-round serial review
+loop during FXA-2312 development.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.docs
+
+_REPO = Path(__file__).resolve().parents[1]
+
+CANONICAL = "📋 COR-1402 Declare Active Process → no formal task SOP"
+
+_SURFACES = [
+    _REPO / "src" / "fx_alfred" / "rules" / "INIT.md",
+    _REPO / "src" / "fx_alfred" / "rules" / "COR-1402-SOP-Declare-Active-Process.md",
+    _REPO / "src" / "fx_alfred" / "commands" / "plan_cmd.py",
+    _REPO / "src" / "fx_alfred" / "commands" / "setup_cmd.py",
+    _REPO / "src" / "fx_alfred" / "commands" / "guide_cmd.py",
+    _REPO / "CLAUDE.md",
+    _REPO / "skills" / "alfred" / "alfred-contract.md",
+    _REPO / "skills" / "alfred" / "claude" / "SKILL.md",
+    _REPO / "skills" / "alfred" / "agents" / "AGENTS.md",
+    _REPO / "skills" / "alfred" / "copilot" / "copilot-instructions.md",
+]
+
+_OLD_SHORT_FORM = "📋 COR-1402 → no formal task SOP"
+
+
+def _old_form_candidates() -> list[Path]:
+    """Walk the four search scopes and return candidate files."""
+    fx = _REPO / "src" / "fx_alfred"
+    files: list[Path] = []
+    files.extend(fx.rglob("*.py"))
+    files.extend((fx / "rules").glob("*.md"))
+    files.extend((_REPO / "skills").rglob("*.md"))
+    files.append(_REPO / "CLAUDE.md")
+    return sorted(set(files))
+
+
+def test_canonical_literal_present_in_all_surfaces() -> None:
+    """CANONICAL string appears (substring, UTF-8) in every teaching surface."""
+    missing = [
+        str(path)
+        for path in _SURFACES
+        if CANONICAL not in path.read_text(encoding="utf-8")
+    ]
+    assert missing == [], (
+        f"CANONICAL literal missing from {len(missing)} surface(s):\n"
+        + "\n".join(f"  {p}" for p in missing)
+    )
+
+
+def test_no_old_shortform_anywhere() -> None:
+    """The OLD short form (without 'Declare Active Process') must not appear."""
+    hits = [
+        str(path)
+        for path in _old_form_candidates()
+        if _OLD_SHORT_FORM in path.read_text(encoding="utf-8")
+    ]
+    assert hits == [], (
+        f"Old short form {_OLD_SHORT_FORM!r} found in {len(hits)} file(s):\n"
+        + "\n".join(f"  {p}" for p in hits)
+    )

--- a/tests/test_guide_cmd.py
+++ b/tests/test_guide_cmd.py
@@ -243,6 +243,19 @@ def test_guide_appends_usage_record_to_user_log(sample_project, monkeypatch):
     assert payload["result_count"] == len(payload["refs"])
 
 
+def test_guide_reminds_active_process_declaration(sample_project, monkeypatch):
+    """Closing reminder tells operators to open replies with a COR-1402 line."""
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["guide"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "active-process line" in result.output
+    assert "COR-1402" in result.output
+    json_result = runner.invoke(cli, ["guide", "--json"], catch_exceptions=False)
+    assert json_result.exit_code == 0
+    assert "active-process line" not in json_result.output
+
+
 def test_guide_logging_failure_does_not_break_command(sample_project, monkeypatch):
     """Usage telemetry is fail-open for the user-facing command."""
     monkeypatch.chdir(sample_project)

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -187,6 +187,18 @@ def test_setup_outputs_prompts(sample_project, monkeypatch):
     assert "af guide" in result.output
 
 
+def test_setup_cor1402_reflects_hardened_rule(sample_project, monkeypatch):
+    """af setup COR-1402 guidance must say 'first line of every reply' and
+    include the no-formal-SOP canonical form (PR #242 Codex finding)."""
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["setup"], catch_exceptions=False)
+    assert result.exit_code == 0
+    output_lower = result.output.lower()
+    assert "first line of every reply" in output_lower
+    assert "📋 COR-1402 Declare Active Process → no formal task SOP" in result.output
+
+
 def _create_skill_ref(
     rules_dir: Path,
     prefix: str,

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -23,14 +23,22 @@ from fx_alfred.core.workflow import BranchSignature, WorkflowSignature
 pytestmark = pytest.mark.cli
 
 
-def _create_sop_with_steps(rules_dir: Path, prefix: str, acid: str, title: str) -> Path:
+def _create_sop_with_steps(
+    rules_dir: Path,
+    prefix: str,
+    acid: str,
+    title: str,
+    *,
+    task_tags: str | None = None,
+) -> Path:
     """Helper to create an SOP document with Steps section."""
     filename = f"{prefix}-{acid}-SOP-{title}.md"
+    task_tags_line = f"**Task tags:** {task_tags}\n" if task_tags else ""
     content = f"""# {prefix}-{acid}: {title.replace("-", " ")}
 
 **Applies to:** Test
 **Status:** Active
----
+{task_tags_line}---
 ## What Is It?
 A test SOP for plan command testing.
 ## Steps
@@ -93,6 +101,48 @@ def test_plan_multiple_sops(sample_project, monkeypatch):
     assert result.exit_code == 0
     assert "Phase 1" in result.output
     assert "Phase 2" in result.output
+
+
+def test_plan_todo_outputs_active_process_declarations(sample_project, monkeypatch):
+    """--todo emits COR-1402 declarations for each composed phase."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Test-Workflow")
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "TST-5001", "--todo"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0
+    assert "# Active Process — COR-1402" in result.output
+    assert "- Phase 1: 📋 TST-5001 Test Workflow" in result.output
+    assert "# Flat TODO — Follow each item in order" in result.output
+
+
+def test_plan_todo_json_outputs_active_process_declarations(
+    sample_project, monkeypatch
+):
+    """--todo --json includes structured COR-1402 declarations."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Test-Workflow")
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "TST-5001", "--todo", "--json"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    assert data["active_process"] == [
+        {
+            "phase": 1,
+            "sop": "TST-5001",
+            "title": "Test Workflow",
+            "declaration": "📋 TST-5001 Test Workflow",
+        }
+    ]
 
 
 def test_plan_skips_non_sop(sample_project, monkeypatch):

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -110,9 +110,7 @@ def test_plan_todo_outputs_active_process_declarations(sample_project, monkeypat
 
     monkeypatch.chdir(sample_project)
     runner = CliRunner()
-    result = runner.invoke(
-        cli, ["plan", "TST-5001", "--todo"], catch_exceptions=False
-    )
+    result = runner.invoke(cli, ["plan", "TST-5001", "--todo"], catch_exceptions=False)
 
     assert result.exit_code == 0
     assert "# Active Process — COR-1402" in result.output

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -114,8 +114,28 @@ def test_plan_todo_outputs_active_process_declarations(sample_project, monkeypat
 
     assert result.exit_code == 0
     assert "# Active Process — COR-1402" in result.output
-    assert "- Phase 1: 📋 TST-5001 Test Workflow" in result.output
+    assert "- 📋 TST-5001 Test Workflow ▶ Phase 1" in result.output
     assert "# Flat TODO — Follow each item in order" in result.output
+
+
+def test_plan_todo_active_process_multiphase_text_ordering(sample_project, monkeypatch):
+    """--todo with two SOPs emits both COR-1402 declarations with correct phase suffixes and ordering."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Test-Workflow")
+    _create_sop_with_steps(rules_dir, "TST", "5002", "Second-Workflow")
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "TST-5001", "TST-5002", "--todo"], catch_exceptions=False
+    )
+
+    assert result.exit_code == 0
+    phase1_line = "- 📋 TST-5001 Test Workflow ▶ Phase 1"
+    phase2_line = "- 📋 TST-5002 Second Workflow ▶ Phase 2"
+    assert phase1_line in result.output
+    assert phase2_line in result.output
+    assert result.output.index(phase1_line) < result.output.index(phase2_line)
 
 
 def test_plan_todo_json_outputs_active_process_declarations(
@@ -138,7 +158,7 @@ def test_plan_todo_json_outputs_active_process_declarations(
             "phase": 1,
             "sop": "TST-5001",
             "title": "Test Workflow",
-            "declaration": "📋 TST-5001 Test Workflow",
+            "declaration": "📋 TST-5001 Test Workflow ▶ Phase 1",
         }
     ]
 

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -1679,6 +1679,44 @@ def test_task_header_shows_provenance(sample_project, monkeypatch):
     assert "(auto)" in result.output
 
 
+def test_release_task_routes_to_pypi_sop_but_changelog_task_does_not(
+    sample_project, monkeypatch
+):
+    """Release tags stay specific enough to avoid routine changelog routing."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_task_tags(
+        rules_dir, "FXA", "2102", "Release-To-PyPI", "[release, pypi, publish]"
+    )
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+
+    release_result = runner.invoke(
+        cli,
+        ["plan", "--task", "release fx-alfred to pypi", "--json"],
+        catch_exceptions=False,
+    )
+    assert release_result.exit_code == 0
+    release_data = json.loads(release_result.output)
+    assert "FXA-2102" in release_data["composed_from"]["auto"]
+
+    changelog_result = runner.invoke(
+        cli, ["plan", "--task", "update changelog"], catch_exceptions=False
+    )
+    assert changelog_result.exit_code == 2
+    assert "matched 0 tagged SOPs" in changelog_result.output
+    assert "FXA-2102" not in changelog_result.output
+
+
+def test_release_sop_task_tags_are_release_specific():
+    """FXA-2102 avoids generic maintenance tags that misroute tasks."""
+    rule_path = Path(__file__).parents[1] / "rules" / "FXA-2102-SOP-Release-To-PyPI.md"
+    parsed = parse_metadata(rule_path.read_text(encoding="utf-8"))
+    field_map = {mf.key: mf.value for mf in parsed.metadata_fields}
+
+    assert field_map["Task tags"] == "release, pypi, publish"
+
+
 def test_task_json_composed_from_structure(sample_project, monkeypatch):
     """--task --json composed_from has always/auto lists."""
     import json

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -1728,10 +1728,17 @@ def test_task_header_shows_provenance(sample_project, monkeypatch):
 def test_release_task_routes_to_pypi_sop_but_changelog_task_does_not(
     sample_project, monkeypatch
 ):
-    """Release tags stay specific enough to avoid routine changelog routing."""
+    """`publish docs` / `update changelog` do not match the `release, pypi` tags.
+
+    Note: this only proves the dropped `publish` tag and the unrelated
+    `changelog` term no longer route. The remaining `release` tag is still
+    broad under the matcher's union semantics (e.g. `release notes` would
+    match); narrowing it cleanly requires a matcher enhancement, not a tag
+    edit — see FXA-2102 Task-tags note.
+    """
     rules_dir = sample_project / "rules"
     _create_sop_with_task_tags(
-        rules_dir, "FXA", "2102", "Release-To-PyPI", "[release, pypi, publish]"
+        rules_dir, "FXA", "2102", "Release-To-PyPI", "[release, pypi]"
     )
 
     monkeypatch.chdir(sample_project)
@@ -1753,6 +1760,12 @@ def test_release_task_routes_to_pypi_sop_but_changelog_task_does_not(
     assert "matched 0 tagged SOPs" in changelog_result.output
     assert "FXA-2102" not in changelog_result.output
 
+    publish_docs_result = runner.invoke(
+        cli, ["plan", "--task", "publish docs"], catch_exceptions=False
+    )
+    assert publish_docs_result.exit_code == 2
+    assert "FXA-2102" not in publish_docs_result.output
+
 
 def test_release_sop_task_tags_are_release_specific():
     """FXA-2102 avoids generic maintenance tags that misroute tasks."""
@@ -1760,7 +1773,7 @@ def test_release_sop_task_tags_are_release_specific():
     parsed = parse_metadata(rule_path.read_text(encoding="utf-8"))
     field_map = {mf.key: mf.value for mf in parsed.metadata_fields}
 
-    assert field_map["Task tags"] == "release, pypi, publish"
+    assert field_map["Task tags"] == "release, pypi"
 
 
 def test_task_json_composed_from_structure(sample_project, monkeypatch):

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -402,6 +402,20 @@ def test_plan_llm_mode_has_rules(sample_project, monkeypatch):
     assert "## RULES" in result.output
 
 
+def test_plan_llm_rules_mentions_every_reply_first_line(sample_project, monkeypatch):
+    """RULES block instructs agents to declare COR-1402 as first line of EVERY reply."""
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Test-Workflow")
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["plan", "TST-5001"], catch_exceptions=False)
+    assert result.exit_code == 0
+    assert "first line of EVERY reply" in result.output
+    assert "📋 COR-1402 Declare Active Process → no formal task SOP" in result.output
+    assert "flag the gap" in result.output
+
+
 def test_plan_human_mode_no_rules(sample_project, monkeypatch):
     """--human mode does NOT include ## RULES section."""
     rules_dir = sample_project / "rules"


### PR DESCRIPTION
## Summary

- Add generated `Active Process — COR-1402` declarations to `af plan` text output.
- Add structured `active_process` data to `af plan --todo --json`.
- Tighten COR-1402 so every user-visible task emits an active-process line, including no-formal-SOP quick tasks.
- Tighten COR-1202 so composed-plan execution emits the generated declarations at task start and phase transitions.
- Add `Task tags` to FXA-2102 so release tasks compose from natural language.

## Validation

- `PYTHONPATH=src uv run --isolated --with pytest --with click --with pyyaml --with wcwidth pytest tests/test_plan_cmd.py -q` — 104 passed
- `uv run af validate --root /Users/frank/Projects/alfred-1402-active-process-output` — 310 docs, 0 issues, 1 known FXA-2271 warning
- `PYTHONPATH=src uv run --isolated --with ruff ruff check src/fx_alfred/commands/plan_cmd.py tests/test_plan_cmd.py` — pass
- `PYTHONPATH=src uv run --isolated --with pyright --with click --with pyyaml --with wcwidth pyright src/fx_alfred/commands/plan_cmd.py` — 0 errors

## Example

`af plan --root . --task "release fx-alfred to pypi" --todo` now emits:

```text
# Composed from: COR-1103(always) → COR-1402(always) → FXA-2102(auto)

# Active Process — COR-1402

- Phase 1: 📋 COR-1103 Workflow Routing
- Phase 2: 📋 COR-1402 Declare Active Process
- Phase 3: 📋 FXA-2102 Release To PyPI
```
