### PR TITLE
docs(fxa-2100): correct dev workflow to 1 subagent + GLM/DeepSeek/MiniMax review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,9 +175,9 @@ af list --type PRP --root /Users/frank/Projects/alfred
 - **First time:** `af setup` (suggested prompts for agent config)
 - **Workflow branches:** SOPs can declare `Workflow branches:` metadata to express branching task flows (e.g., "do EITHER A or B"). `af plan --graph` renders these as ASCII/Mermaid branch diagrams. Branch targets use step indices; sub-steps use `{phase}.{step}{letter}` notation (e.g., `3.1a`).
 - **Routing:** COR-1103 (PKG) → ALF-2207 (USR) → FXA-2125 (PRJ)
-- All code changes go through `/trinity` dispatch (GLM = Worker, Codex/Gemini = Reviewer)
+- All code changes: implement via a single subagent (the `coder` agent), then review via the trinity panel — GLM + DeepSeek + MiniMax (3 independent reviewers). See FXA-2100.
 - TDD mandatory: COR-1500 (Red-Green-Refactor)
-- Code review: COR-1602 + COR-1608/1609/1610 rubrics + COR-1611 calibration (both >= 9.0 to pass)
+- Code review: COR-1602 + COR-1608/1609/1610 rubrics + COR-1611 calibration (all three reviewers >= 9.0 to pass; Leader may arbitrate severity per COR-1621)
 - PR review loop: use COR-1615 to match GitHub App reviews to the current head, COR-1612 to process actionable comments, and COR-1623 for operator-specified PR/thread verification. For repo-level scan/watch requests, use FXA-1623 to discover candidate PRs and delegate thread decisions back to COR-1623.
 - Release: FXA-2102 SOP + FXA-2136 README check (GitHub Actions → PyPI)
 - Documents: always `af create`, never manual files

--- a/rules/FXA-2100-SOP-Leader-Mediated-Development.md
+++ b/rules/FXA-2100-SOP-Leader-Mediated-Development.md
@@ -1,7 +1,7 @@
 # SOP-2100: Leader Mediated Development
 
 **Applies to:** FXA project
-**Last updated:** 2026-04-01
+**Last updated:** 2026-06-28
 **Last reviewed:** 2026-03-17
 **Status:** Active
 
@@ -9,28 +9,28 @@
 
 ## What Is It?
 
-A Leader-mediated development workflow where GLM implements code and two independent reviewers (Codex + Gemini) evaluate in parallel. Based on COR-1601 (Leader Mediated Loop) with Claude as Leader coordinating the full cycle.
+A Leader-mediated development workflow where a single implementation subagent (the `coder` agent) writes code and three independent reviewers (GLM + DeepSeek + MiniMax) evaluate in parallel. Based on COR-1601 (Leader Mediated Loop) with Claude as Leader coordinating the full cycle.
 
 ---
 
 ## Why
 
-Separating code implementation from review, and using two independent reviewers, reduces bias and catches issues that a single reviewer would miss. The Leader-mediated pattern ensures no direct communication between coder and reviewers, preserving review independence.
+Separating code implementation from review, and using three independent reviewers, reduces bias and catches issues that a single reviewer would miss. The Leader-mediated pattern ensures no direct communication between coder and reviewers, preserving review independence.
 
 ---
 
 ## When to Use
 
 - Developing new features or modifying existing code in FXA
-- Any code change that requires dual review before merge
-- Tasks where Leader (Claude) coordinates GLM (coder) and Codex+Gemini (reviewers)
+- Any code change that requires independent review before merge
+- Tasks where Leader (Claude) coordinates the implementation subagent (coder) and GLM + DeepSeek + MiniMax (reviewers)
 
 ---
 
 ## When NOT to Use
 
 - Document-only changes in `fx_alfred/rules/` that don't need code review
-- Trivial fixes where dual review is overkill (e.g., typo in a comment)
+- Trivial fixes where independent review is overkill (e.g., typo in a comment)
 - Releasing to PyPI -- use FXA-2102 (Release To PyPI) instead
 
 ---
@@ -40,41 +40,39 @@ Separating code implementation from review, and using two independent reviewers,
 | Role | Provider | Responsibility |
 |------|----------|----------------|
 | **Leader** | Claude | Coordinates, merges feedback, decides next action |
-| **Coder** | GLM | Implements code |
-| **Reviewer A** | Codex | Independent code review |
-| **Reviewer B** | Gemini | Independent code review |
+| **Coder** | Subagent (`coder`) | Implements code under TDD |
+| **Reviewer A** | GLM (`trinity-glm`) | Independent code review |
+| **Reviewer B** | DeepSeek (`trinity-deepseek`) | Independent code review |
+| **Reviewer C** | MiniMax (`trinity-minimax`) | Independent code review |
 
 ---
 
 ## Flow
 
 ```
-                  ┌──────────────────────────┐
-                  │     Leader (Claude)      │
-                  │  all communication goes  │
-                  │     through Leader       │
-                  └──┬───────┬──────────┬────┘
-                     │       │          │
-               assign│  forward│    forward│
-                task │  output │    output │
-                     │       │          │
-                     ▼       ▼          ▼
-                  Coder   Rev A      Rev B
-                  (GLM) (Codex)   (Gemini)
-                     │       │          │
-                     │       │          │
-               output│  score │    score │
-              to Leader│to Leader│ to Leader│
-                     │       │          │
-                     ▼       ▼          ▼
-                  ┌──────────────────────────┐
-                  │     Leader decides:      │
-                  │  - revise → instruct     │
-                  │    Coder with merged     │
-                  │    feedback              │
-                  │  - accept → both pass    │
-                  │  - arbitrate → conflicts │
-                  └──────────────────────────┘
+              ┌──────────────────────────────┐
+              │       Leader (Claude)        │
+              │  all communication flows     │
+              │       through Leader         │
+              └─┬──────┬──────┬──────┬───────┘
+                │      │      │      │
+          assign│ fwd  │ fwd  │ fwd  │
+            task│output│output│output│
+                ▼      ▼      ▼      ▼
+             Coder   Rev A  Rev B  Rev C
+           (coder)  (GLM)(DeepSeek)(MiniMax)
+                │      │      │      │
+          output│ score│ score│ score│
+         toLeader│  to  │  to  │  to  │
+                │Leader│Leader│Leader│
+                ▼      ▼      ▼      ▼
+              ┌──────────────────────────────┐
+              │       Leader decides:        │
+              │  - revise → instruct Coder   │
+              │    with merged feedback      │
+              │  - accept → all pass         │
+              │  - arbitrate → conflicts     │
+              └──────────────────────────────┘
 ```
 
 **Key rule**: Coder and Reviewers never communicate directly. All output and feedback flows through Leader.
@@ -86,32 +84,33 @@ Separating code implementation from review, and using two independent reviewers,
 1. **Leader assigns task to Coder** — clear deliverable, acceptance criteria
 2. **Coder implements** — follows TDD (COR-1500), produces code + tests
 3. **Coder submits output to Leader** — Coder does not contact Reviewers
-4. **Leader forwards output to both Reviewers simultaneously** — via `/trinity codex "review <description>" gemini "review <description>"`
-5. **Both Reviewers return scores to Leader** — each scores using the COR-1610 rubric:
+4. **Leader forwards output to all three Reviewers simultaneously** — spawns `trinity-glm`, `trinity-deepseek`, and `trinity-minimax` as parallel review subagents (via the `/trinity` skill or the Agent tool)
+5. **All three Reviewers return scores to Leader** — each scores using the COR-1610 rubric:
 
 ```
-| Dimension      | Weight | Codex | Gemini |
-|----------------|--------|-------|--------|
-| Correctness    |   25%  |   ?   |   ?    |
-| Test Coverage  |   25%  |   ?   |   ?    |
-| Code Style     |   15%  |   ?   |   ?    |
-| Security       |   15%  |   ?   |   ?    |
-| Simplicity     |   20%  |   ?   |   ?    |
+| Dimension      | Weight | GLM | DeepSeek | MiniMax |
+|----------------|--------|-----|----------|---------|
+| Correctness    |   25%  |  ?  |    ?     |    ?    |
+| Test Coverage  |   25%  |  ?  |    ?     |    ?    |
+| Code Style     |   15%  |  ?  |    ?     |    ?    |
+| Security       |   15%  |  ?  |    ?     |    ?    |
+| Simplicity     |   20%  |  ?  |    ?     |    ?    |
 ```
 
 6. **Leader collects and merges feedback** — presents combined weighted averages
 7. **Leader evaluates pass/fail**:
-   - **Pass**: both reviewers' weighted average >= 9.0/10
-   - **Fail**: either reviewer's weighted average < 9.0
-8. **If fail** — Leader merges issues from both, instructs Coder to fix. Coder revises and submits back to Leader. Repeat from step 4. If 5 rounds reached without pass, Leader makes final call.
+   - **Pass**: all three reviewers' weighted average >= 9.0/10
+   - **Fail**: any reviewer's weighted average < 9.0
+8. **If fail** — Leader merges issues from all three, instructs Coder to fix. Coder revises and submits back to Leader. Repeat from step 4. If 5 rounds reached without pass, Leader makes final call. Leader may also arbitrate a reviewer's sub-9.0 score down per COR-1621 severity triage when the residual finding is out-of-scope or pre-existing — documenting the rationale.
 9. **If pass** — task complete
 
 ---
 
 ## Pass Criteria
 
-- Both Codex AND Gemini must achieve weighted average >= 9.0/10 per COR-1610
+- All three reviewers (GLM, DeepSeek, MiniMax) must achieve weighted average >= 9.0/10 per COR-1610
 - Maximum 5 review rounds; Leader makes final call if not reached
+- Leader may arbitrate severity disagreements per COR-1621 (e.g., a sub-9.0 score resting solely on a pre-existing or out-of-scope finding)
 
 ---
 
@@ -137,17 +136,21 @@ When dispatching reviews for projects with specialized CLIs (e.g., `af` for fx_a
 
 ## Conflict Resolution
 
-When Codex and Gemini disagree:
-- Leader evaluates both arguments on technical merit
-- Leader may side with either, or propose a third approach
+When reviewers disagree:
+- Leader evaluates each argument on technical merit
+- Leader may side with any reviewer, or propose a different approach
 - Leader documents reasoning in the review summary
 
 ## Examples
 
 ```bash
-# Implement a new feature
-/trinity glm "implement FXA-2134 af plan command"           # GLM writes code
-/trinity codex "review af plan code" gemini "review af plan code"  # Codex+Gemini review
+# Implement a new feature — Leader spawns one implementation subagent
+Agent(subagent_type="coder", "implement FXA-2134 af plan command")
+
+# Review — Leader spawns three reviewers in parallel
+Agent(subagent_type="trinity-glm", "review af plan code")
+Agent(subagent_type="trinity-deepseek", "review af plan code")
+Agent(subagent_type="trinity-minimax", "review af plan code")
 ```
 
 ---
@@ -163,3 +166,4 @@ When Codex and Gemini disagree:
 | 2026-04-01 | CHG FXA-2174: Align scoring with COR-1610 (4 dims → 5 weighted dims), update pass criteria to weighted average | Claude Code |
 | 2026-04-01 | CHG FXA-2180: Standardize role naming — replace Droid with GLM in description, roles table, and flow diagram | Claude Code |
 | 2026-04-01 | CHG FXA-2181: Add optional Tool Context block to Review Prompt Template for project-specific CLI instructions | Claude Code |
+| 2026-06-28 | Issue #249: correct workflow to actual practice — Coder = single subagent (`coder`); Reviewers = GLM + DeepSeek + MiniMax (3, replacing Codex + Gemini); update roles, flow, steps, scoring matrix, pass criteria, conflict resolution, examples; add COR-1621 arbitration note | Claude Code |


### PR DESCRIPTION
## Summary

Corrects FXA-2100 (Leader Mediated Development) and CLAUDE.md to match the actual development workflow. Closes #249.

Before → After:
- **Coder:** GLM → a single implementation subagent (the `coder` agent)
- **Reviewers:** Codex + Gemini (2) → GLM + DeepSeek + MiniMax (3 independent)

Updated consistently across Roles, Flow diagram, Steps, the COR-1610 scoring matrix, Pass Criteria, Conflict Resolution, and Examples. Added a COR-1621 severity-arbitration note for the Leader's pass/fail call. Fixed the two corresponding CLAUDE.md workflow lines.

## Verification

- `af validate --root .` → 0 issues
- `pytest tests/test_docs_drift.py` → 5 passed (CLAUDE.md command/module pins intact)
- Doc-only change — per FXA-2100's own "When NOT to Use", document edits are exempt from the code-review loop.

## Notes

- Separate from #248 (the `af tag` feature). This PR only touches FXA-2100 + the two CLAUDE.md workflow lines; #248 touches different CLAUDE.md sections, so the two merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSNQ361V8ApCWPbMV81xne
