### PR TITLE
feat(scanner): USR sub-project layer via projects.json mapping (FXA-2314)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ src/fx_alfred/
 │   ├── parser.py          # parse_metadata(), render_document(), extract_section(), fence-state iterator
 │   ├── phases.py          # PhaseDict/StepDict typed shapes
 │   ├── preferences.py     # ~/.alfred preferences store (star bookmarks)
+│   ├── projects.py        # projects.json loader + resolve_subproject() (FXA-2314)
 │   ├── routing.py         # routing-document detection (shared by guide + export)
 │   ├── scanner.py         # scan_documents(), find_document(), layer validation
 │   ├── schema.py          # DocType/DocRole enums, ALLOWED_STATUSES, REQUIRED_METADATA/SECTIONS

--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -1,234 +1,235 @@
 # REF-0000: Document Index
 
 **Applies to:** FXA project
-**Last updated:** 2026-06-26
-**Last reviewed:** 2026-06-21
+**Last updated:** 2026-06-27
+**Last reviewed:** 2026-06-27
 **Status:** Active
 
 ---
 
-| ACID | Type | Title | Status |
-|------|------|-------|--------|
-| 1623 | SOP | PR Review Thread Watchdog | Active |
-| 2100 | SOP | Leader Mediated Development | Active |
-| 2101 | CHG | Multi Layer Scan | Approved |
-| 2102 | SOP | Release To PyPI | Active |
-| 2103 | CHG | Root Option And Spacing | Approved |
-| 2104 | PRP | AF Update Command | Implemented |
-| 2105 | PRP | AF Rename Command | Rejected |
-| 2106 | PRP | AF CLI Optimization v0.6 | Implemented |
-| 2107 | CHG | Code Quality Refactoring | Completed |
-| 2108 | REF | Session Retrospective 2026 03 19 D1 | Active |
-| 2109 | CHG | DRY Scan Boilerplate | Proposed |
-| 2110 | CHG | Lazy Command Loading | Proposed |
-| 2111 | CHG | List Filtering | Proposed |
-| 2112 | CHG | JSON Output | Proposed |
-| 2113 | REF | Discussion Tracker 2026 03 19 D2 | Active |
-| 2114 | CHG | AF Search Command | Proposed |
-| 2115 | CHG | AF Validate Command | Proposed |
-| 2116 | PRP | Document Format Contract | Implemented |
-| 2117 | PRP | AF Filter And Section Update | Draft |
-| 2118 | REF | Session Retrospective 2026 03 19 D2 | Active |
-| 2119 | PLN | Document Format Contract Implementation | Completed |
-| 2120 | CHG | Create Document Format Contract Reference | Completed |
-| 2121 | CHG | Update Create Templates To Format Contract | Completed |
-| 2122 | CHG | Enhance Validate Per Type Fields And Status | Completed |
-| 2123 | CHG | Migrate Existing Documents To Format Contract | Completed |
-| 2124 | CHG | Layered Workflow Routing AF Guide | Completed |
-| 2125 | SOP | Workflow Routing PRJ | Active |
-| 2126 | PRP | AF Create Routing Shortcut | Rejected |
-| 2127 | SOP | Commit Alfred Ops | Deprecated |
-| 2128 | REF | Discussion Tracker 2026 03 20 | Active |
-| 2129 | CHG | Implement Review Scoring Framework | Completed |
-| 2130 | CHG | Standardize SOP Section Structure | Rolled Back |
-| 2131 | CHG | SOP Template And COR 1103 Reading Guide | Completed |
-| 2132 | CHG | AF Validate SOP Section Checking | Completed |
-| 2133 | CHG | Migrate All SOPs To Standard Structure | Completed |
-| 2134 | PRP | AF Plan Command Workflow Checklist | Implemented |
-| 2135 | CHG | Implement AF Plan Command | Completed |
-| 2136 | SOP | Update README | Active |
-| 2137 | CHG | AF Setup Guide Every Task Wording | Completed |
-| 2138 | PRP | Create Routing Document SOP | Approved |
-| 2139 | CHG | Implement COR 1004 Create Routing Document SOP | Completed |
-| 2140 | PRP | Core Python Schema Architecture | Implemented |
-| 2141 | PRP | AF Fmt Command | Implemented |
-| 2142 | CHG | JSON Output For Guide Plan Search Validate | Completed |
-| 2143 | CHG | Structured Spec Input For Create Update | Completed |
-| 2144 | CHG | AF Where Command | Completed |
-| 2145 | PRP | Auto Evolution SOP and CLI | Approved |
-| 2146 | REF | Evolution Philosophy | Active |
-| 2147 | CHG | Implement Auto Evolution SOPs REF Philosophy | Completed |
-| 2148 | SOP | Evolve SOP | Active |
-| 2149 | SOP | Evolve CLI | Active |
-| 2150 | REF | Evolve Run 20260330 204515 | Active |
-| 2151 | PRP | Translate FXA 2125 Decision Tree To English | Implemented |
-| 2152 | PRP | Fix FXA 2100 Command Reference And Round Limit | Implemented |
-| 2153 | CHG | Translate FXA 2125 Decision Tree To English | Completed |
-| 2154 | CHG | Fix FXA 2100 Command Reference And Round Limit | Completed |
-| 2155 | REF | Evolve Run 20260330 211109 | Active |
-| 2156 | PRP | Extract Duplicated Helpers And Add Gate Detection Tests | Draft |
-| 2157 | CHG | Extract Duplicated Helpers And Add Gate Detection Tests | Proposed |
-| 2158 | REF | Evolve Run 20260330 221843 | Active |
-| 2159 | PRP | Replace Assert With ClickException | Draft |
-| 2160 | CHG | Replace Assert With ClickException | Proposed |
-| 2161 | REF | Evolve Run 20260330 232601 | Active |
-| 2162 | PRP | Extract Atomic Write Helper | Draft |
-| 2163 | CHG | Extract Atomic Write Helper | Approved |
-| 2164 | REF | Evolve Run 20260401 050827 | Active |
-| 2165 | PRP | Extract Invoke Index Update Helper | Draft |
-| 2166 | CHG | Extract Invoke Index Update Helper | Approved |
-| 2167 | REF | Evolve Run 20260401 085641 | Active |
-| 2168 | PRP | Deduplicate Plan Cmd Phase Formatters | Draft |
-| 2169 | CHG | Deduplicate Plan Cmd Phase Formatters | Proposed |
-| 2170 | PRP | Evolve CLI Batch C3 C4 C5 | Draft |
-| 2171 | CHG | Evolve CLI Batch C3 C4 C5 | Proposed |
-| 2172 | REF | Evolve SOP Run 20260401 154338 | Active |
-| 2173 | PRP | Define Review Gate And Align Scoring | Draft |
-| 2174 | CHG | Define Review Gate And Align Scoring | Proposed |
-| 2175 | REF | Evolve Run 20260401 220000 | Active |
-| 2176 | PRP | Fix Corrupted FXA 2166 CHG Document | Approved |
-| 2177 | PRP | Standardize Role Naming In FXA 2100 | Approved |
-| 2178 | PRP | Add AF Tool Context To Review Dispatch Template | Approved |
-| 2179 | CHG | Fix Corrupted FXA 2166 CHG Document | Completed |
-| 2180 | CHG | Standardize Role Naming In FXA 2100 | Completed |
-| 2181 | CHG | Add AF Tool Context To Review Dispatch Template | Completed |
-| 2182 | PRP | Add AF Tool Context To COR Workflow Dispatch Steps | Approved |
-| 2183 | CHG | Add AF Tool Context To COR Workflow Dispatch Steps | Completed |
-| 2184 | REF | Discussion Tracker 2026 04 03 | Active |
-| 2185 | CHG | Add COR 1201 Discussion Tracker Step To AF Setup | Completed |
-| 2186 | CHG | Merge Alfred Ops Rules Into FX Alfred | Proposed |
-| 2187 | REF | Evolve Run 20260404 001357 | Active |
-| 2188 | PRP | Fix FXA 2125 Stale Alfred Ops Refs | Approved |
-| 2189 | PRP | Fix FXA 2185 Invalid CHG Status | Approved |
-| 2190 | CHG | Fix FXA 2125 Stale Alfred Ops Refs | Completed |
-| 2191 | CHG | Fix FXA 2185 Invalid CHG Status | Completed |
-| 2192 | REF | Evolve Run 20260404 082129 | Active |
-| 2193 | PRP | Simplify Fmt Metadata Order Comparison | Draft |
-| 2194 | CHG | Simplify Fmt Metadata Order Comparison | Proposed |
-| 2195 | REF | Session Retrospective 2026 04 04 D1 | Active |
-| 2196 | CHG | MkDocs Material PKG Documentation Site | Proposed |
-| 2197 | CHG | Auto Deploy Docs On Push | Proposed |
-| 2198 | PRP | COR Evolution Philosophy Reference | Approved |
-| 2199 | CHG | Implement COR 1800 REF Evolution Philosophy | Completed |
-| 2200 | PRP | Document Tags Metadata Field | Approved |
-| 2201 | CHG | Implement Document Tags Metadata Field | Completed |
-| 2202 | CHG | Add COR 1612 Respond To PR Review Comments SOP | Completed |
-| 2203 | REF | Discussion Tracker 2026 04 05 | Active |
-| 2204 | CHG | Typed SOP Composition For AF Plan | Proposed |
-| 2205 | PRP | AF Plan Auto Compose Todo And Graph | Implemented |
-| 2206 | CHG | FXA 2205 Follow Ups ASCII Graph And SOP Metadata Backfills | Completed |
-| 2207 | CHG | Add COR 1202 Compose Session Plan SOP | Completed |
-| 2208 | CHG | Add Pyright To FXA 2102 Release Prerequisites | Approved |
-| 2209 | REF | Evolve Run 20260419 063843 | Active |
-| 2210 | PRP | Close three edge arm coverage gaps with tests | Draft |
-| 2211 | CHG | Close three edge arm coverage gaps with tests | Completed |
-| 2212 | REF | Evolve Seed ASCII DAG Graph Layout | Active |
-| 2213 | REF | Evolve Run 20260419 094124 | Active |
-| 2214 | PRP | Bundle N2 N3 C4 plan cmd parser area int edges | Draft |
-| 2215 | CHG | Bundle N2 N3 plan cmd parser edge tests | Completed |
-| 2216 | REF | Discussion Tracker 2026 04 19 | Active |
-| 2217 | PRP | ASCII DAG nested graph layout for af plan graph | Draft |
-| 2218 | CHG | ASCII DAG nested graph layout implementation | Completed |
-| 2219 | CHG | Migrate ALF Prefix To FXA In PRJ Rules | Approved |
-| 2220 | PRP | Layered Workflow Routing USR And PRJ | Implemented |
-| 2221 | PRP | Standardized Review Scoring Framework | Implemented |
-| 2222 | PRP | Team Skill Session Resume | Rejected |
-| 2223 | PRP | Standardized SOP Section Structure | Implemented |
-| 2224 | PRP | Workflow Enforcement From Advisory To Mandatory | Approved |
-| 2225 | PRP | Branching ASCII In Plan Graph | Approved |
-| 2226 | CHG | Implement Branching ASCII Data Layer | Proposed |
-| 2227 | CHG | Implement Branching ASCII Presentation Layer | Proposed |
-| 2228 | SOP | CHG 2227 Remaining Work — Phases 8b, 9, 10 | Active |
-| 2229 | PRP | Layered SOP Memory Model | Draft |
-| 2230 | PRP | Agent Activity Log Protocol | Approved |
-| 2231 | CHG | Agent Activity Log Protocol v1 Implementation | Proposed |
-| 2232 | PRP | Quarkdown Documentation Rendering Layer | Draft |
-| 2233 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 | Proposed |
-| 2234 | CHG | Promote GitHub App PR Review Bot Loop SOP | Completed |
-| 2235 | PRP | Agent Editable Helpers And Skills | Approved |
-| 2236 | CHG | Implement Agent Editable Helpers And Skills | Completed |
-| 2237 | REF | Agent Helpers And Skills Usage | Active |
-| 2238 | CHG | Add COR 1615 Operator Checklist | Completed |
-| 2239 | CHG | Add COR 1801 Pattern Promotion SOP | Completed |
-| 2240 | PRP | Code Review Checklist v2.0 as Alfred SOP REF | Draft |
-| 2241 | CHG | Create Code Review Checklist COR 1705 1709 | Proposed |
-| 2242 | CHG | Promote Multi Phase Execution Contract SOP | Completed |
-| 2243 | CHG | Add COR 1615 Pre Trigger Finalization Gate | Completed |
-| 2244 | PRP | Add Custom Pytest Markers for Test Categorization | Draft |
-| 2245 | PRP | Add Parametrized Tests for Repeated Assertions | Draft |
-| 2246 | PRP | Enforce Pytest Coverage Thresholds | Draft |
-| 2247 | CHG | Implement Pytest Test Governance Improvements | Completed |
-| 2248 | REF | SOP Outcome Notebook | Draft |
-| 2249 | REF | Evolve CLI Run 20260405 210018 | Active |
-| 2250 | PRP | Extract H1 Extraction Regex To Parser | Draft |
-| 2251 | CHG | Consolidate H1 Regex Named Groups | Proposed |
-| 2252 | REF | Evolve Run 20260405 225815 | Active |
-| 2253 | PRP | Validate Status Flag In Update Cmd | Draft |
-| 2254 | CHG | Validate Status Flag In Update Cmd | Proposed |
-| 2255 | REF | Evolve Run 20260406 070318 | Active |
-| 2256 | CHG | Add Completion Checklist To Evolve CLI SOP | Completed |
-| 2257 | PRP | Deduplicate Total Issues In Validate Cmd | Draft |
-| 2258 | CHG | Deduplicate Total Issues In Validate Cmd | Completed |
-| 2259 | CHG | Add Completion Checklist To Evolve SOP | Completed |
-| 2260 | CHG | Add Post Push Review Loop To Evolve SOPs | Completed |
-| 2261 | CHG | Reorder Review Loop To Process Comments Before CI Gate | Proposed |
-| 2262 | PRP | COR 1613 Council Review Mechanism | Approved |
-| 2263 | CHG | COR 1103 Add Council Review Routing | Approved |
-| 2264 | CHG | COR 1602 Add Council Cross Reference | Approved |
-| 2265 | PRP | COR 1503 Diagnose Feedback Loop | Approved |
-| 2266 | CHG | COR 1103 Add Diagnose Routing | Approved |
-| 2267 | CHG | COR 1613 Add Half Diagnosed Fix Prohibition | Approved |
-| 2268 | CHG | COR 1504 REF Diagnose Phase Gates | Proposed |
-| 2269 | PRP | COR 1203 Pre Task Alignment | Approved |
-| 2270 | CHG | COR 1103 Add Pre Task Alignment Routing | Approved |
-| 2271 | CTX | Alfred Glossary | Active |
-| 2272 | CHG | Merge fx_alfredrules Into Top Level rules | Proposed |
-| 2273 | PRP | AF Tag Star Command And List Filter | Rejected |
-| 2274 | PRP | AF Star Command Bookmark Documents | Draft |
-| 2275 | CHG | FXA 2102 Promote README Check To Numbered Step | Proposed |
-| 2276 | REF | Multi Agent Loop Configuration | Active |
-| 2277 | CHG | COR 1622 Schema Refinements For Heterogeneous Adopters | Proposed |
-| 2278 | CHG | Add FXA 2276 Invocation Shorthand | Proposed |
-| 2279 | CHG | Codify GitHub App PR Review Bot Scope Hint Technique In COR 1612 + COR 1615 | Proposed |
-| 2280 | CHG | FXA 2276 Phase 10 Mergeable Trigger | Proposed |
-| 2281 | CHG | Add COR 1802 Build Weighted Decision Matrix SOP | Approved |
-| 2282 | CHG | Add Scoring to COR 1200 Session Retrospective | Proposed |
-| 2283 | CHG | Add Retrospective Phase to COR 1617 | Proposed |
-| 2284 | REF | Discussion Tracker 2026 05 15 | Active |
-| 2285 | CHG | Pre Merge GH Bot Review Sweep Gate | Completed |
-| 2286 | CHG | Explicit UTF 8 For Alfred Document IO | Approved |
-| 2287 | CHG | COR 1500 Phase 1 Worker Assignment Sub Section | Approved |
-| 2288 | CHG | COR 1500 Phase 2 Implementer Reading Constraint | Approved |
-| 2289 | CHG | COR 1619 Two Worker TDD Dispatch Sub Section | Approved |
-| 2290 | CHG | COR 1619 Decision Tree Two Worker Branch | Approved |
-| 2291 | CHG | COR 1622 Test Writer Worker Agent Schema Row | Approved |
-| 2292 | CHG | Alfred Opt In Two Worker TDD Split | Approved |
-| 2293 | PRP | 11 Star SOP Experience Review | Implemented |
-| 2294 | CHG | Fence Aware Extract Section | Completed |
-| 2295 | CHG | Compose Domain Exceptions | Completed |
-| 2296 | CHG | Validate Unknown Type Warning | Completed |
-| 2297 | CHG | CLAUDE Md Refresh And Drift Guard | Completed |
-| 2298 | CHG | CI Python Matrix And Pyright Gate | Completed |
-| 2299 | CHG | Workflow Fence Loop Dedup | Completed |
-| 2300 | CHG | Root Auto Discovery | Completed |
-| 2301 | CHG | JSON Output And Exit Code Unification | Completed |
-| 2302 | CHG | Plan Cmd Decomposition | Completed |
-| 2303 | PRP | AF Export Single File Runbook | Implemented |
-| 2304 | CHG | Export Repeatable Sources And File Includes | Completed |
-| 2305 | PRP | Cross Platform Agent Skill | Implemented |
-| 2306 | REF | Object To Transformation Design Lens | Active |
-| 2307 | PRP | Append Only Usage Ledger For Evolve Signals | Approved |
-| 2308 | PRP | Evolve Engine SOP Refactor | Draft |
-| 2309 | SOP | Evolve Engine | Active |
-| 2310 | CHG | Implement Evolve Engine SOP Refactor | Proposed |
-| 2311 | CHG | Strengthen L2 PR Readiness Loop Gates | Proposed |
-| 2312 | CHG | COR 1402 Active Process Output | Completed |
-| 2313 | REF | Case Study Loop Governance Of The PR Review Fix Loop | Active |
+| ACID | Type | Title |
+|------|------|-------|
+| 1623 | SOP | PR Review Thread Watchdog |
+| 2100 | SOP | Leader Mediated Development |
+| 2101 | CHG | Multi Layer Scan (Approved) |
+| 2102 | SOP | Release To PyPI |
+| 2103 | CHG | Root Option And Spacing (Approved) |
+| 2104 | PRP | AF Update Command (Implemented) |
+| 2105 | PRP | AF Rename Command (Rejected) |
+| 2106 | PRP | AF CLI Optimization v0.6 (Implemented) |
+| 2107 | CHG | Code Quality Refactoring (Completed) |
+| 2108 | REF | Session Retrospective 2026 03 19 D1 |
+| 2109 | CHG | DRY Scan Boilerplate (Proposed) |
+| 2110 | CHG | Lazy Command Loading (Proposed) |
+| 2111 | CHG | List Filtering (Proposed) |
+| 2112 | CHG | JSON Output (Proposed) |
+| 2113 | REF | Discussion Tracker 2026 03 19 D2 |
+| 2114 | CHG | AF Search Command (Proposed) |
+| 2115 | CHG | AF Validate Command (Proposed) |
+| 2116 | PRP | Document Format Contract (Implemented) |
+| 2117 | PRP | AF Filter And Section Update (Draft) |
+| 2118 | REF | Session Retrospective 2026 03 19 D2 |
+| 2119 | PLN | Document Format Contract Implementation (Completed) |
+| 2120 | CHG | Create Document Format Contract Reference (Completed) |
+| 2121 | CHG | Update Create Templates To Format Contract (Completed) |
+| 2122 | CHG | Enhance Validate Per Type Fields And Status (Completed) |
+| 2123 | CHG | Migrate Existing Documents To Format Contract (Completed) |
+| 2124 | CHG | Layered Workflow Routing AF Guide (Completed) |
+| 2125 | SOP | Workflow Routing PRJ |
+| 2126 | PRP | AF Create Routing Shortcut (Rejected) |
+| 2127 | SOP | Commit Alfred Ops (Deprecated) |
+| 2128 | REF | Discussion Tracker 2026 03 20 |
+| 2129 | CHG | Implement Review Scoring Framework (Completed) |
+| 2130 | CHG | Standardize SOP Section Structure (Rolled Back) |
+| 2131 | CHG | SOP Template And COR 1103 Reading Guide (Completed) |
+| 2132 | CHG | AF Validate SOP Section Checking (Completed) |
+| 2133 | CHG | Migrate All SOPs To Standard Structure (Completed) |
+| 2134 | PRP | AF Plan Command Workflow Checklist (Implemented) |
+| 2135 | CHG | Implement AF Plan Command (Completed) |
+| 2136 | SOP | Update README |
+| 2137 | CHG | AF Setup Guide Every Task Wording (Completed) |
+| 2138 | PRP | Create Routing Document SOP (Approved) |
+| 2139 | CHG | Implement COR 1004 Create Routing Document SOP (Completed) |
+| 2140 | PRP | Core Python Schema Architecture (Implemented) |
+| 2141 | PRP | AF Fmt Command (Implemented) |
+| 2142 | CHG | JSON Output For Guide Plan Search Validate (Completed) |
+| 2143 | CHG | Structured Spec Input For Create Update (Completed) |
+| 2144 | CHG | AF Where Command (Completed) |
+| 2145 | PRP | Auto Evolution SOP and CLI (Approved) |
+| 2146 | REF | Evolution Philosophy |
+| 2147 | CHG | Implement Auto Evolution SOPs REF Philosophy (Completed) |
+| 2148 | SOP | Evolve SOP |
+| 2149 | SOP | Evolve CLI |
+| 2150 | REF | Evolve Run 20260330 204515 |
+| 2151 | PRP | Translate FXA 2125 Decision Tree To English (Implemented) |
+| 2152 | PRP | Fix FXA 2100 Command Reference And Round Limit (Implemented) |
+| 2153 | CHG | Translate FXA 2125 Decision Tree To English (Completed) |
+| 2154 | CHG | Fix FXA 2100 Command Reference And Round Limit (Completed) |
+| 2155 | REF | Evolve Run 20260330 211109 |
+| 2156 | PRP | Extract Duplicated Helpers And Add Gate Detection Tests (Draft) |
+| 2157 | CHG | Extract Duplicated Helpers And Add Gate Detection Tests (Proposed) |
+| 2158 | REF | Evolve Run 20260330 221843 |
+| 2159 | PRP | Replace Assert With ClickException (Draft) |
+| 2160 | CHG | Replace Assert With ClickException (Proposed) |
+| 2161 | REF | Evolve Run 20260330 232601 |
+| 2162 | PRP | Extract Atomic Write Helper (Draft) |
+| 2163 | CHG | Extract Atomic Write Helper (Approved) |
+| 2164 | REF | Evolve Run 20260401 050827 |
+| 2165 | PRP | Extract Invoke Index Update Helper (Draft) |
+| 2166 | CHG | Extract Invoke Index Update Helper (Approved) |
+| 2167 | REF | Evolve Run 20260401 085641 |
+| 2168 | PRP | Deduplicate Plan Cmd Phase Formatters (Draft) |
+| 2169 | CHG | Deduplicate Plan Cmd Phase Formatters (Proposed) |
+| 2170 | PRP | Evolve CLI Batch C3 C4 C5 (Draft) |
+| 2171 | CHG | Evolve CLI Batch C3 C4 C5 (Proposed) |
+| 2172 | REF | Evolve SOP Run 20260401 154338 |
+| 2173 | PRP | Define Review Gate And Align Scoring (Draft) |
+| 2174 | CHG | Define Review Gate And Align Scoring (Proposed) |
+| 2175 | REF | Evolve Run 20260401 220000 |
+| 2176 | PRP | Fix Corrupted FXA 2166 CHG Document (Approved) |
+| 2177 | PRP | Standardize Role Naming In FXA 2100 (Approved) |
+| 2178 | PRP | Add AF Tool Context To Review Dispatch Template (Approved) |
+| 2179 | CHG | Fix Corrupted FXA 2166 CHG Document (Completed) |
+| 2180 | CHG | Standardize Role Naming In FXA 2100 (Completed) |
+| 2181 | CHG | Add AF Tool Context To Review Dispatch Template (Completed) |
+| 2182 | PRP | Add AF Tool Context To COR Workflow Dispatch Steps (Approved) |
+| 2183 | CHG | Add AF Tool Context To COR Workflow Dispatch Steps (Completed) |
+| 2184 | REF | Discussion Tracker 2026 04 03 |
+| 2185 | CHG | Add COR 1201 Discussion Tracker Step To AF Setup (Completed) |
+| 2186 | CHG | Merge Alfred Ops Rules Into FX Alfred (Proposed) |
+| 2187 | REF | Evolve Run 20260404 001357 |
+| 2188 | PRP | Fix FXA 2125 Stale Alfred Ops Refs (Approved) |
+| 2189 | PRP | Fix FXA 2185 Invalid CHG Status (Approved) |
+| 2190 | CHG | Fix FXA 2125 Stale Alfred Ops Refs (Completed) |
+| 2191 | CHG | Fix FXA 2185 Invalid CHG Status (Completed) |
+| 2192 | REF | Evolve Run 20260404 082129 |
+| 2193 | PRP | Simplify Fmt Metadata Order Comparison (Draft) |
+| 2194 | CHG | Simplify Fmt Metadata Order Comparison (Proposed) |
+| 2195 | REF | Session Retrospective 2026 04 04 D1 |
+| 2196 | CHG | MkDocs Material PKG Documentation Site (Proposed) |
+| 2197 | CHG | Auto Deploy Docs On Push (Proposed) |
+| 2198 | PRP | COR Evolution Philosophy Reference (Approved) |
+| 2199 | CHG | Implement COR 1800 REF Evolution Philosophy (Completed) |
+| 2200 | PRP | Document Tags Metadata Field (Approved) |
+| 2201 | CHG | Implement Document Tags Metadata Field (Completed) |
+| 2202 | CHG | Add COR 1612 Respond To PR Review Comments SOP (Completed) |
+| 2203 | REF | Discussion Tracker 2026 04 05 |
+| 2204 | CHG | Typed SOP Composition For AF Plan (Proposed) |
+| 2205 | PRP | AF Plan Auto Compose Todo And Graph (Implemented) |
+| 2206 | CHG | FXA 2205 Follow Ups ASCII Graph And SOP Metadata Backfills (Completed) |
+| 2207 | CHG | Add COR 1202 Compose Session Plan SOP (Completed) |
+| 2208 | CHG | Add Pyright To FXA 2102 Release Prerequisites (Approved) |
+| 2209 | REF | Evolve Run 20260419 063843 |
+| 2210 | PRP | Close three edge arm coverage gaps with tests (Draft) |
+| 2211 | CHG | Close three edge arm coverage gaps with tests (Completed) |
+| 2212 | REF | Evolve Seed ASCII DAG Graph Layout |
+| 2213 | REF | Evolve Run 20260419 094124 |
+| 2214 | PRP | Bundle N2 N3 C4 plan cmd parser area int edges (Draft) |
+| 2215 | CHG | Bundle N2 N3 plan cmd parser edge tests (Completed) |
+| 2216 | REF | Discussion Tracker 2026 04 19 |
+| 2217 | PRP | ASCII DAG nested graph layout for af plan graph (Draft) |
+| 2218 | CHG | ASCII DAG nested graph layout implementation (Completed) |
+| 2219 | CHG | Migrate ALF Prefix To FXA In PRJ Rules (Approved) |
+| 2220 | PRP | Layered Workflow Routing USR And PRJ (Implemented) |
+| 2221 | PRP | Standardized Review Scoring Framework (Implemented) |
+| 2222 | PRP | Team Skill Session Resume (Rejected) |
+| 2223 | PRP | Standardized SOP Section Structure (Implemented) |
+| 2224 | PRP | Workflow Enforcement From Advisory To Mandatory (Approved) |
+| 2225 | PRP | Branching ASCII In Plan Graph (Approved) |
+| 2226 | CHG | Implement Branching ASCII Data Layer (Proposed) |
+| 2227 | CHG | Implement Branching ASCII Presentation Layer (Proposed) |
+| 2228 | SOP | CHG 2227 Remaining Work — Phases 8b, 9, 10 |
+| 2229 | PRP | Layered SOP Memory Model (Draft) |
+| 2230 | PRP | Agent Activity Log Protocol (Approved) |
+| 2231 | CHG | Agent Activity Log Protocol v1 Implementation (Proposed) |
+| 2232 | PRP | Quarkdown Documentation Rendering Layer (Draft) |
+| 2233 | CHG | Subsection Guard Symmetry in COR 1612 Step 6 (Proposed) |
+| 2234 | CHG | Promote GitHub App PR Review Bot Loop SOP (Completed) |
+| 2235 | PRP | Agent Editable Helpers And Skills (Approved) |
+| 2236 | CHG | Implement Agent Editable Helpers And Skills (Completed) |
+| 2237 | REF | Agent Helpers And Skills Usage |
+| 2238 | CHG | Add COR 1615 Operator Checklist (Completed) |
+| 2239 | CHG | Add COR 1801 Pattern Promotion SOP (Completed) |
+| 2240 | PRP | Code Review Checklist v2.0 as Alfred SOP REF (Draft) |
+| 2241 | CHG | Create Code Review Checklist COR 1705 1709 (Proposed) |
+| 2242 | CHG | Promote Multi Phase Execution Contract SOP (Completed) |
+| 2243 | CHG | Add COR 1615 Pre Trigger Finalization Gate (Completed) |
+| 2244 | PRP | Add Custom Pytest Markers for Test Categorization (Draft) |
+| 2245 | PRP | Add Parametrized Tests for Repeated Assertions (Draft) |
+| 2246 | PRP | Enforce Pytest Coverage Thresholds (Draft) |
+| 2247 | CHG | Implement Pytest Test Governance Improvements (Completed) |
+| 2248 | REF | SOP Outcome Notebook (Draft) |
+| 2249 | REF | Evolve CLI Run 20260405 210018 |
+| 2250 | PRP | Extract H1 Extraction Regex To Parser (Draft) |
+| 2251 | CHG | Consolidate H1 Regex Named Groups (Proposed) |
+| 2252 | REF | Evolve Run 20260405 225815 |
+| 2253 | PRP | Validate Status Flag In Update Cmd (Draft) |
+| 2254 | CHG | Validate Status Flag In Update Cmd (Proposed) |
+| 2255 | REF | Evolve Run 20260406 070318 |
+| 2256 | CHG | Add Completion Checklist To Evolve CLI SOP (Completed) |
+| 2257 | PRP | Deduplicate Total Issues In Validate Cmd (Draft) |
+| 2258 | CHG | Deduplicate Total Issues In Validate Cmd (Completed) |
+| 2259 | CHG | Add Completion Checklist To Evolve SOP (Completed) |
+| 2260 | CHG | Add Post Push Review Loop To Evolve SOPs (Completed) |
+| 2261 | CHG | Reorder Review Loop To Process Comments Before CI Gate (Proposed) |
+| 2262 | PRP | COR 1613 Council Review Mechanism (Approved) |
+| 2263 | CHG | COR 1103 Add Council Review Routing (Approved) |
+| 2264 | CHG | COR 1602 Add Council Cross Reference (Approved) |
+| 2265 | PRP | COR 1503 Diagnose Feedback Loop (Approved) |
+| 2266 | CHG | COR 1103 Add Diagnose Routing (Approved) |
+| 2267 | CHG | COR 1613 Add Half Diagnosed Fix Prohibition (Approved) |
+| 2268 | CHG | COR 1504 REF Diagnose Phase Gates (Proposed) |
+| 2269 | PRP | COR 1203 Pre Task Alignment (Approved) |
+| 2270 | CHG | COR 1103 Add Pre Task Alignment Routing (Approved) |
+| 2271 | CTX | Alfred Glossary |
+| 2272 | CHG | Merge fx_alfredrules Into Top Level rules (Proposed) |
+| 2273 | PRP | AF Tag Star Command And List Filter (Rejected) |
+| 2274 | PRP | AF Star Command Bookmark Documents (Draft) |
+| 2275 | CHG | FXA 2102 Promote README Check To Numbered Step (Proposed) |
+| 2276 | REF | Multi Agent Loop Configuration |
+| 2277 | CHG | COR 1622 Schema Refinements For Heterogeneous Adopters (Proposed) |
+| 2278 | CHG | Add FXA 2276 Invocation Shorthand (Proposed) |
+| 2279 | CHG | Codify GitHub App PR Review Bot Scope Hint Technique In COR 1612 + COR 1615 (Proposed) |
+| 2280 | CHG | FXA 2276 Phase 10 Mergeable Trigger (Proposed) |
+| 2281 | CHG | Add COR 1802 Build Weighted Decision Matrix SOP (Approved) |
+| 2282 | CHG | Add Scoring to COR 1200 Session Retrospective (Proposed) |
+| 2283 | CHG | Add Retrospective Phase to COR 1617 (Proposed) |
+| 2284 | REF | Discussion Tracker 2026 05 15 |
+| 2285 | CHG | Pre Merge GH Bot Review Sweep Gate (Completed) |
+| 2286 | CHG | Explicit UTF 8 For Alfred Document IO (Approved) |
+| 2287 | CHG | COR 1500 Phase 1 Worker Assignment Sub Section (Approved) |
+| 2288 | CHG | COR 1500 Phase 2 Implementer Reading Constraint (Approved) |
+| 2289 | CHG | COR 1619 Two Worker TDD Dispatch Sub Section (Approved) |
+| 2290 | CHG | COR 1619 Decision Tree Two Worker Branch (Approved) |
+| 2291 | CHG | COR 1622 Test Writer Worker Agent Schema Row (Approved) |
+| 2292 | CHG | Alfred Opt In Two Worker TDD Split (Approved) |
+| 2293 | PRP | 11 Star SOP Experience Review (Implemented) |
+| 2294 | CHG | Fence Aware Extract Section (Completed) |
+| 2295 | CHG | Compose Domain Exceptions (Completed) |
+| 2296 | CHG | Validate Unknown Type Warning (Completed) |
+| 2297 | CHG | CLAUDE Md Refresh And Drift Guard (Completed) |
+| 2298 | CHG | CI Python Matrix And Pyright Gate (Completed) |
+| 2299 | CHG | Workflow Fence Loop Dedup (Completed) |
+| 2300 | CHG | Root Auto Discovery (Completed) |
+| 2301 | CHG | JSON Output And Exit Code Unification (Completed) |
+| 2302 | CHG | Plan Cmd Decomposition (Completed) |
+| 2303 | PRP | AF Export Single File Runbook (Implemented) |
+| 2304 | CHG | Export Repeatable Sources And File Includes (Completed) |
+| 2305 | PRP | Cross Platform Agent Skill (Implemented) |
+| 2306 | REF | Object To Transformation Design Lens |
+| 2307 | PRP | Append Only Usage Ledger For Evolve Signals (Approved) |
+| 2308 | PRP | Evolve Engine SOP Refactor (Draft) |
+| 2309 | SOP | Evolve Engine |
+| 2310 | CHG | Implement Evolve Engine SOP Refactor (Proposed) |
+| 2311 | CHG | Strengthen L2 PR Readiness Loop Gates (Proposed) |
+| 2312 | CHG | COR 1402 Active Process Output (Completed) |
+| 2313 | REF | Case Study Loop Governance Of The PR Review Fix Loop |
+| 2314 | CHG | USR Sub Project Layer Via Projects JSON Mapping (Proposed) |
 
 ---
 
 ## Change History
 
-| Date       | Change                     | By     |
-|------------|----------------------------|--------|
-| 2026-06-21 | Auto-generated by af index | af CLI |
+| Date | Change | By |
+|------|--------|----|
+| 2026-06-27 | Auto-generated by af index | af CLI |

--- a/rules/FXA-2314-CHG-USR-Sub-Project-Layer-Via-Projects-JSON-Mapping.md
+++ b/rules/FXA-2314-CHG-USR-Sub-Project-Layer-Via-Projects-JSON-Mapping.md
@@ -1,0 +1,138 @@
+# CHG-2314: USR Sub-Project Layer Via Projects-JSON Mapping
+
+**Applies to:** FXA project
+**Last updated:** 2026-06-28
+**Last reviewed:** 2026-06-28
+**Status:** Approved
+**Date:** 2026-06-27
+**Requested by:** Frank Xu
+**Priority:** Medium (risk: High — touches the shared scan core)
+**Change Type:** Normal
+**Issue:** frankyxhl/alfred#243
+
+---
+
+## What
+
+Teach the scan core to treat a subdirectory of the USR home (`~/.alfred/<NAME>/`) as a per-project PRJ-equivalent layer, selected by a new `~/.alfred/projects.json` mapping that points an external project root path at that subdirectory.
+
+Concretely:
+
+1. **New config** `~/.alfred/projects.json` — maps an absolute external project root to a USR subdirectory name:
+   ```json
+   { "projects": { "/Users/frank/Projects/marvin/prefrontal-cortex": "NRV" } }
+   ```
+   Loader contract: no module-level cache (re-read each call, so tests/long-lived processes never see stale data). The two entry points (`context.discover_root` and `scanner.scan_documents`) each load it once per CLI invocation; collapsing the two small reads into one invocation-scoped read was judged unnecessary at code review (harmless; not worth threading the mapping through the `ctx` call-chain). Missing file, malformed JSON, wrong shape, or unknown top-level keys ⇒ empty mapping (graceful, **and a one-line warning to stderr on a present-but-unparseable file** — not silent). Keys MUST be absolute paths; relative keys are ignored with a warning. Values MUST be a single subdirectory leaf name under `~/.alfred/` — a value containing a path separator, or equal to `.`, `..`, or empty, is rejected and ignored with a warning (guards against `~/.alfred/.` resolving to the USR home itself). Many-to-one is allowed (several roots may map to the same `<NAME>`).
+
+2. **PRJ-layer redirect (mapping wins)** — when the active root matches a mapping key, `scan_documents` loads `~/.alfred/<NAME>/` as the PRJ layer (`source="prj"`). The mapping **always** fires for a registered root. If that root *also* has its own populated `<root>/rules/`, the local `rules/` is **shadowed with a warning** — the explicit `projects.json` opt-in wins. **Why mapping-wins (not real-`rules/`-wins):** §What-4's USR exclusion is necessarily *global* (a registered subproject must be hidden from the flat USR layer in **every** context, or the original "2 active routing docs in USR" warning re-fires from any unmapped directory and the isolation property breaks). If the redirect were instead gated on the absence of a local `rules/` (the R2 design), a mapped root that also had `rules/` would have its subproject docs excluded from USR **and** not loaded as PRJ → they vanish from every scan (the "orphan-docs" interaction MiniMax flagged in R2). Making the redirect unconditional for registered roots keeps it consistent with the global exclusion and makes the orphan state unreachable. The hybrid config (a mapped repo that also hosts `rules/`) is near-pathological — you register a repo in `projects.json` precisely *because* it cannot host `rules/` — so shadow-with-warning is the right contract, not a silent drop.
+
+3. **Redirected PRJ scan is recursive** — the redirected `~/.alfred/<NAME>/` is scanned **recursively** (same depth semantics the USR scan gave these docs before this change), with the same `logs/` skip. This prevents the silent loss of docs nested under `~/.alfred/<NAME>/<subdir>/` that a non-recursive PRJ scan would cause (resolves R1 blocking #1). The ordinary `<root>/rules/` PRJ scan stays non-recursive (unchanged).
+
+4. **USR-scan exclusion** — the recursive USR scan excludes **every** registered subproject directory (top-level leaf names from the mapping), so those docs never appear in the flat USR layer. This is what prevents the duplicate `prefix+ACID` `LayerValidationError` (the same file would otherwise be scanned as both `usr` and `prj`).
+
+5. **Path normalization** — both `projects.json` keys and the candidate path (cwd, its ancestors, or explicit `--root`) are compared **after `Path(...).resolve()` on both sides**, so symlinks (e.g. macOS `/var`→`/private/var`), trailing slashes, and `..` segments match correctly. `get_root`/`discover_root` currently compare an unresolved `Path.cwd()`; this change resolves it before matching. Matching is exact-resolved-path equality (the operator authors absolute paths).
+
+6. **cwd auto-resolution (new code path)** — today a third-party repo with no `rules/` is NOT recognized as an Alfred root (`discover_root` only accepts dirs whose `rules/` holds non-COR docs). This change adds mapping-aware recognition: if the resolved cwd or an ancestor is a `projects.json` key, that directory becomes the active root and its subproject PRJ layer loads — no `--root` needed. When several ancestors are mapping keys, the **nearest mapped ancestor wins** (the deepest matching directory, consistent with how `discover_root` already prefers the nearest `rules/`). If both a `rules/`-bearing ancestor and a mapped ancestor match at different depths, the **deepest match wins** (one uniform nearest-wins rule across both root kinds). Explicit `--root` still wins over cwd. This is a genuinely new branch in `context.py`, called out here so reviewers can target it.
+
+7. **Missing target dir** — if a mapping value points to a `~/.alfred/<NAME>/` that does not exist, the PRJ layer is empty and a warning is emitted; no crash, no fallback to `<root>/rules/` resurrection.
+
+8. **`Document.directory` field** — for redirected PRJ docs this leaf label becomes `<NAME>` (e.g. `"NRV"`) instead of the USR scan's `"alfred"`. This field is an **opaque display/label value**; file resolution uses `base_path` (`Document.resolve_resource`), not `directory`, so no behavior depends on the change. A test pins the field value so the shift is intentional and visible, not silent.
+
+9. **Backward compatible** — absent/malformed `projects.json`, or an unregistered subdir, ⇒ behavior is exactly as today (recursive USR, PRJ = `<root>/rules/`).
+
+
+## Why
+
+`af guide` currently emits `Warning: 2 active routing docs in USR layer, using lowest ACID`, and the PRJ section shows `(no active routing document found)`.
+
+Root cause: docs under `~/.alfred/NRV/` are flattened into USR by the recursive USR scan (`scanner._scan_path_dir(..., recursive=True)`). The `prefrontal-cortex` repo is **third-party** — we cannot add a `rules/` directory to someone else's repo — so the only place for its PRJ-layer docs is a USR subdir, which then collides with the genuine USR routing doc (ALF-2207).
+
+After this change: ALF-2207 stays the sole USR routing doc, NRV-2500 becomes the PRJ routing doc → warning gone, PRJ no longer empty. Because the fix lives in the shared `scan_documents`, every command that routes through it (`list`, `read`, `validate`, `status`, `search`, `where`, `export`, `plan`, `guide`, …) inherits the corrected classification automatically.
+
+
+## Design / Rejected Alternatives
+
+**Chosen:** projects.json path→subdir mapping + unconditional (mapping-wins) recursive PRJ redirect for registered roots + global USR exclusion of registered subdirs + resolve-both-sides path matching.
+
+| # | Alternative | Why rejected |
+|---|-------------|--------------|
+| A | `--project NRV` flag or `ALFRED_PROJECT` env var to select the subproject | Requires the operator to remember and pass it on every call. cwd auto-match against `projects.json` is zero-friction. A flag/env can be layered on later without breaking the mapping (kept Out of Scope). |
+| B | Add a new `Source` label (e.g. `"sub"`) + extend `SOURCE_ORDER` to a 4-layer model | Invasive: every consumer (`guide`, `list`, `status`, sort keys, `SOURCE_LABELS`) would need a 4th layer. Redirecting the existing PRJ layer reuses the proven 3-layer model and keeps the diff small. |
+| C | Make the USR scan non-recursive globally | Breaks backward compatibility for any USR layout that relies on recursive discovery. We only exclude **registered** subprojects; unregistered subdirs keep recursing. |
+| D | Move NRV docs into a real `rules/` inside the `prefrontal-cortex` repo | The repo is third-party — polluting it with a `rules/` dir is the exact constraint that created this problem. |
+| E | Real `<root>/rules/` wins over the mapping (precedence-gated redirect — the R2 design) | Combined with the necessarily-global USR exclusion (§What-4), a mapped root that also has `rules/` would have its subproject docs excluded from USR *and* not loaded as PRJ → silent vanish (the "orphan-docs" interaction, MiniMax R2). Also needs a fuzzy "populated `rules/`" threshold. Chose mapping-wins + shadow-warning instead (§What-2) — orphan state unreachable, no threshold needed. AC reworded to scope "no behavior change" to **unregistered** repos. |
+| F | Make USR exclusion conditional (exclude only when the redirect actually fires for the active root) | Fails the core fix: from an unmapped context the redirect never fires, so the subproject would reappear in USR and the "2 active routing docs" warning returns globally + isolation breaks. Global exclusion is required, which forces mapping-wins (Alt E). |
+
+**Isolation semantics (accepted trade-off):** once `NRV` is registered, its docs are visible (as PRJ) **only** in the mapped repo context; from an unmapped directory `af list`/`af read` will not surface them. This mirrors how genuine `<root>/rules/` PRJ docs are already scoped to their own repo, and is what prevents the duplicate-ID collision. A future cross-subproject view (`af list --all-subprojects`) is Out of Scope.
+
+
+## Impact Analysis
+
+- **Systems affected:**
+  - `src/fx_alfred/core/scanner.py` — `scan_documents` (unconditional mapping-wins recursive PRJ redirect + global USR exclusion). Reuses existing `_scan_path_dir(..., recursive=True)` and its `logs/` skip for the redirected layer.
+  - `src/fx_alfred/context.py` — `discover_root`/`get_root` gain resolve-both-sides matching + mapping-aware root recognition (new branch, §What-6).
+  - **New** `src/fx_alfred/core/projects.py` — load/parse `~/.alfred/projects.json` once with graceful fallback; expose a shared `resolve_subproject(root: Path) -> str | None` consumed by both the scanner exclusion and `context` root discovery (single source of truth, the concrete REFACTOR target).
+  - `tests/` — new coverage in `test_scanner.py`, `test_guide_cmd.py`, `test_list_cmd.py`, and a new `test_projects.py` for the loader.
+  - Docs — `README.md` / `CLAUDE.md` three-layer-model section gains a `projects.json` note (pairs with the existing `af create --subdir`).
+  - **No change** to command logic — every scan-routing command (`guide`, `list`, `read`, `validate`, `status`, `search`, `where`, `export`, `plan`, **`index`**) inherits via `scan_documents`/`scan_or_fail`; confirmed `index_cmd.py` and `validate_cmd.py` route through it (no private scan path).
+- **`af create --subdir` interaction:** `af create --subdir <NAME>` always **writes** to `~/.alfred/<NAME>/` (unchanged — create targets the USR subdir, never a shadowed local `rules/`). Only the *scan-time* classification differs afterwards: an UNREGISTERED subdir's docs stay USR-visible (recursive USR), exactly as today; a REGISTERED subdir's docs become PRJ-in-context and USR-hidden. Documented so the write-target vs scan-classification asymmetry is intentional.
+- **`Document.directory` consumers:** audited — `resolve_resource` uses `base_path`; `directory` is informational. No behavioral consumer; pinned by a test on both the dataclass attr and `list --json` output (§What-8).
+- **Observability:** each of these cases emits a `click.echo`-to-stderr warning where user-facing (guide), consistent with the existing "2 active routing docs" warning style: ignored mapping, **shadowed local `rules/`** (registered root that also hosts `rules/`), missing target dir, relative key, and rejected value (`.`/`..`/separator/empty). Warnings are de-duplicated per `(root, NAME)` per invocation to avoid noise on high-frequency commands. A verbose per-scan debug log is **deferred** (advisory) to avoid introducing a logging dependency this CHG doesn't otherwise need.
+- **Data / config migration:** after release + reinstall, add `prefrontal-cortex → NRV` to `~/.alfred/projects.json` (user-layer config, not in this repo).
+- **Risk:** High — `scan_documents` is shared by all scan-routing commands. Mitigated by: additive config (absent file ⇒ old behavior), mapping-wins redirect (orphan-docs state unreachable) + global USR exclusion + shadow-warning for a registered root's own `rules/`, explicit duplicate-prevention + nested-doc + normalization tests, and COR-1602 parallel review (GLM + DeepSeek + MiniMax).
+- **Rollback plan:** revert the implementation commit; `~/.alfred/projects.json` is additive and inert without the code, so no data migration to undo. Removing/renaming the file also restores prior behavior. Downgrade safety: an older `af` simply ignores `projects.json` (it never reads it), and the loader ignores unknown keys so a newer config never breaks an older reader of the same file. Post-rollback symptom (documented for ops): registered subproject docs reappear in USR and the original "2 active routing docs" warning returns — that is the expected signal the rollback took effect, not a new fault.
+
+
+## Implementation Plan
+
+TDD per COR-1500; implementation dispatched via `/trinity glm`, reviewed via GLM + DeepSeek + MiniMax (FXA-2100). Test fixtures: `monkeypatch` `Path.home` to a `tmp_path` sandbox; build `~/.alfred/`, subproject dirs, and an external repo root under it; `CliRunner` for `guide`/`list` assertions.
+
+1. **RED** — add failing tests:
+   - **loader** (`test_projects.py`): valid map parses; missing file ⇒ `{}`; malformed JSON ⇒ `{}` **+ warning**; wrong shape / unknown keys ⇒ `{}`; relative key ignored + warned; value with path separator / `.` / `..` / empty ignored + warned; parsed once per invocation.
+   - **scanner — happy path:** mapped root loads `~/.alfred/<NAME>/` as `source=prj`; registered subdir excluded from USR; no `LayerValidationError`.
+   - **scanner — recursion:** doc at `~/.alfred/<NAME>/<subdir>/X.md` IS found under PRJ (nested-doc regression guard, R1 #1).
+   - **scanner — mapping-wins / orphan-unreachable:** mapped root that ALSO has populated `<root>/rules/` ⇒ subproject docs load with `source=prj` (assert specific doc IDs), `_validate_layers` passes (no `LayerValidationError`), the shadow warning is emitted, and **no local `rules/` doc appears in PRJ** (`assert not any(d.base_path == local_rules_dir for d in prj_docs)`) — shadow enforced independently of any coincidental collision (MiniMax R2/R3 orphan guard).
+   - **scanner — normalization:** key vs candidate that differ only by a symlink (built with a `tmp_path` symlink fixture, not the real `/var`→`/private/var`) / trailing slash / `..` still match after resolve (R1 #3).
+   - **scanner — missing dir:** mapping value with no such `~/.alfred/<NAME>/` ⇒ empty PRJ + warning, no crash.
+   - **scanner — backward compat:** absent/malformed json ⇒ current behavior; UNREGISTERED subdir still recurses into USR (locks `test_scan_usr_recursive`).
+   - **scanner — directory field:** redirected PRJ doc has `directory == "<NAME>"` on the dataclass AND in `af list --json` output (pins §What-8).
+   - **context:** resolved cwd under a mapped root resolves without `--root`; explicit `--root` overrides; nested mapped ancestors ⇒ nearest (deepest) wins; many-to-one mapping resolves each key.
+   - **guide:** mapped root ⇒ no "2 active routing docs" warning, PRJ shows the subproject routing doc.
+   - **list (`--json`):** subproject docs labelled PRJ in mapped context (assert via `CliRunner` `--json`); `--source usr` excludes them; unmapped context hides them.
+   - **index / validate:** run in mapped context ⇒ they see the subproject docs as PRJ (locks the "inherits via shared `scan_documents`" claim in CI).
+2. **GREEN** — implement `core/projects.py` (loader + `resolve_subproject`); wire the unconditional mapping-wins recursive PRJ redirect + global USR exclusion into `scan_documents`; wire resolve-both-sides + mapping-aware recognition into `context`.
+3. **REFACTOR** — route both the scanner USR-exclusion and `context` root discovery through the single `resolve_subproject(root)` / registered-subdir-set helper in `core/projects.py`; confirm `projects.json` is read once per invocation. **Implementation note:** the shadow-warning dedup state MUST be per-call (e.g. a set threaded through the scan), NOT a module-level global — a module-level set leaks across invocations and would silently suppress warnings on later calls in long-lived processes/tests.
+4. **Verify** — full `pytest` + `ruff` clean; manual `af guide --root <prefrontal-cortex>` against a temp `projects.json` shows the fixed output.
+5. **Release** — FXA-2102 (PyPI) → `pipx` reinstall → register NRV in `~/.alfred/projects.json` → confirm warning gone in the user's live `af`.
+
+
+## Acceptance Criteria
+
+- [ ] `~/.alfred/projects.json` parsed once in core; missing/malformed/wrong-shape/unknown-keys ⇒ empty mapping (no crash; malformed-but-present ⇒ warning); relative keys and values containing a separator / `.` / `..` / empty ignored + warned
+- [ ] Mapped active root ⇒ `~/.alfred/<NAME>/` docs load with `source=prj` (mapping always fires for a registered root)
+- [ ] Redirected PRJ layer is scanned recursively — docs nested under `~/.alfred/<NAME>/<subdir>/` are found (no silent loss)
+- [ ] Mapped root that ALSO has populated `<root>/rules/` ⇒ mapping wins (subproject loads as PRJ), local `rules/` shadowed + warned, subproject docs do NOT vanish (orphan-unreachable)
+- [ ] Path matching resolves both sides — symlinked / trailing-slash / `..` candidates match their `projects.json` key
+- [ ] Mapping value pointing to a non-existent `~/.alfred/<NAME>/` ⇒ empty PRJ + warning, no crash
+- [ ] Recursive USR scan excludes every registered subproject dir (no duplicate `prefix+ACID` error)
+- [ ] Redirected PRJ doc exposes `Document.directory == "<NAME>"` (pinned, intentional)
+- [ ] `af guide --root <mapped repo>` emits no USR-layer warning and shows the subproject routing doc under PRJ
+- [ ] `af list` labels subproject docs PRJ in mapped context; `--source usr` excludes them; unmapped context hides them
+- [ ] cwd/ancestor under a mapped root resolves without `--root`; explicit `--root` overrides; nearest (deepest) mapped/`rules/` ancestor wins
+- [ ] `af index` / `af validate` run in a mapped context see the subproject docs as PRJ (shared-scan inheritance locked in CI)
+- [ ] Unregistered `~/.alfred/` subdirs retain recursive-USR behavior
+- [ ] No behavior change for **unregistered** repos using a real `<root>/rules/` PRJ layer
+- [ ] `pytest` + `ruff` clean; new tests cover all of the above
+
+---
+
+## Change History
+
+| Date       | Change                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | By          |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| 2026-06-27 | Initial version (issue #243; CHG over PRP — design pre-settled, carried in Design/Rejected Alternatives)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Claude Code |
+| 2026-06-27 | R1 fixes (GLM 7.6 / DeepSeek 7.7 / MiniMax 7.05, all FIX): recursive redirected-PRJ scan (nested-doc loss); real-`rules/`-wins precedence (AC contradiction); resolve-both-sides path normalization; missing-dir + relative-key + unknown-key handling; `Document.directory` field pinned; new-context-path called out; concrete REFACTOR target (`resolve_subproject`); fixture mechanism + expanded RED list; reviewer roster corrected to GLM/DeepSeek/MiniMax                                                                                                                                           | Claude Code |
+| 2026-06-28 | R2 fixes (GLM 9.5 PASS / DeepSeek 9.0 PASS / MiniMax 8.5 FIX): flipped redirect to **mapping-wins** to make the orphan-docs interaction (MiniMax — precedence-gate vs global USR exclusion) unreachable; dropped the "populated `rules/`" threshold; added Alt E/F design record; value validation rejects `.`/`..`/separator/empty; malformed-JSON warns; `af index`/`validate` confirmed on shared scan; `af create --subdir` interaction + rollback post-mortem hint documented; `list --json` directory pin; symlink test uses `tmp_path` fixture; AC "no behavior change" scoped to unregistered repos | Claude Code |
+| 2026-06-28 | R3 doc-consistency fixes (GLM 9.5 PASS / DeepSeek 8.8 FIX / MiniMax 8.75 FIX — all confirmed the mapping-wins flip sound; sole deduction was stale text): corrected the two stale "precedence gate (real `rules/` wins)" lines in §Impact (Systems-affected + Risk) and the GREEN step to mapping-wins; added "nearest mapped ancestor wins" (§What-6); added shadowed-`rules/` to the Observability warning enumeration + per-`(root,NAME)` dedup; clarified `af create --subdir` write target; strengthened orphan-unreachable RED assertions; added `index`/`validate` inheritance RED test              | Claude Code |
+| 2026-06-28 | APPROVED via COR-1602 — R4 unanimous PASS (GLM 9.5 / DeepSeek 9.85 / MiniMax 9.5, all >=9.0). Absorbed final non-blocking advisories: deepest-ancestor tiebreaker, per-call shadow-warning dedup, AC bullets for nearest-ancestor + index/validate inheritance. Status -> Approved; proceed to implementation per FXA-2100.                                                                                                                                                                                                                                                                                 | Claude Code |
+| 2026-06-28 | Code review COR-1610 — all PASS (GLM 9.6 / DeepSeek 9.55 / MiniMax 9.4, zero blocking). Folded convergent advisories: COR- filter parity in shadow-warning check (scanner.py), dedicated index/validate mapped-context tests, USR directory-field assertion. Double-read of projects.json accepted as harmless (no cache added). Tests 1256 passed, ruff clean.                                                                                                                                                                                                                                             | Claude Code |

--- a/src/fx_alfred/context.py
+++ b/src/fx_alfred/context.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import click
 
 from fx_alfred.core.document import FILENAME_PATTERN
+from fx_alfred.core.projects import load_projects
 
 
 def discover_root(start: Path) -> Path:
@@ -17,8 +18,23 @@ def discover_root(start: Path) -> Path:
     e.g. when running from inside ``src/fx_alfred/``). The fallback
     preserves the pre-CHG-2300 behavior (cwd) for invocations outside any
     Alfred project.
+
+    FXA-2314: if a candidate (or one of its ancestors) is a key in
+    ``~/.alfred/projects.json``, it also qualifies as a root.  Both the
+    candidate and every mapping key are compared after ``Path.resolve()``
+    so that symlinked paths match correctly.  When both a ``rules/``-bearing
+    ancestor and a mapped ancestor qualify at different depths, the deepest
+    (nearest) match wins — the same rule that already governs ``rules/``
+    ancestors applies uniformly.
     """
     usr_alfred = Path.home() / ".alfred"
+
+    # Load the projects mapping once; pre-compute resolved keys for O(1) lookup.
+    mapping = load_projects()
+    resolved_keys: dict[str, str] = {
+        str(Path(k).resolve()): v for k, v in mapping.items()
+    }
+
     for candidate in (start, *start.parents):
         if candidate == usr_alfred:
             # The USR layer home can never be a PRJ root: discovering it
@@ -26,6 +42,12 @@ def discover_root(start: Path) -> Path:
             # and PRJ (rules/) scans → duplicate-ID LayerValidationError
             # (FXA-2300 R1 glm finding).
             continue
+
+        # FXA-2314: mapping-aware recognition — deepest registered ancestor wins.
+        if str(candidate.resolve()) in resolved_keys:
+            return candidate
+
+        # Existing logic: qualify on a rules/ dir with non-COR Alfred docs.
         rules_dir = candidate / "rules"
         if not rules_dir.is_dir():
             continue

--- a/src/fx_alfred/core/projects.py
+++ b/src/fx_alfred/core/projects.py
@@ -1,0 +1,106 @@
+"""FXA-2314: projects.json loader and subproject resolver.
+
+Provides two public functions:
+
+- ``load_projects()`` — reads ``~/.alfred/projects.json`` once (no module-level
+  cache) and returns a validated ``{absolute-path-string: leaf-name}`` dict.
+- ``resolve_subproject(root, mapping)`` — resolves symlinks on both sides and
+  returns the NAME for the given root, or None if not registered.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def load_projects(projects_json_path: Path | None = None) -> dict[str, str]:
+    """Load and validate ``~/.alfred/projects.json``.
+
+    Returns a ``{path_string: name}`` mapping.  On every error condition the
+    function degrades gracefully:
+
+    - Missing file or missing ``~/.alfred/`` → ``{}`` (silent).
+    - Malformed JSON or wrong top-level shape → ``{}`` + one stderr warning.
+    - Relative key → entry skipped + one stderr warning per entry.
+    - Invalid value (``.``, ``..``, contains a path separator, or empty) →
+      entry skipped + one stderr warning per entry.
+
+    No module-level cache: the file is re-read on every call so callers that
+    invoke the function multiple times within a long-lived process always see
+    the current state (and tests never see stale data).
+    """
+    if projects_json_path is None:
+        projects_json_path = Path.home() / ".alfred" / "projects.json"
+
+    if not projects_json_path.exists():
+        return {}
+
+    try:
+        data = json.loads(projects_json_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        print(
+            f"Warning: projects.json is malformed and will be ignored ({exc})",
+            file=sys.stderr,
+        )
+        return {}
+
+    if not isinstance(data, dict):
+        return {}
+
+    projects = data.get("projects")
+    if not isinstance(projects, dict):
+        return {}
+
+    result: dict[str, str] = {}
+    for key, value in projects.items():
+        # Key must be an absolute path string.
+        if not isinstance(key, str) or not Path(key).is_absolute():
+            print(
+                f"Warning: projects.json key {key!r} is not an absolute path; skipping.",
+                file=sys.stderr,
+            )
+            continue
+
+        # Value must be a non-empty single-component leaf name.
+        if (
+            not isinstance(value, str)
+            or not value
+            or value in (".", "..")
+            or "/" in value
+            or "\\" in value
+        ):
+            print(
+                f"Warning: projects.json value {value!r} for key {key!r} is not a valid "
+                "subproject name (must be a non-empty leaf name, not '.' or '..'); skipping.",
+                file=sys.stderr,
+            )
+            continue
+
+        result[key] = value
+
+    return result
+
+
+def resolve_subproject(
+    root: Path, mapping: dict[str, str] | None = None
+) -> str | None:
+    """Return the subproject NAME for *root*, or ``None`` if not registered.
+
+    Both *root* and every key in *mapping* are normalised with
+    ``Path.resolve()`` before comparison so that symlinked paths, trailing
+    slashes, and ``..`` segments all reduce to the same canonical form.
+
+    When *mapping* is ``None``, :func:`load_projects` is called automatically.
+    Callers that have already loaded the mapping should pass it explicitly to
+    avoid a redundant file read.
+    """
+    if mapping is None:
+        mapping = load_projects()
+
+    resolved_root = str(root.resolve())
+    for key, name in mapping.items():
+        if str(Path(key).resolve()) == resolved_root:
+            return name
+    return None

--- a/src/fx_alfred/core/scanner.py
+++ b/src/fx_alfred/core/scanner.py
@@ -5,7 +5,10 @@ from importlib import resources
 from pathlib import Path
 from typing import Protocol, runtime_checkable
 
-from fx_alfred.core.document import Document
+import sys
+
+from fx_alfred.core.document import Document, FILENAME_PATTERN
+from fx_alfred.core.projects import load_projects, resolve_subproject
 from fx_alfred.core.source import source_sort_key
 
 
@@ -67,7 +70,10 @@ def _scan_pkg_dir(traversable: Traversable) -> list[Document]:
 
 
 def _scan_path_dir(
-    directory: Path, source: str, recursive: bool = False
+    directory: Path,
+    source: str,
+    recursive: bool = False,
+    exclude_subdirs: set[str] | None = None,
 ) -> list[Document]:
     """Scan USR/PRJ layer using Path.
 
@@ -75,6 +81,8 @@ def _scan_path_dir(
         directory: Path to scan
         source: Source label ('usr' or 'prj')
         recursive: If True, scan subdirectories recursively
+        exclude_subdirs: Top-level subdirectory names to skip entirely
+            (used to hide registered subproject dirs from the USR layer).
     """
     if not directory.is_dir():
         return []
@@ -93,6 +101,8 @@ def _scan_path_dir(
         except ValueError:
             rel_parts = f.parts
         if rel_parts and rel_parts[0] == "logs":
+            continue
+        if exclude_subdirs and rel_parts and rel_parts[0] in exclude_subdirs:
             continue
         if "rules" in rel_parts and "logs" in rel_parts:
             continue
@@ -141,21 +151,74 @@ def _validate_layers(docs: list[Document]) -> None:
 def scan_documents(project_root: Path) -> list[Document]:
     """Scan all layers for documents.
 
-    Layers (in order): PKG (bundled), USR (~/.alfred/), PRJ (rules/)
+    Layers (in order): PKG (bundled), USR (~/.alfred/), PRJ (rules/ or
+    ~/.alfred/<NAME>/ when the root is registered in projects.json).
+
+    FXA-2314: when ``~/.alfred/projects.json`` maps *project_root* to a
+    subproject NAME, the PRJ layer is loaded from ``~/.alfred/<NAME>/``
+    (recursive) instead of ``<project_root>/rules/`` (non-recursive).  Every
+    registered subproject directory is globally excluded from the USR
+    recursive scan so the same file is never classified as both USR and PRJ.
     """
     docs: list[Document] = []
+
+    # Load projects mapping once per invocation (no module-level cache).
+    mapping = load_projects()
+    registered_names: set[str] = set(mapping.values())
 
     # Layer 1: PKG - bundled rules inside the package
     pkg_rules = resources.files("fx_alfred").joinpath("rules")
     docs.extend(_scan_pkg_dir(pkg_rules))
 
-    # Layer 2: USR - ~/.alfred/ (recursive)
+    # Layer 2: USR - ~/.alfred/ (recursive, excluding registered subproject dirs)
     user_alfred = Path.home() / ".alfred"
-    docs.extend(_scan_path_dir(user_alfred, source="usr", recursive=True))
+    docs.extend(
+        _scan_path_dir(
+            user_alfred,
+            source="usr",
+            recursive=True,
+            exclude_subdirs=registered_names,
+        )
+    )
 
-    # Layer 3: PRJ - rules/ in project (no .alfred/)
-    rules_path = project_root / "rules"
-    docs.extend(_scan_path_dir(rules_path, source="prj"))
+    # Layer 3: PRJ
+    name = resolve_subproject(project_root, mapping)
+    if name is not None:
+        # Mapping wins: load ~/.alfred/<NAME>/ as PRJ (recursive).
+        subproject_dir = user_alfred / name
+
+        # Emit a shadow warning when local rules/ is populated (mapping wins
+        # unconditionally, but warn so the operator is aware).
+        local_rules = project_root / "rules"
+        if local_rules.is_dir():
+            try:
+                if any(
+                    f.is_file()
+                    and FILENAME_PATTERN.match(f.name)
+                    and not f.name.startswith("COR-")
+                    for f in local_rules.iterdir()
+                ):
+                    print(
+                        f"Warning: {local_rules} is shadowed by the projects.json "
+                        f"mapping to ~/.alfred/{name}/; local rules/ docs will not "
+                        "be loaded as PRJ.",
+                        file=sys.stderr,
+                    )
+            except OSError:
+                pass
+
+        if not subproject_dir.is_dir():
+            print(
+                f"Warning: projects.json maps this project to {name!r} but "
+                f"~/.alfred/{name}/ does not exist; PRJ layer will be empty.",
+                file=sys.stderr,
+            )
+        else:
+            docs.extend(_scan_path_dir(subproject_dir, source="prj", recursive=True))
+    else:
+        # Normal behavior: use <project_root>/rules/ (non-recursive)
+        rules_path = project_root / "rules"
+        docs.extend(_scan_path_dir(rules_path, source="prj"))
 
     # Validate layer invariants
     _validate_layers(docs)

--- a/tests/test_guide_cmd.py
+++ b/tests/test_guide_cmd.py
@@ -269,3 +269,80 @@ def test_guide_logging_failure_does_not_break_command(sample_project, monkeypatc
 
     assert result.exit_code == 0
     assert "Workflow Routing" in result.output
+
+
+# ── FXA-2314: USR sub-project layer via projects.json mapping ─────────────────
+
+
+def _setup_mapped_guide_context(tmp_path):
+    """Build the full fixture for a mapped-root guide test.
+
+    Layout:
+        ~/.alfred/ALF-2207-SOP-Workflow-Routing-USR.md   (sole USR routing doc)
+        ~/.alfred/NRV/NRV-2500-SOP-Workflow-Routing-PRJ.md  (subproject)
+        ~/.alfred/projects.json  → { <ext_repo>: "NRV" }
+        <ext_repo>/  (no rules/)
+    """
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+
+    # Sole USR routing doc
+    (alfred / "ALF-2207-SOP-Workflow-Routing-USR.md").write_text(
+        "# SOP-2207: Workflow Routing USR\n\n"
+        "**Applies to:** All\n"
+        "**Status:** Active\n\n"
+        "---\n\n"
+        "USR routing content.\n",
+        encoding="utf-8",
+    )
+
+    # Subproject routing doc
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir(exist_ok=True)
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text(
+        "# SOP-2500: Workflow Routing PRJ\n\n"
+        "**Applies to:** NRV\n"
+        "**Status:** Active\n\n"
+        "---\n\n"
+        "NRV subproject routing content.\n",
+        encoding="utf-8",
+    )
+
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir(exist_ok=True)
+
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {str(ext_repo.resolve()): "NRV"}}),
+        encoding="utf-8",
+    )
+    return ext_repo
+
+
+def test_guide_mapped_root_no_usr_layer_warning(tmp_path):
+    """Mapped root: guide must NOT warn about multiple active routing docs in USR."""
+    ext_repo = _setup_mapped_guide_context(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["guide", "--root", str(ext_repo)], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert "2 active routing docs in USR layer" not in result.output, (
+        "With NRV mapped as PRJ, ALF-2207 should be the sole USR routing doc "
+        "— no 'multiple active' warning should appear"
+    )
+
+
+def test_guide_mapped_root_shows_subproject_routing_doc_under_prj(tmp_path):
+    """Mapped root: guide shows the subproject routing doc in the PRJ section."""
+    ext_repo = _setup_mapped_guide_context(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["guide", "--root", str(ext_repo)], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    # The PRJ section header must reference NRV-2500
+    assert "PRJ: NRV-2500" in result.output, (
+        "Guide output must show NRV-2500 as the PRJ routing doc in a mapped context"
+    )
+    # The "no active routing document found" placeholder must NOT appear for PRJ
+    assert "PRJ: (no active routing document found)" not in result.output

--- a/tests/test_index_cmd.py
+++ b/tests/test_index_cmd.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 
@@ -278,3 +279,47 @@ def test_index_handles_mixed_statuses(tmp_path):
     assert "| 2101 | PRP | Doc 2101 | Rejected |" in content
     assert "| 2102 | SOP | Doc 2102 | Draft |" in content
     assert "| 2103 | SOP | Doc 2103 | Deprecated |" in content
+
+
+# ── FXA-2314: index inherits projects.json redirect via scan_documents ────────
+
+
+def test_index_mapped_context_includes_subproject_docs(tmp_path):
+    """af index in a mapped context indexes the subproject (PRJ) docs, not local rules/."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir(exist_ok=True)
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text(
+        "# SOP-2500: Workflow Routing PRJ\n"
+        "\n"
+        "**Applies to:** NRV\n"
+        "**Status:** Active\n"
+        "\n"
+        "---\n"
+        "\n"
+        "NRV routing content.\n"
+    )
+
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {str(ext_repo.resolve()): "NRV"}}),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["index", "--root", str(ext_repo)], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    # index_cmd writes to <root>/rules/; the subproject docs (from ~/.alfred/NRV/)
+    # must appear in the generated index because scan_documents resolves them as PRJ.
+    index_file = ext_repo / "rules" / "NRV-0000-REF-Document-Index.md"
+    assert index_file.exists(), (
+        "af index must generate an NRV prefix index that includes the subproject docs"
+    )
+    content = index_file.read_text()
+    assert "2500" in content, "NRV-2500 must appear in the generated index"

--- a/tests/test_list_cmd.py
+++ b/tests/test_list_cmd.py
@@ -225,3 +225,114 @@ def test_list_json_empty_result(sample_project, monkeypatch):
     assert result.exit_code == 0
     assert result.output == "[]\n"
     assert json.loads(result.output) == []
+
+
+# ── FXA-2314: USR sub-project layer via projects.json mapping ─────────────────
+
+
+def _setup_mapped_list_context(tmp_path):
+    """Build a fixture with one USR doc, one subproject doc, and a mapping.
+
+    Returns (alfred_dir, ext_repo, other_project).
+    """
+    import json as _json  # local import to avoid shadowing module-level
+
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+
+    # Genuine USR-layer doc (NOT in any subproject dir)
+    (alfred / "ALF-2207-SOP-Workflow-Routing-USR.md").write_text(
+        "# USR doc", encoding="utf-8"
+    )
+
+    # Subproject dir
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir(exist_ok=True)
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text(
+        "# Subproject doc", encoding="utf-8"
+    )
+
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir(exist_ok=True)
+
+    other_project = tmp_path / "other_project"
+    other_project.mkdir(exist_ok=True)
+
+    (alfred / "projects.json").write_text(
+        _json.dumps({"projects": {str(ext_repo.resolve()): "NRV"}}),
+        encoding="utf-8",
+    )
+    return alfred, ext_repo, other_project
+
+
+def test_list_subproject_docs_labelled_prj_in_mapped_context(tmp_path):
+    """Subproject docs appear with source='prj' in a mapped context (--json)."""
+    import json as _json
+
+    _, ext_repo, _ = _setup_mapped_list_context(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["list", "--json", "--root", str(ext_repo)], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    data = _json.loads(result.output)
+    nrv_doc = next(
+        (d for d in data if d["prefix"] == "NRV" and d["acid"] == "2500"), None
+    )
+    assert nrv_doc is not None, "NRV-2500 must appear in list output for mapped context"
+    assert nrv_doc["source"] == "prj", (
+        f"Expected source='prj' for NRV-2500 in mapped context, got '{nrv_doc['source']}'"
+    )
+
+
+def test_list_source_usr_excludes_subproject_docs(tmp_path):
+    """--source usr must NOT include subproject docs in a mapped context."""
+    _, ext_repo, _ = _setup_mapped_list_context(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["list", "--source", "usr", "--root", str(ext_repo)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "NRV-2500" not in result.output, (
+        "NRV-2500 is a subproject (PRJ) doc in mapped context — must NOT appear under --source usr"
+    )
+
+
+def test_list_unmapped_context_hides_subproject_docs(tmp_path):
+    """From an unmapped context, registered subproject docs are absent (global USR exclusion)."""
+    import json as _json
+
+    _, _, other_project = _setup_mapped_list_context(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["list", "--json", "--root", str(other_project)], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    data = _json.loads(result.output)
+    nrv_docs = [d for d in data if d.get("prefix") == "NRV"]
+    assert len(nrv_docs) == 0, (
+        "NRV subproject docs must NOT appear in an unmapped context "
+        "(global USR exclusion keeps them isolated)"
+    )
+
+
+def test_list_redirected_prj_doc_directory_in_json(tmp_path):
+    """Redirected PRJ doc has directory=='NRV' (not '.alfred') in --json output."""
+    import json as _json
+
+    _, ext_repo, _ = _setup_mapped_list_context(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["list", "--json", "--root", str(ext_repo)], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    data = _json.loads(result.output)
+    nrv_doc = next(
+        (d for d in data if d["prefix"] == "NRV" and d["acid"] == "2500"), None
+    )
+    assert nrv_doc is not None, "NRV-2500 must appear in list --json output"
+    assert nrv_doc["directory"] == "NRV", (
+        f"Expected directory='NRV' for redirected PRJ doc, got '{nrv_doc.get('directory')}'"
+    )

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,0 +1,293 @@
+"""Tests for fx_alfred.core.projects (FXA-2314).
+
+All imports are done lazily inside test functions so this file can be
+collected by pytest even before the module exists.  In the RED phase every
+test fails with ImportError; after implementation they exercise the real
+behaviour.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+# ── lazy importers (keep collection-time ImportError out of module scope) ────
+
+
+def _load_projects():
+    from fx_alfred.core.projects import load_projects  # noqa: PLC0415
+
+    return load_projects
+
+
+def _resolve_subproject():
+    from fx_alfred.core.projects import resolve_subproject  # noqa: PLC0415
+
+    return resolve_subproject
+
+
+# ── load_projects ─────────────────────────────────────────────────────────────
+
+
+def test_valid_map_parses_correctly():
+    """A well-formed projects.json returns the full mapping dict."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    data = {"projects": {"/abs/path/repo": "NRV", "/abs/other/repo": "ALF"}}
+    (alfred / "projects.json").write_text(json.dumps(data), encoding="utf-8")
+    result = load_projects()
+    assert result == {"/abs/path/repo": "NRV", "/abs/other/repo": "ALF"}
+
+
+def test_missing_file_returns_empty_dict():
+    """Missing ~/.alfred/projects.json returns {} without crashing."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    # No projects.json written
+    result = load_projects()
+    assert result == {}
+
+
+def test_alfred_dir_absent_returns_empty_dict():
+    """If ~/.alfred/ itself doesn't exist, return {} without crashing."""
+    load_projects = _load_projects()
+    # isolate_home gives us a fresh fake_home; do NOT create .alfred
+    result = load_projects()
+    assert result == {}
+
+
+def test_malformed_json_returns_empty_and_warns(capsys):
+    """Malformed JSON => {} AND a warning is written to stderr (or stdout)."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    (alfred / "projects.json").write_text("{this is not: valid json{{{", encoding="utf-8")
+    result = load_projects()
+    assert result == {}
+    captured = capsys.readouterr()
+    assert captured.err or captured.out, (
+        "Expected a warning on stderr (or stdout) for a malformed-but-present projects.json"
+    )
+
+
+def test_wrong_shape_returns_empty():
+    """JSON without 'projects' top-level key => {}."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    (alfred / "projects.json").write_text(
+        json.dumps({"mappings": {"/abs/repo": "NRV"}}), encoding="utf-8"
+    )
+    result = load_projects()
+    assert result == {}
+
+
+def test_unknown_top_level_keys_returns_empty():
+    """JSON with only unknown top-level keys => {}."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    (alfred / "projects.json").write_text(
+        json.dumps({"foo": "bar", "baz": 123}), encoding="utf-8"
+    )
+    result = load_projects()
+    assert result == {}
+
+
+def test_projects_value_not_dict_returns_empty():
+    """projects.json where 'projects' value is a list (not dict) => {}."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": ["/abs/repo", "NRV"]}), encoding="utf-8"
+    )
+    result = load_projects()
+    assert result == {}
+
+
+def test_relative_key_ignored_with_warning(capsys):
+    """Relative path key is excluded from the result and a warning is emitted."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    data = {"projects": {"relative/path": "NRV", "/abs/valid": "ALF"}}
+    (alfred / "projects.json").write_text(json.dumps(data), encoding="utf-8")
+    result = load_projects()
+    assert "relative/path" not in result, "Relative key must be excluded"
+    assert "/abs/valid" in result, "Absolute key must be kept"
+    captured = capsys.readouterr()
+    assert captured.err or captured.out, "Expected a warning for the relative key"
+
+
+def test_value_with_path_separator_rejected(capsys):
+    """Value containing '/' is rejected and a warning is emitted."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {"/abs/repo": "sub/dir"}}), encoding="utf-8"
+    )
+    result = load_projects()
+    assert result == {}
+    captured = capsys.readouterr()
+    assert captured.err or captured.out, "Expected a warning for value with path separator"
+
+
+def test_value_dot_rejected(capsys):
+    """Value '.' is rejected and a warning is emitted."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {"/abs/repo": "."}}), encoding="utf-8"
+    )
+    result = load_projects()
+    assert result == {}
+    captured = capsys.readouterr()
+    assert captured.err or captured.out, "Expected a warning for value '.'"
+
+
+def test_value_dotdot_rejected(capsys):
+    """Value '..' is rejected and a warning is emitted."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {"/abs/repo": ".."}}), encoding="utf-8"
+    )
+    result = load_projects()
+    assert result == {}
+    captured = capsys.readouterr()
+    assert captured.err or captured.out, "Expected a warning for value '..'"
+
+
+def test_value_empty_string_rejected(capsys):
+    """Empty string value is rejected and a warning is emitted."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {"/abs/repo": ""}}), encoding="utf-8"
+    )
+    result = load_projects()
+    assert result == {}
+    captured = capsys.readouterr()
+    assert captured.err or captured.out, "Expected a warning for empty-string value"
+
+
+def test_mixed_valid_and_invalid_entries(capsys):
+    """Valid entries are kept; invalid entries (relative key, bad value) are excluded."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    data = {
+        "projects": {
+            "/abs/good": "NRV",       # valid
+            "relative/bad": "ALF",    # relative key → excluded + warned
+            "/abs/dot": ".",           # bad value → excluded + warned
+        }
+    }
+    (alfred / "projects.json").write_text(json.dumps(data), encoding="utf-8")
+    result = load_projects()
+    assert "/abs/good" in result
+    assert result["/abs/good"] == "NRV"
+    assert "relative/bad" not in result
+    assert "/abs/dot" not in result
+
+
+def test_not_cached_across_calls():
+    """load_projects reads the file fresh each call (no stale module-level cache)."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    pj = alfred / "projects.json"
+    pj.write_text(json.dumps({"projects": {"/abs/repo": "NRV"}}), encoding="utf-8")
+    first = load_projects()
+    # Overwrite the file
+    pj.write_text(json.dumps({"projects": {"/abs/repo": "ALF"}}), encoding="utf-8")
+    second = load_projects()
+    assert second == {"/abs/repo": "ALF"}, (
+        "Second call must reflect updated file — module-level cache leaks across invocations"
+    )
+    assert first != second
+
+
+def test_many_to_one_mapping_allowed():
+    """Multiple roots may map to the same NAME (many-to-one is legal)."""
+    load_projects = _load_projects()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    data = {
+        "projects": {
+            "/abs/repo1": "NRV",
+            "/abs/repo2": "NRV",
+            "/abs/repo3": "ALF",
+        }
+    }
+    (alfred / "projects.json").write_text(json.dumps(data), encoding="utf-8")
+    result = load_projects()
+    assert result["/abs/repo1"] == "NRV"
+    assert result["/abs/repo2"] == "NRV"
+    assert result["/abs/repo3"] == "ALF"
+
+
+# ── resolve_subproject ────────────────────────────────────────────────────────
+
+
+def test_resolve_subproject_returns_name_for_mapped_root(tmp_path):
+    """resolve_subproject(root) returns the NAME when root is in projects.json."""
+    resolve_subproject = _resolve_subproject()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {str(ext_repo.resolve()): "NRV"}}),
+        encoding="utf-8",
+    )
+    assert resolve_subproject(ext_repo) == "NRV"
+
+
+def test_resolve_subproject_returns_none_for_unmapped(tmp_path):
+    """resolve_subproject(root) returns None for a root not in projects.json."""
+    resolve_subproject = _resolve_subproject()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+    # No projects.json → no mapping
+    assert resolve_subproject(ext_repo) is None
+
+
+def test_resolve_subproject_handles_symlink(tmp_path):
+    """resolve_subproject resolves symlinks on both sides before comparing."""
+    resolve_subproject = _resolve_subproject()
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+    real_repo = tmp_path / "real_repo"
+    real_repo.mkdir()
+    link_repo = tmp_path / "link_repo"
+    link_repo.symlink_to(real_repo)
+    # Register with the canonical real path
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {str(real_repo.resolve()): "NRV"}}),
+        encoding="utf-8",
+    )
+    # Passing the symlink must still resolve to "NRV"
+    assert resolve_subproject(link_repo) == "NRV"
+
+
+def test_resolve_subproject_no_projects_json_returns_none(tmp_path):
+    """resolve_subproject returns None when projects.json is absent (no crash)."""
+    resolve_subproject = _resolve_subproject()
+    # isolate_home gives a fresh home; don't create .alfred
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+    assert resolve_subproject(ext_repo) is None

--- a/tests/test_root_discovery.py
+++ b/tests/test_root_discovery.py
@@ -7,7 +7,9 @@ no qualifying ancestor → cwd fallback (the pre-CHG-2300 behavior).
 
 from __future__ import annotations
 
+import json
 import pytest
+from pathlib import Path
 
 from click.testing import CliRunner
 
@@ -181,3 +183,139 @@ def test_usr_alfred_home_is_never_a_prj_root(tmp_path):
     start.mkdir()
     # Pre-exclusion this would discover ~/.alfred; now it must fall back.
     assert discover_root(start) == start
+
+
+# ── FXA-2314: mapping-aware root discovery ────────────────────────────────────
+
+
+def _write_projects_json(alfred_dir: Path, mapping: dict) -> None:
+    (alfred_dir / "projects.json").write_text(
+        json.dumps({"projects": mapping}), encoding="utf-8"
+    )
+
+
+def test_discover_root_mapped_ancestor_recognized(tmp_path):
+    """discover_root returns the mapped ancestor when cwd is inside a mapped repo.
+
+    Without the feature: discover_root falls back to `start` (no rules/ found).
+    With the feature:    it recognises ext_repo as a mapping key and returns it.
+    """
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    subdir = ext_repo / "src" / "pkg"
+    subdir.mkdir(parents=True)
+
+    _write_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    result = discover_root(subdir)
+    assert result == ext_repo, (
+        f"Expected discover_root to return mapped ext_repo, got {result}"
+    )
+
+
+def test_discover_root_nearest_mapped_ancestor_wins(tmp_path):
+    """When several mapped ancestors exist, the DEEPEST (nearest) one wins."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+
+    outer = tmp_path / "outer"
+    inner = outer / "sub" / "inner"
+    deep = inner / "src"
+    deep.mkdir(parents=True)
+
+    _write_projects_json(
+        alfred,
+        {
+            str(outer.resolve()): "OUT",
+            str(inner.resolve()): "INN",
+        },
+    )
+
+    result = discover_root(deep)
+    assert result == inner, (
+        f"Deepest mapped ancestor must win; expected {inner}, got {result}"
+    )
+
+
+def test_discover_root_mapped_beats_distant_rules_ancestor(tmp_path):
+    """Deepest match wins whether it's a rules/ ancestor or a mapped ancestor.
+
+    Setup: outer has rules/ (discovered by old logic); inner is a mapping key
+    (no rules/).  Starting from inner/src, the nearest qualifying ancestor is
+    inner (mapped) — it must beat the more distant outer (rules/).
+    """
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+
+    outer = _make_project(tmp_path / "outer")
+    inner = outer / "sub" / "inner"
+    start = inner / "src"
+    start.mkdir(parents=True)
+
+    _write_projects_json(alfred, {str(inner.resolve()): "INN"})
+
+    result = discover_root(start)
+    assert result == inner, (
+        f"Nearest (mapped) inner must beat the more distant outer (rules/); got {result}"
+    )
+
+
+def test_discover_root_explicit_root_overrides_mapping(tmp_path, monkeypatch):
+    """Explicit --root always wins over mapping-based discovery.
+
+    This is a regression guard (--root already worked before FXA-2314) and
+    ensures the new mapping branch doesn't accidentally break --root priority.
+    """
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+    _write_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    # elsewhere has its own rules/; --root points here
+    elsewhere = _make_project(tmp_path / "elsewhere")
+
+    # cwd is inside ext_repo (mapping would normally resolve here)
+    monkeypatch.chdir(ext_repo)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["list", "--root", str(elsewhere)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    # TST-7001 only exists under elsewhere (created by _make_project)
+    assert "TST-7001" in result.output, (
+        "--root must override mapping-based discovery; TST-7001 from elsewhere must appear"
+    )
+
+
+def test_discover_root_many_to_one_each_key_resolves(tmp_path):
+    """Many-to-one mapping: each registered key independently discovers its own root."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+
+    repo_a = tmp_path / "repo_a"
+    repo_b = tmp_path / "repo_b"
+    src_a = repo_a / "src"
+    src_b = repo_b / "src"
+    src_a.mkdir(parents=True)
+    src_b.mkdir(parents=True)
+
+    _write_projects_json(
+        alfred,
+        {
+            str(repo_a.resolve()): "NRV",
+            str(repo_b.resolve()): "NRV",  # many-to-one: both map to "NRV"
+        },
+    )
+
+    assert discover_root(src_a) == repo_a, (
+        f"src_a must resolve to repo_a; got {discover_root(src_a)}"
+    )
+    assert discover_root(src_b) == repo_b, (
+        f"src_b must resolve to repo_b; got {discover_root(src_b)}"
+    )

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 
 
@@ -195,3 +196,379 @@ def test_scan_prj_not_recursive(tmp_path):
     assert len(prj_docs) == 1
     assert prj_docs[0].acid == "5000"
     assert not any(d.acid == "4000" for d in prj_docs)
+
+
+# ── FXA-2314: USR sub-project layer via projects.json mapping ─────────────────
+
+
+def _make_projects_json(alfred_dir: Path, mapping: dict) -> None:
+    """Write ~/.alfred/projects.json with the given mapping."""
+    (alfred_dir / "projects.json").write_text(
+        json.dumps({"projects": mapping}), encoding="utf-8"
+    )
+
+
+def _write_routing_doc(path: Path, prefix: str, acid: str) -> None:
+    """Write a minimal but parse-able routing document."""
+    path.write_text(
+        f"# SOP-{acid}: Workflow Routing\n\n"
+        f"**Applies to:** {prefix}\n"
+        "**Status:** Active\n\n"
+        "---\n\n"
+        f"{prefix}-{acid} routing content.\n",
+        encoding="utf-8",
+    )
+
+
+# ── Happy-path: mapped root loads subproject as PRJ ──────────────────────────
+
+
+def test_scan_mapped_root_loads_subproject_as_prj(tmp_path):
+    """Mapped root: ~/.alfred/<NAME>/ docs load with source='prj'."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    docs = scan_documents(ext_repo)
+    prj_docs = [d for d in docs if d.source == "prj"]
+
+    assert any(
+        d.prefix == "NRV" and d.acid == "2500" for d in prj_docs
+    ), "NRV-2500 must appear as source='prj' in a mapped context"
+
+
+def test_scan_mapped_root_excludes_subdir_from_usr(tmp_path):
+    """Registered subproject dir is excluded from the flat USR layer scan."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+    # A genuine USR doc (not in NRV subdir)
+    (alfred / "ALF-2207-SOP-Workflow-Routing-USR.md").write_text("# USR doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    docs = scan_documents(ext_repo)
+    usr_docs = [d for d in docs if d.source == "usr"]
+
+    assert not any(
+        d.prefix == "NRV" for d in usr_docs
+    ), "NRV-* docs must NOT appear in USR layer when NRV is a registered subproject"
+
+
+def test_scan_mapped_root_no_layer_validation_error(tmp_path):
+    """Mapped root scan must complete without LayerValidationError (no duplicates)."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+    (alfred / "ALF-2207-SOP-Workflow-Routing-USR.md").write_text("# USR doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    # Must not raise LayerValidationError
+    docs = scan_documents(ext_repo)
+    assert docs  # scan completes
+
+
+# ── Recursion: nested doc inside the subproject dir is found under PRJ ────────
+
+
+def test_scan_nested_doc_in_subproject_found_as_prj(tmp_path):
+    """Doc at ~/.alfred/<NAME>/<subdir>/X.md is found as PRJ (recursive scan)."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    nrv_dir = alfred / "NRV"
+    nrv_deep = nrv_dir / "sub_category"
+    nrv_deep.mkdir(parents=True)
+    (nrv_deep / "NRV-2600-SOP-Nested-Doc.md").write_text("# Nested NRV doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    docs = scan_documents(ext_repo)
+    prj_docs = [d for d in docs if d.source == "prj"]
+
+    assert any(
+        d.prefix == "NRV" and d.acid == "2600" for d in prj_docs
+    ), "Doc nested inside ~/.alfred/NRV/sub_category/ must be found as PRJ"
+
+
+# ── Mapping-wins / shadow: local rules/ is shadowed when mapping fires ────────
+
+
+def test_scan_mapping_wins_subproject_loads_as_prj(tmp_path):
+    """Mapped root + local rules/: subproject docs still load as PRJ (mapping wins)."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    # Local rules/ in the repo (will be shadowed)
+    local_rules = ext_repo / "rules"
+    local_rules.mkdir()
+    (local_rules / "ALF-9001-SOP-Local-Doc.md").write_text("# Local doc")
+
+    # Subproject
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    docs = scan_documents(ext_repo)
+    prj_docs = [d for d in docs if d.source == "prj"]
+
+    assert any(
+        d.prefix == "NRV" and d.acid == "2500" for d in prj_docs
+    ), "NRV subproject docs must appear as PRJ even when local rules/ exists"
+
+
+def test_scan_mapping_wins_local_rules_shadowed(tmp_path):
+    """Mapped root + local rules/: local rules docs must NOT appear in PRJ (orphan-unreachable)."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    local_rules = ext_repo / "rules"
+    local_rules.mkdir()
+    (local_rules / "ALF-9001-SOP-Local-Doc.md").write_text("# Local doc")
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    docs = scan_documents(ext_repo)
+
+    assert not any(
+        d.acid == "9001" and d.source == "prj" for d in docs
+    ), "ALF-9001 from local rules/ must NOT appear in PRJ when mapping wins (shadow)"
+
+
+def test_scan_mapping_wins_no_layer_validation_error(tmp_path):
+    """Mapped root with local rules/: _validate_layers passes (no duplicates)."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    local_rules = ext_repo / "rules"
+    local_rules.mkdir()
+    (local_rules / "ALF-9001-SOP-Local-Doc.md").write_text("# Local doc")
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    # Must not raise LayerValidationError
+    docs = scan_documents(ext_repo)
+    assert docs
+
+
+def test_scan_mapping_wins_shadow_warning_emitted(tmp_path, capsys):
+    """Mapped root with local rules/ emits a shadow warning to stderr."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    local_rules = ext_repo / "rules"
+    local_rules.mkdir()
+    (local_rules / "ALF-9001-SOP-Local-Doc.md").write_text("# Local doc")
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    scan_documents(ext_repo)
+    captured = capsys.readouterr()
+    assert captured.err or captured.out, (
+        "A shadow warning must be emitted when mapping wins over a populated local rules/"
+    )
+
+
+# ── Path normalisation: symlink on the candidate still matches ────────────────
+
+
+def test_scan_symlink_path_matches_after_resolve(tmp_path):
+    """Key and candidate differing only by a symlink match after resolve() on both sides."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    real_repo = tmp_path / "real_repo"
+    real_repo.mkdir()
+    link_repo = tmp_path / "link_repo"
+    link_repo.symlink_to(real_repo)
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+
+    # Register with the canonical real path
+    _make_projects_json(alfred, {str(real_repo.resolve()): "NRV"})
+
+    # Scan via the symlinked path
+    docs = scan_documents(link_repo)
+    prj_docs = [d for d in docs if d.source == "prj"]
+
+    assert any(
+        d.prefix == "NRV" and d.acid == "2500" for d in prj_docs
+    ), "Symlinked repo path must resolve to the registered key and load subproject as PRJ"
+
+
+# ── Missing target dir: ~/.alfred/<NAME>/ doesn't exist ──────────────────────
+
+
+def test_scan_missing_subproject_dir_empty_prj_with_warning(tmp_path, capsys):
+    """If the mapped ~/.alfred/<NAME>/ dir doesn't exist: empty PRJ + warning, no crash."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    # Map to "NRV" but DON'T create ~/.alfred/NRV/
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    docs = scan_documents(ext_repo)  # must not raise
+    prj_docs = [d for d in docs if d.source == "prj"]
+    assert prj_docs == [], "PRJ must be empty when target dir does not exist"
+
+    captured = capsys.readouterr()
+    assert captured.err or captured.out, (
+        "A warning must be emitted when the mapped ~/.alfred/<NAME>/ dir is absent"
+    )
+
+
+# ── Backward compatibility ────────────────────────────────────────────────────
+
+
+def test_scan_absent_projects_json_backward_compat(tmp_path):
+    """No projects.json => existing behavior (regular PRJ scan from rules/)."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    project = tmp_path / "project"
+    project.mkdir()
+    rules = project / "rules"
+    rules.mkdir()
+    (rules / "ALF-5001-SOP-Normal.md").write_text("# Normal doc")
+
+    # No projects.json
+    docs = scan_documents(project)
+    prj_docs = [d for d in docs if d.source == "prj"]
+    assert any(d.acid == "5001" and d.source == "prj" for d in prj_docs), (
+        "Absent projects.json must not change behavior for an ordinary project"
+    )
+
+
+def test_scan_malformed_projects_json_backward_compat(tmp_path, capsys):
+    """Malformed projects.json => fallback to normal behavior (regular PRJ scan)."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    (alfred / "projects.json").write_text("{broken{{", encoding="utf-8")
+
+    project = tmp_path / "project"
+    project.mkdir()
+    rules = project / "rules"
+    rules.mkdir()
+    (rules / "ALF-5002-SOP-Normal.md").write_text("# Normal doc")
+
+    docs = scan_documents(project)
+    prj_docs = [d for d in docs if d.source == "prj"]
+    assert any(d.acid == "5002" and d.source == "prj" for d in prj_docs), (
+        "Malformed projects.json must fall back to normal behavior"
+    )
+
+
+def test_scan_unregistered_subdir_still_recurses_into_usr(tmp_path):
+    """An UNREGISTERED ~/.alfred/ subdir retains recursive-USR behavior (locked)."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    # Unregistered subdir
+    unregistered = alfred / "unregistered_sub"
+    unregistered.mkdir()
+    (unregistered / "TST-8001-SOP-Unregistered.md").write_text("# Unregistered")
+
+    # A mapping that does NOT include 'unregistered_sub'
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    # Scanning a different project — unregistered docs should still be in USR
+    other_project = tmp_path / "other_project"
+    other_project.mkdir()
+    docs = scan_documents(other_project)
+    usr_docs = [d for d in docs if d.source == "usr"]
+    assert any(d.acid == "8001" for d in usr_docs), (
+        "Unregistered subdirs must still recurse into USR"
+    )
+
+
+# ── Document.directory field for redirected PRJ docs ─────────────────────────
+
+
+def test_scan_redirected_prj_doc_directory_field(tmp_path):
+    """Redirected PRJ doc must have directory == '<NAME>' (e.g. 'NRV'), not '.alfred'."""
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True)
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir()
+    (nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md").write_text("# NRV doc")
+
+    _make_projects_json(alfred, {str(ext_repo.resolve()): "NRV"})
+
+    docs = scan_documents(ext_repo)
+    prj_docs = [d for d in docs if d.source == "prj"]
+    nrv_doc = next(
+        (d for d in prj_docs if d.prefix == "NRV" and d.acid == "2500"), None
+    )
+    assert nrv_doc is not None, "NRV-2500 must be found as a PRJ doc"
+    assert nrv_doc.directory == "NRV", (
+        f"Expected directory='NRV', got '{nrv_doc.directory}'"
+    )
+
+
+def test_scan_usr_doc_directory_field(tmp_path, monkeypatch):
+    """USR-layer doc must have directory == '.alfred' (not the subproject name)."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    alfred = fake_home / ".alfred"
+    alfred.mkdir()
+    # Plain USR doc living directly in ~/.alfred/
+    (alfred / "USR-9002-SOP-Plain-USR.md").write_text("# USR doc")
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    project = tmp_path / "project"
+    project.mkdir()
+    docs = scan_documents(project)
+    usr_docs = [d for d in docs if d.source == "usr"]
+    usr_doc = next((d for d in usr_docs if d.acid == "9002"), None)
+    assert usr_doc is not None, "USR-9002 must be found as a USR doc"
+    assert usr_doc.directory == ".alfred", (
+        f"Expected directory='.alfred', got '{usr_doc.directory}'"
+    )

--- a/tests/test_validate_cmd.py
+++ b/tests/test_validate_cmd.py
@@ -1,5 +1,6 @@
 """Tests for af validate command."""
 
+import json
 import pytest
 
 from click.testing import CliRunner
@@ -2642,3 +2643,42 @@ def test_validate_single_doc_json_output(tmp_path):
     payload = json_mod.loads(result.output)
     doc_ids = [r["doc_id"] for r in payload["results"]]
     assert doc_ids == ["SOP-1000"]
+
+
+# ── FXA-2314: validate inherits projects.json redirect via scan_documents ─────
+
+
+def test_validate_mapped_context_scans_subproject_docs(tmp_path):
+    """af validate in a mapped context validates the subproject (PRJ) docs."""
+    from pathlib import Path
+
+    alfred = Path.home() / ".alfred"
+    alfred.mkdir(parents=True, exist_ok=True)
+
+    ext_repo = tmp_path / "ext_repo"
+    ext_repo.mkdir()
+
+    nrv_dir = alfred / "NRV"
+    nrv_dir.mkdir(exist_ok=True)
+    _write_valid_document(
+        nrv_dir / "NRV-2500-SOP-Workflow-Routing-PRJ.md",
+        "NRV",
+        "2500",
+        "SOP",
+        "Workflow Routing PRJ",
+    )
+
+    (alfred / "projects.json").write_text(
+        json.dumps({"projects": {str(ext_repo.resolve()): "NRV"}}),
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["validate", "--root", str(ext_repo)], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    assert "0 issues found" in result.output, (
+        "af validate must scan the subproject docs via projects.json redirect "
+        "and find NRV-2500 valid"
+    )


### PR DESCRIPTION
## Summary

Adds a **USR sub-project layer**: `~/.alfred/projects.json` maps an external repo root to a `~/.alfred/<NAME>/` subdirectory, which is then loaded as that repo's **PRJ layer**. This lets a third-party repo that cannot host its own `rules/` directory still get project-scoped routing.

Fixes `af guide`'s `Warning: 2 active routing docs in USR layer` and the empty PRJ layer for such repos. Because the fix lives in the shared `scan_documents`, every command that routes through it (`guide`, `list`, `read`, `validate`, `status`, `search`, `where`, `export`, `plan`, `index`) inherits the corrected classification automatically.

Closes #243.

## Design (see `rules/FXA-2314` for the full CHG)

- **`projects.json`** — `{ "projects": { "<abs-repo-root>": "<NAME>" } }`. Graceful loader: missing → `{}`; malformed/wrong-shape → `{}` + warning; non-absolute keys and `.`/`..`/separator/empty values rejected + warned (closes the `~/.alfred/.` traversal).
- **Mapping-wins redirect** — a registered root always loads `~/.alfred/<NAME>/` as PRJ (recursive). If that root also has its own populated `rules/`, the local `rules/` is shadowed with a warning. This (vs real-`rules/`-wins) is what makes the **orphan-docs state unreachable**, since the USR exclusion must be global.
- **Global USR exclusion** — registered subproject dirs are excluded from the recursive USR scan, preventing a duplicate `prefix+ACID` `LayerValidationError`.
- **cwd auto-resolution** — `discover_root` recognizes a mapped cwd/ancestor (deepest wins); `resolve()` on both sides handles symlinks/trailing-slash; explicit `--root` still wins.
- Backward compatible: absent/malformed config or unregistered subdirs behave exactly as today.

## Review trail

- **CHG review (COR-1602, 4 rounds)** — GLM / DeepSeek / MiniMax. Final R4: 9.5 / 9.85 / 9.5, all PASS. Caught the non-recursive-PRJ nested-doc loss, the hybrid-repo precedence contradiction, and the orphan-docs interaction that drove the mapping-wins design.
- **Code review (COR-1610)** — GLM 9.6 / DeepSeek 9.55 / MiniMax 9.4, zero blocking. Convergent advisories folded in (COR- filter parity in the shadow check, dedicated `index`/`validate` mapped-context tests, USR directory-field assertion). The two-reads-of-projects.json was reviewed and accepted as harmless (no cache added).

## Tests

`1256 passed, 2 skipped, 0 failed`; `ruff check src tests` clean. New coverage: `test_projects.py`, `test_root_discovery.py`, plus additions to scanner/guide/list/index/validate.

## Post-merge

To activate for the NRV docs after release (FXA-2102) + `pipx` reinstall, add to `~/.alfred/projects.json`:

```json
{ "projects": { "/Users/frank/Projects/marvin/prefrontal-cortex": "NRV" } }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KDrFrXG7RUZsWqTjueto7T
