### PR TITLE
feat(tag): af tag add/rm write subcommands (BREAKING: af tag → ls/show)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,10 @@ af where IDENTIFIER [--json]               # print absolute file path of a docum
 af fmt [DOC_IDS...] [--write] [--check]     # format documents to canonical style
 af search PATTERN [--json]                  # case-insensitive content search
 af validate [--root DIR] [--json]           # structural checks; warns on unknown TYPE codes
-af tag [NAME] [--json]                      # list all tags with counts, or docs for a given tag
+af tag ls [--json]                           # list all distinct tags with counts
+af tag show NAME [--json]                    # list docs carrying a given tag
+af tag add ID TAG...                         # add one or more tags to a document
+af tag rm ID TAG...                          # remove one or more tags from a document
 af status [--json]                          # document counts by source/type/prefix
 af index                                    # regenerate PRJ layer index
 af changelog                                # show version changelog
@@ -69,7 +72,7 @@ src/fx_alfred/
 │   ├── skill_cmd.py    # skill document discovery/read
 │   ├── star_cmd.py     # star/starred/unstar bookmarks
 │   ├── status_cmd.py   # summary counts + --json
-│   ├── tag_cmd.py      # af tag — list all tags with counts or docs for a given tag
+│   ├── tag_cmd.py      # af tag ls/show/add/rm — tag management (list, filter, write)
 │   ├── update_cmd.py   # metadata/history/rename updates; --spec FILE
 │   ├── validate_cmd.py # metadata + status + SOP section validation; unknown-TYPE warnings
 │   └── where_cmd.py    # find absolute file path of a document (--json)

--- a/rules/FXA-2315-SOP-Tag-Documents-For-Filtering.md
+++ b/rules/FXA-2315-SOP-Tag-Documents-For-Filtering.md
@@ -63,15 +63,21 @@ curating every entry.
    favouring one lifecycle tag + one or two domain tags. `routing` for routers,
    `scoring` for review rubrics, `loop` for autonomous loops, etc.
 
-2. **PRJ / USR documents — apply via `af update`:**
+2. **PRJ / USR documents — apply via `af tag add`:**
+   ```bash
+   af tag add <PREFIX-ACID> routing plan --root <project-root>
+   ```
+   Comma-separated values and multiple positional args are both accepted.
+   `af tag add` is idempotent (re-adding an existing tag is a no-op). Use
+   `af tag rm <PREFIX-ACID> <tag>` to remove a tag; removing the last tag drops
+   the `Tags:` field entirely.
+
+   Alternatively, use `af update --spec` to set the full `Tags:` value in one
+   operation (useful when bulk-setting tags from a YAML spec):
    ```bash
    printf 'metadata:\n  Tags: "%s"\n' "routing, plan" > /tmp/tags.yaml
    af update <PREFIX-ACID> --spec /tmp/tags.yaml --root <project-root> -y
    ```
-   `--spec` appends the `Tags:` field in canonical order (CLI `--field` cannot
-   add a field that does not yet exist). `af update` re-renders the document to
-   canonical style — this bumps `Last updated` and may re-align tables; that is
-   expected and acceptable for a single-document edit.
 
 3. **PKG / COR documents — PR only:** do **not** use `af update` (it refuses).
    Edit the `**Status:**` line's successor in `src/fx_alfred/rules/<COR-file>.md`

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+
+### Breaking Changes
+
+- **`af tag` group refactor (#252)** — `af tag` is now a command group. The old
+  `af tag` (list all tags) becomes `af tag ls`; the old `af tag <name>` (filter
+  docs) becomes `af tag show <name>`. New write subcommands: `af tag add <ID>
+  <tag>...` adds one or more tags (comma-separated or multiple args); `af tag rm
+  <ID> <tag>...` removes tags (removing absent tags is idempotent; removing the
+  last tag drops the `Tags:` field). PKG/COR documents are refused on add/rm with
+  the same read-only guard as `af update`.
+
 ## v1.22.0 (2026-06-28)
 
 Feature release: USR sub-project layer via `~/.alfred/projects.json` (FXA-2314)

--- a/src/fx_alfred/commands/_helpers.py
+++ b/src/fx_alfred/commands/_helpers.py
@@ -26,6 +26,9 @@ from fx_alfred.core.source import SOURCE_LABELS
 # plan_cmd versions its payload shape independently.
 SCHEMA_VERSION = "1"
 
+# Shared read-only guard message — used by update_cmd, tag_cmd (add/rm).
+PKG_READONLY_MSG = "Cannot update PKG layer documents. They are read-only."
+
 
 class ExitCodeError(click.ClickException):
     """ClickException with a caller-specified exit code.

--- a/src/fx_alfred/commands/fmt_cmd.py
+++ b/src/fx_alfred/commands/fmt_cmd.py
@@ -286,6 +286,7 @@ def normalize_table_alignment(parsed: ParsedDocument) -> bool:
             row.change = cells[1].ljust(widths[1]) if widths[1] > 0 else cells[1]
         if num_cols > 2:
             row.by = cells[2].ljust(widths[2]) if widths[2] > 0 else cells[2]
+        row.dirty = True
     return True
 
 

--- a/src/fx_alfred/commands/tag_cmd.py
+++ b/src/fx_alfred/commands/tag_cmd.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 from collections import Counter
+from datetime import date
 from pathlib import Path
+from typing import Callable
 
 import click
 
 from fx_alfred.commands._helpers import (
+    PKG_READONLY_MSG,
     atomic_write,
     emit_json,
     find_or_fail,
@@ -15,6 +18,8 @@ from fx_alfred.commands._helpers import (
     scan_or_fail,
 )
 from fx_alfred.context import root_option
+from fx_alfred.core.document import Document
+from fx_alfred.core.normalize import sort_metadata
 from fx_alfred.core.parser import (
     MalformedDocumentError,
     MetadataField,
@@ -22,6 +27,90 @@ from fx_alfred.core.parser import (
     parse_tags,
     render_document,
 )
+from fx_alfred.core.schema import CONTROLLED_TAGS, DocType
+
+
+def _edit_tags(
+    ctx: click.Context,
+    identifier: str,
+    mutate: Callable[[list[str]], list[str] | None],
+) -> tuple[Document, list[str]] | None:
+    """Load doc → PKG guard → parse → mutate(existing_tags) → bump Last updated → write.
+
+    Returns (doc, new_tags) on success, or None when mutate signals nothing to do.
+    An empty new_tags list means the Tags field was dropped entirely.
+    """
+    docs = scan_or_fail(ctx)
+    doc = find_or_fail(docs, identifier)
+
+    if doc.source == "pkg":
+        raise click.ClickException(PKG_READONLY_MSG)
+
+    resource = doc.resolve_resource()
+    file_path = Path(str(resource))
+    content = file_path.read_text(encoding="utf-8")
+
+    try:
+        parsed = parse_metadata(content)
+    except MalformedDocumentError as e:
+        raise click.ClickException(str(e)) from e
+
+    tag_field = next((mf for mf in parsed.metadata_fields if mf.key == "Tags"), None)
+    existing_tags = parse_tags(tag_field.value) if tag_field is not None else []
+
+    new_tags = mutate(existing_tags)
+    if new_tags is None:
+        return None
+
+    if not new_tags:
+        parsed.metadata_fields = [
+            mf for mf in parsed.metadata_fields if mf.key != "Tags"
+        ]
+    else:
+        tags_value = ", ".join(new_tags)
+        if tag_field is None:
+            inferred_style = (
+                parsed.metadata_fields[0].prefix_style
+                if parsed.metadata_fields
+                else "bold"
+            )
+            parsed.metadata_fields.append(
+                MetadataField(
+                    key="Tags",
+                    value=tags_value,
+                    prefix_style=inferred_style,
+                    raw_line="",
+                    dirty=True,
+                )
+            )
+            try:
+                doc_type = DocType(doc.type_code)
+            except ValueError:
+                doc_type = None
+            if doc_type is not None:
+                current_keys = [mf.key for mf in parsed.metadata_fields]
+                canonical_keys = sort_metadata(current_keys, doc_type)
+                ordered: list[MetadataField] = []
+                remaining = list(parsed.metadata_fields)
+                for key in canonical_keys:
+                    for i, mf in enumerate(remaining):
+                        if mf.key == key:
+                            ordered.append(remaining.pop(i))
+                            break
+                ordered.extend(remaining)
+                parsed.metadata_fields = ordered
+        else:
+            tag_field.value = tags_value
+            tag_field.dirty = True
+
+    for mf in parsed.metadata_fields:
+        if mf.key == "Last updated":
+            mf.value = date.today().isoformat()
+            mf.dirty = True
+            break
+
+    atomic_write(file_path, render_document(parsed))
+    return doc, new_tags
 
 
 @click.group("tag")
@@ -113,60 +202,28 @@ def add_cmd(ctx: click.Context, identifier: str, tags: tuple[str, ...]) -> None:
     mix: `af tag add FXA-2315 routing,plan session`
     PKG/COR documents are read-only; submit a PR to change their tags.
     """
-    docs = scan_or_fail(ctx)
-    doc = find_or_fail(docs, identifier)
-
-    if doc.source == "pkg":
-        raise click.ClickException(
-            "Cannot update PKG layer documents. They are read-only."
-        )
-
-    # Flatten comma-separated args to a deduplicated ordered list
     new_tags: list[str] = []
     for tag_arg in tags:
         new_tags.extend(parse_tags(tag_arg))
 
-    resource = doc.resolve_resource()
-    file_path = Path(str(resource))
-    content = file_path.read_text(encoding="utf-8")
+    if not new_tags:
+        click.echo("No valid tags provided.")
+        return
 
-    try:
-        parsed = parse_metadata(content)
-    except MalformedDocumentError as e:
-        raise click.ClickException(str(e)) from e
-
-    tag_field = next((mf for mf in parsed.metadata_fields if mf.key == "Tags"), None)
-    existing_tags = parse_tags(tag_field.value) if tag_field is not None else []
-
-    # Union: preserve existing order, append new (deduped)
-    seen: set[str] = set(existing_tags)
-    merged = list(existing_tags)
     for t in new_tags:
-        if t not in seen:
-            merged.append(t)
-            seen.add(t)
-
-    tags_value = ", ".join(merged)
-
-    if tag_field is None:
-        inferred_style = (
-            parsed.metadata_fields[0].prefix_style if parsed.metadata_fields else "bold"
-        )
-        parsed.metadata_fields.append(
-            MetadataField(
-                key="Tags",
-                value=tags_value,
-                prefix_style=inferred_style,
-                raw_line="",
-                dirty=True,
+        if t not in CONTROLLED_TAGS:
+            click.echo(
+                f"warning: '{t}' is not in the FXA-2315 controlled vocabulary",
+                err=True,
             )
-        )
-    else:
-        tag_field.value = tags_value
-        tag_field.dirty = True
 
-    atomic_write(file_path, render_document(parsed))
-    click.echo(f"{doc.prefix}-{doc.acid} tags: {tags_value}")
+    def mutate(existing: list[str]) -> list[str]:
+        return list(dict.fromkeys(existing + new_tags))
+
+    result = _edit_tags(ctx, identifier, mutate)
+    if result is not None:
+        doc, final_tags = result
+        click.echo(f"{doc.prefix}-{doc.acid} tags: {', '.join(final_tags)}")
 
 
 @tag_cmd.command("rm")
@@ -182,55 +239,24 @@ def rm_cmd(ctx: click.Context, identifier: str, tags: tuple[str, ...]) -> None:
     tag drops the Tags: field entirely.
     PKG/COR documents are read-only; submit a PR to change their tags.
     """
-    docs = scan_or_fail(ctx)
-    doc = find_or_fail(docs, identifier)
-
-    if doc.source == "pkg":
-        raise click.ClickException(
-            "Cannot update PKG layer documents. They are read-only."
-        )
-
-    # Flatten comma-separated args
     tags_to_remove: set[str] = set()
     for tag_arg in tags:
         tags_to_remove.update(parse_tags(tag_arg))
 
-    resource = doc.resolve_resource()
-    file_path = Path(str(resource))
-    content = file_path.read_text(encoding="utf-8")
-
-    try:
-        parsed = parse_metadata(content)
-    except MalformedDocumentError as e:
-        raise click.ClickException(str(e)) from e
-
-    tag_field = next((mf for mf in parsed.metadata_fields if mf.key == "Tags"), None)
-
-    if tag_field is None:
-        click.echo(f"No Tags field on {doc.prefix}-{doc.acid}; nothing to remove.")
+    if not tags_to_remove:
+        click.echo("No valid tags provided.")
         return
 
-    existing_tags = parse_tags(tag_field.value)
-    existing_set = set(existing_tags)
-    absent = sorted(tags_to_remove - existing_set)
+    def mutate(existing: list[str]) -> list[str] | None:
+        existing_set = set(existing)
+        for t in sorted(tags_to_remove - existing_set):
+            click.echo(f"Tag '{t}' not present on {identifier}; skipping.")
+        if not (tags_to_remove & existing_set):
+            return None
+        return [t for t in existing if t not in tags_to_remove]
 
-    for t in absent:
-        click.echo(f"Tag '{t}' not present on {doc.prefix}-{doc.acid}; skipping.")
-
-    actually_removed = tags_to_remove & existing_set
-    if not actually_removed:
-        return
-
-    kept = [t for t in existing_tags if t not in tags_to_remove]
-
-    if kept:
-        tag_field.value = ", ".join(kept)
-        tag_field.dirty = True
-    else:
-        parsed.metadata_fields = [
-            mf for mf in parsed.metadata_fields if mf.key != "Tags"
-        ]
-
-    atomic_write(file_path, render_document(parsed))
-    remaining = ", ".join(kept) if kept else "(none — field removed)"
-    click.echo(f"{doc.prefix}-{doc.acid} tags: {remaining}")
+    result = _edit_tags(ctx, identifier, mutate)
+    if result is not None:
+        doc, remaining = result
+        display = ", ".join(remaining) if remaining else "(none — field removed)"
+        click.echo(f"{doc.prefix}-{doc.acid} tags: {display}")

--- a/src/fx_alfred/commands/tag_cmd.py
+++ b/src/fx_alfred/commands/tag_cmd.py
@@ -1,73 +1,236 @@
+"""Tag commands — list/show/add/rm tags on Alfred documents."""
+
+from __future__ import annotations
+
 from collections import Counter
+from pathlib import Path
 
 import click
 
-from fx_alfred.commands._helpers import emit_json, format_doc_row, scan_or_fail
+from fx_alfred.commands._helpers import (
+    atomic_write,
+    emit_json,
+    find_or_fail,
+    format_doc_row,
+    scan_or_fail,
+)
 from fx_alfred.context import root_option
+from fx_alfred.core.parser import (
+    MalformedDocumentError,
+    MetadataField,
+    parse_metadata,
+    parse_tags,
+    render_document,
+)
 
 
-@click.command("tag")
+@click.group("tag")
+def tag_cmd() -> None:
+    """Manage document tags.
+
+    Subcommands:
+      ls   — list every distinct tag with usage counts
+      show — list documents carrying a given tag
+      add  — add tags to a document
+      rm   — remove tags from a document
+    """
+
+
+@tag_cmd.command("ls")
 @root_option
-@click.argument("name", required=False, default=None)
 @click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
 @click.pass_context
-def tag_cmd(ctx: click.Context, name: str | None, json_output: bool):
-    """List tags or documents matching a tag.
-
-    With no argument: list every distinct tag across all documents with
-    its usage count, sorted alphabetically.
-
-    With NAME: list every document that carries that tag (case-insensitive
-    exact match, same output format as `af list`).
-    """
+def ls_cmd(ctx: click.Context, json_output: bool) -> None:
+    """List every distinct tag with usage count, sorted alphabetically."""
     docs = scan_or_fail(ctx)
 
-    if name is None:
-        # Aggregate all tags across all documents
-        tag_counter: Counter[str] = Counter()
-        for doc in docs:
-            tag_counter.update(set(doc.tags))
+    tag_counter: Counter[str] = Counter()
+    for doc in docs:
+        tag_counter.update(set(doc.tags))
 
-        sorted_tags = sorted(tag_counter.items())
+    sorted_tags = sorted(tag_counter.items())
 
-        if not sorted_tags:
-            if json_output:
-                emit_json([])
-            else:
-                click.echo("No tags found.")
-            return
-
+    if not sorted_tags:
         if json_output:
-            emit_json([{"tag": t, "count": c} for t, c in sorted_tags])
+            emit_json([])
         else:
-            width = max(len(t) for t, _ in sorted_tags)
-            for t, c in sorted_tags:
-                click.echo(f"{t:<{width}}  {c}")
+            click.echo("No tags found.")
+        return
+
+    if json_output:
+        emit_json([{"tag": t, "count": c} for t, c in sorted_tags])
     else:
-        # Filter documents by the given tag name (case-insensitive exact match)
-        matched = [d for d in docs if name.lower() in d.tags]
+        width = max(len(t) for t, _ in sorted_tags)
+        for t, c in sorted_tags:
+            click.echo(f"{t:<{width}}  {c}")
 
-        if not matched:
-            if json_output:
-                emit_json([])
-            else:
-                click.echo("No documents found.")
-            return
 
+@tag_cmd.command("show")
+@root_option
+@click.argument("name")
+@click.option("--json", "json_output", is_flag=True, help="Output as JSON.")
+@click.pass_context
+def show_cmd(ctx: click.Context, name: str, json_output: bool) -> None:
+    """List all documents carrying NAME (case-insensitive exact match)."""
+    docs = scan_or_fail(ctx)
+    matched = [d for d in docs if name.lower() in d.tags]
+
+    if not matched:
         if json_output:
-            emit_json(
-                [
-                    {
-                        "prefix": doc.prefix,
-                        "acid": doc.acid,
-                        "type_code": doc.type_code,
-                        "title": doc.title,
-                        "source": doc.source,
-                        "directory": doc.directory,
-                    }
-                    for doc in matched
-                ]
-            )
+            emit_json([])
         else:
-            for doc in matched:
-                click.echo(format_doc_row(doc))
+            click.echo("No documents found.")
+        return
+
+    if json_output:
+        emit_json(
+            [
+                {
+                    "prefix": doc.prefix,
+                    "acid": doc.acid,
+                    "type_code": doc.type_code,
+                    "title": doc.title,
+                    "source": doc.source,
+                    "directory": doc.directory,
+                }
+                for doc in matched
+            ]
+        )
+    else:
+        for doc in matched:
+            click.echo(format_doc_row(doc))
+
+
+@tag_cmd.command("add")
+@root_option
+@click.argument("identifier")
+@click.argument("tags", nargs=-1, required=True)
+@click.pass_context
+def add_cmd(ctx: click.Context, identifier: str, tags: tuple[str, ...]) -> None:
+    """Add one or more TAGS to document IDENTIFIER.
+
+    TAGS may be multiple positional arguments, comma-separated values, or a
+    mix: `af tag add FXA-2315 routing,plan session`
+    PKG/COR documents are read-only; submit a PR to change their tags.
+    """
+    docs = scan_or_fail(ctx)
+    doc = find_or_fail(docs, identifier)
+
+    if doc.source == "pkg":
+        raise click.ClickException(
+            "Cannot update PKG layer documents. They are read-only."
+        )
+
+    # Flatten comma-separated args to a deduplicated ordered list
+    new_tags: list[str] = []
+    for tag_arg in tags:
+        new_tags.extend(parse_tags(tag_arg))
+
+    resource = doc.resolve_resource()
+    file_path = Path(str(resource))
+    content = file_path.read_text(encoding="utf-8")
+
+    try:
+        parsed = parse_metadata(content)
+    except MalformedDocumentError as e:
+        raise click.ClickException(str(e)) from e
+
+    tag_field = next((mf for mf in parsed.metadata_fields if mf.key == "Tags"), None)
+    existing_tags = parse_tags(tag_field.value) if tag_field is not None else []
+
+    # Union: preserve existing order, append new (deduped)
+    seen: set[str] = set(existing_tags)
+    merged = list(existing_tags)
+    for t in new_tags:
+        if t not in seen:
+            merged.append(t)
+            seen.add(t)
+
+    tags_value = ", ".join(merged)
+
+    if tag_field is None:
+        inferred_style = (
+            parsed.metadata_fields[0].prefix_style if parsed.metadata_fields else "bold"
+        )
+        parsed.metadata_fields.append(
+            MetadataField(
+                key="Tags",
+                value=tags_value,
+                prefix_style=inferred_style,
+                raw_line="",
+                dirty=True,
+            )
+        )
+    else:
+        tag_field.value = tags_value
+        tag_field.dirty = True
+
+    atomic_write(file_path, render_document(parsed))
+    click.echo(f"{doc.prefix}-{doc.acid} tags: {tags_value}")
+
+
+@tag_cmd.command("rm")
+@root_option
+@click.argument("identifier")
+@click.argument("tags", nargs=-1, required=True)
+@click.pass_context
+def rm_cmd(ctx: click.Context, identifier: str, tags: tuple[str, ...]) -> None:
+    """Remove one or more TAGS from document IDENTIFIER.
+
+    TAGS may be multiple positional arguments, comma-separated values, or a
+    mix. Removing a tag not present is idempotent (exit 0). Removing the last
+    tag drops the Tags: field entirely.
+    PKG/COR documents are read-only; submit a PR to change their tags.
+    """
+    docs = scan_or_fail(ctx)
+    doc = find_or_fail(docs, identifier)
+
+    if doc.source == "pkg":
+        raise click.ClickException(
+            "Cannot update PKG layer documents. They are read-only."
+        )
+
+    # Flatten comma-separated args
+    tags_to_remove: set[str] = set()
+    for tag_arg in tags:
+        tags_to_remove.update(parse_tags(tag_arg))
+
+    resource = doc.resolve_resource()
+    file_path = Path(str(resource))
+    content = file_path.read_text(encoding="utf-8")
+
+    try:
+        parsed = parse_metadata(content)
+    except MalformedDocumentError as e:
+        raise click.ClickException(str(e)) from e
+
+    tag_field = next((mf for mf in parsed.metadata_fields if mf.key == "Tags"), None)
+
+    if tag_field is None:
+        click.echo(f"No Tags field on {doc.prefix}-{doc.acid}; nothing to remove.")
+        return
+
+    existing_tags = parse_tags(tag_field.value)
+    existing_set = set(existing_tags)
+    absent = sorted(tags_to_remove - existing_set)
+
+    for t in absent:
+        click.echo(f"Tag '{t}' not present on {doc.prefix}-{doc.acid}; skipping.")
+
+    actually_removed = tags_to_remove & existing_set
+    if not actually_removed:
+        return
+
+    kept = [t for t in existing_tags if t not in tags_to_remove]
+
+    if kept:
+        tag_field.value = ", ".join(kept)
+        tag_field.dirty = True
+    else:
+        parsed.metadata_fields = [
+            mf for mf in parsed.metadata_fields if mf.key != "Tags"
+        ]
+
+    atomic_write(file_path, render_document(parsed))
+    remaining = ", ".join(kept) if kept else "(none — field removed)"
+    click.echo(f"{doc.prefix}-{doc.acid} tags: {remaining}")

--- a/src/fx_alfred/commands/tag_cmd.py
+++ b/src/fx_alfred/commands/tag_cmd.py
@@ -217,8 +217,12 @@ def add_cmd(ctx: click.Context, identifier: str, tags: tuple[str, ...]) -> None:
                 err=True,
             )
 
-    def mutate(existing: list[str]) -> list[str]:
-        return list(dict.fromkeys(existing + new_tags))
+    def mutate(existing: list[str]) -> list[str] | None:
+        merged = list(dict.fromkeys(existing + new_tags))
+        if merged == existing:
+            click.echo(f"{identifier} tags unchanged")
+            return None
+        return merged
 
     result = _edit_tags(ctx, identifier, mutate)
     if result is not None:

--- a/src/fx_alfred/commands/tag_cmd.py
+++ b/src/fx_alfred/commands/tag_cmd.py
@@ -67,6 +67,7 @@ def _edit_tags(
             mf for mf in parsed.metadata_fields if mf.key != "Tags"
         ]
     else:
+        new_tags = sorted(set(new_tags))
         tags_value = ", ".join(new_tags)
         if tag_field is None:
             inferred_style = (

--- a/src/fx_alfred/commands/tag_cmd.py
+++ b/src/fx_alfred/commands/tag_cmd.py
@@ -114,6 +114,7 @@ def _edit_tags(
 
 
 @click.group("tag")
+@root_option
 def tag_cmd() -> None:
     """Manage document tags.
 

--- a/src/fx_alfred/commands/update_cmd.py
+++ b/src/fx_alfred/commands/update_cmd.py
@@ -12,6 +12,7 @@ import click
 import yaml
 
 from fx_alfred.commands._helpers import (
+    PKG_READONLY_MSG,
     atomic_write,
     find_or_fail,
     invoke_index_update,
@@ -165,9 +166,7 @@ def update_cmd(
 
     # PKG layer is read-only
     if doc.source == "pkg":
-        raise click.ClickException(
-            "Cannot update PKG layer documents. They are read-only."
-        )
+        raise click.ClickException(PKG_READONLY_MSG)
 
     # Resolve file path
     resource = doc.resolve_resource()

--- a/src/fx_alfred/core/parser.py
+++ b/src/fx_alfred/core/parser.py
@@ -33,6 +33,10 @@ class HistoryRow:
     date: str
     change: str
     by: str
+    raw_line: str = ""  # original source line for verbatim round-trip
+    dirty: bool = (
+        False  # True when cells have been modified (forces re-render from values)
+    )
 
 
 @dataclass
@@ -222,6 +226,7 @@ def parse_metadata(content: str) -> ParsedDocument:
                     date=cells[0] if cells else "",
                     change=cells[1] if len(cells) > 1 else "",
                     by=cells[2] if len(cells) > 2 else "",
+                    raw_line=line,
                 )
             )
         else:
@@ -280,7 +285,10 @@ def render_document(parsed: ParsedDocument) -> str:
     if parsed.history_header:
         lines.append(parsed.history_header)
         for row in parsed.history_rows:
-            lines.append(f"| {row.date} | {row.change} | {row.by} |")
+            if not row.dirty and row.raw_line:
+                lines.append(row.raw_line)
+            else:
+                lines.append(f"| {row.date} | {row.change} | {row.by} |")
         if parsed.trailing:
             lines.append(parsed.trailing)
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,6 +8,7 @@ from fx_alfred.core.parser import (
     extract_section,
     iter_lines_with_fence_state,
     parse_metadata,
+    render_document,
 )
 
 
@@ -229,3 +230,55 @@ def test_fence_state_short_run_is_not_a_fence():
     # Runs of 1-2 backticks (inline code) do not open a fence.
     states = _states("``\nx\n`code`\ny")
     assert [f for _, f in states] == [False, False, False, False]
+
+
+# --- HistoryRow raw_line preservation (P2 bug fix) ---
+
+
+def test_parse_metadata_stores_raw_line_on_history_rows():
+    """parse_metadata stores the original line text in HistoryRow.raw_line.
+
+    This is the data required for render_document to emit verbatim lines
+    instead of re-rendering from stripped cell values.
+    """
+    content = (
+        "# REF-9001: Test\n\n"
+        "**Applies to:** Test\n"
+        "**Status:** Active\n\n"
+        "---\n\n"
+        "## Change History\n\n"
+        "| Date       | Change                    | By          |\n"
+        "|------------|---------------------------|-------------|\n"
+        "| 2026-01-01 | Initial version           | Alice       |\n"
+    )
+    parsed = parse_metadata(content)
+    assert len(parsed.history_rows) == 1
+    assert parsed.history_rows[0].raw_line == (
+        "| 2026-01-01 | Initial version           | Alice       |"
+    )
+
+
+def test_render_document_preserves_aligned_history_rows_verbatim():
+    """render_document must round-trip aligned history table rows byte-for-byte.
+
+    Regression: rows were always re-rendered from stripped cell values, so
+    padding added by af fmt --write was silently discarded on the next write
+    (af tag add / af update), leaving the doc fmt-dirty.
+    """
+    content = (
+        "# SOP-9001: History Round-Trip\n\n"
+        "**Applies to:** Test\n"
+        "**Last updated:** 2026-01-01\n"
+        "**Status:** Active\n\n"
+        "---\n\n"
+        "## Change History\n\n"
+        "| Date       | Change                    | By          |\n"
+        "|------------|---------------------------|-------------|\n"
+        "| 2026-01-01 | Initial version           | Alice       |\n"
+        "| 2026-06-28 | A much longer description | Charlie Bob |\n"
+    )
+    parsed = parse_metadata(content)
+    rendered = render_document(parsed)
+    assert rendered == content, (
+        "render_document must emit aligned history rows verbatim via raw_line"
+    )

--- a/tests/test_tag_cmd.py
+++ b/tests/test_tag_cmd.py
@@ -137,6 +137,39 @@ def write_project(tmp_path):
         encoding="utf-8",
     )
 
+    # ALF-6005: REF doc with unsorted tags — used by sort/rm tests.
+    # xtag-zoo > xtag-mango > xtag-apple alphabetically, so all three orderings
+    # are wrong; sorted canonical form is xtag-apple, xtag-mango, xtag-zoo.
+    (rules / "ALF-6005-REF-Sortable.md").write_text(
+        "# REF-6005: Sortable\n\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2026-06-28\n"
+        "**Last reviewed:** 2026-06-28\n"
+        "**Status:** Active\n"
+        "**Tags:** xtag-zoo, xtag-mango, xtag-apple\n\n"
+        "---\n\n"
+        "## What Is It?\n\n"
+        "A sortable test reference document.\n\n"
+        "## Change History\n\n"
+        "| Date | Change | By |\n"
+        "|------|--------|----|",
+        encoding="utf-8",
+    )
+
+    # ALF-6007: REF doc with unsorted tags — used by no-op/set-unchanged test.
+    # xtag-zoo > xtag-apple alphabetically; unsorted in file intentionally to
+    # test that re-adding an already-present tag on an unsorted doc stays no-op.
+    (rules / "ALF-6007-REF-Unsorted-Present.md").write_text(
+        "# REF-6007: Unsorted Present\n\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2026-06-28\n"
+        "**Last reviewed:** 2026-06-28\n"
+        "**Status:** Active\n"
+        "**Tags:** xtag-zoo, xtag-apple\n\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
     return tmp_path
 
 
@@ -909,3 +942,133 @@ def test_tag_add_genuinely_new_tag_still_writes(write_project):
     assert after != before, "File must be rewritten when a genuinely new tag is added"
     assert "xtag-b" in after
     assert f"**Last updated:** {date.today().isoformat()}" in after
+
+
+# ── Fix 7: tag add/rm writes sorted (fmt-canonical) Tags field ───────────────
+
+
+def test_tag_add_result_is_sorted_and_fmt_clean(write_project):
+    """af tag add writes tags in sorted order; af fmt --check exits 0 after.
+
+    ALF-6001 has Tags: xtag-existing.  Adding xtag-alpha ('a' < 'e') must
+    produce Tags: xtag-alpha, xtag-existing — NOT the insertion-order
+    'xtag-existing, xtag-alpha' that the unfixed code writes.
+    af fmt --check must exit 0 (canonical == written).
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6001", "xtag-alpha", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6001-REF-Write-Test.md").read_text(
+        encoding="utf-8"
+    )
+    tag_line = next(
+        (ln for ln in content.splitlines() if ln.startswith("**Tags:**")), None
+    )
+    assert tag_line == "**Tags:** xtag-alpha, xtag-existing", (
+        f"Expected sorted tags; got: {tag_line!r}"
+    )
+    fmt_result = runner.invoke(
+        cli,
+        ["fmt", "ALF-6001", "--check", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert fmt_result.exit_code == 0, (
+        f"af fmt --check reported changes after tag add:\n{fmt_result.output}"
+    )
+
+
+def test_tag_add_new_field_multiple_tags_written_sorted(write_project):
+    """af tag add creating a new Tags field writes multiple tags sorted.
+
+    ALF-6002 has no Tags field.  Adding 'xtag-zoo,xtag-alpha' (z before a
+    as provided) must write Tags: xtag-alpha, xtag-zoo — sorted, not
+    input-order.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tag",
+            "add",
+            "ALF-6002",
+            "xtag-zoo,xtag-alpha",
+            "--root",
+            str(write_project),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6002-REF-No-Tags.md").read_text(
+        encoding="utf-8"
+    )
+    tag_line = next(
+        (ln for ln in content.splitlines() if ln.startswith("**Tags:**")), None
+    )
+    assert tag_line is not None, "Tags field not written"
+    assert tag_line == "**Tags:** xtag-alpha, xtag-zoo", (
+        f"Expected sorted tags in new field; got: {tag_line!r}"
+    )
+
+
+def test_tag_rm_result_is_sorted_and_fmt_clean(write_project):
+    """af tag rm leaving multiple tags writes them sorted; af fmt --check exits 0.
+
+    ALF-6005 has Tags: xtag-zoo, xtag-mango, xtag-apple (unsorted in file).
+    Removing xtag-zoo yields ['xtag-mango', 'xtag-apple'] in insertion order
+    — currently written unsorted.  After fix: xtag-apple, xtag-mango.
+    af fmt --check must exit 0.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "rm", "ALF-6005", "xtag-zoo", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6005-REF-Sortable.md").read_text(
+        encoding="utf-8"
+    )
+    tag_line = next(
+        (ln for ln in content.splitlines() if ln.startswith("**Tags:**")), None
+    )
+    assert tag_line == "**Tags:** xtag-apple, xtag-mango", (
+        f"Expected sorted remaining tags; got: {tag_line!r}"
+    )
+    fmt_result = runner.invoke(
+        cli,
+        ["fmt", "ALF-6005", "--check", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert fmt_result.exit_code == 0, (
+        f"af fmt --check reported changes after tag rm:\n{fmt_result.output}"
+    )
+
+
+def test_tag_add_noop_set_unchanged_with_unsorted_existing(write_project):
+    """af tag add of an already-present tag on an unsorted doc is a no-op.
+
+    Design decision: the no-op gate is 'no change to the tag SET', not
+    'no change to the rendered string'.  ALF-6007 has Tags: xtag-zoo,
+    xtag-apple (unsorted).  Re-adding xtag-apple (already present) must
+    leave the file byte-for-byte unchanged — the sort must NOT trigger a
+    rewrite just to reorder an already-correct set.
+    """
+    runner = CliRunner()
+    file_path = write_project / "rules" / "ALF-6007-REF-Unsorted-Present.md"
+    before = file_path.read_text(encoding="utf-8")
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6007", "xtag-apple", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "unchanged" in result.output
+    after = file_path.read_text(encoding="utf-8")
+    assert after == before, (
+        "File must be byte-for-byte unchanged when tag set is unchanged "
+        "(even if existing order is unsorted)"
+    )

--- a/tests/test_tag_cmd.py
+++ b/tests/test_tag_cmd.py
@@ -1,6 +1,7 @@
 """Tests for `af tag` command group (tag_cmd.py)."""
 
 import json
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -57,6 +58,8 @@ def write_project(tmp_path):
       ALF-6001-REF  tags: xtag-existing   (single tag; fully valid for af validate)
       ALF-6002-REF  (no Tags field)
       ALF-6003-REF  tags: xtag-a, xtag-b  (multiple tags for rm-one tests)
+      ALF-6004-REF  tags: xtag-a           (old Last updated: 2025-01-01; for bump tests)
+      ALF-6006-REF  (no Tags; has Custom-Field unknown opt; fully valid; for canonical-pos tests)
     """
     rules = tmp_path / "rules"
     rules.mkdir()
@@ -98,6 +101,39 @@ def write_project(tmp_path):
         "**Status:** Active\n"
         "**Tags:** xtag-a, xtag-b\n\n"
         "---\n",
+        encoding="utf-8",
+    )
+
+    # ALF-6004: REF doc with old Last-updated date — used by fix-4 (bump) tests.
+    # Date is 2025-01-01 (clearly in the past) so bumping to today is detectable.
+    (rules / "ALF-6004-REF-Date-Test.md").write_text(
+        "# REF-6004: Date Test\n\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2025-01-01\n"
+        "**Last reviewed:** 2025-01-01\n"
+        "**Status:** Active\n"
+        "**Tags:** xtag-a\n\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    # ALF-6006: fully valid REF doc with an unknown optional field but NO Tags field.
+    # Custom-Field is unknown (not in KNOWN_OPTIONAL_ORDER), so sort_metadata puts
+    # Tags (a known optional) BEFORE Custom-Field.  Append-at-end (current buggy
+    # behaviour) puts Tags AFTER Custom-Field — giving a clear RED signal for fix-2.
+    (rules / "ALF-6006-REF-Full-No-Tags.md").write_text(
+        "# REF-6006: Full No Tags\n\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2025-01-01\n"
+        "**Last reviewed:** 2025-01-01\n"
+        "**Status:** Active\n"
+        "**Custom-Field:** custom value\n\n"
+        "---\n\n"
+        "## What Is It?\n\n"
+        "A test reference document for canonical-position tests.\n\n"
+        "## Change History\n\n"
+        "| Date | Change | By |\n"
+        "|------|--------|----|",
         encoding="utf-8",
     )
 
@@ -600,3 +636,205 @@ def test_tag_rm_pkg_doc_refused(tmp_path):
     )
     assert result.exit_code != 0
     assert "Cannot update PKG layer documents" in result.output
+
+
+# ── Fix 1: empty/comma-only tag arg guard ─────────────────────────────────────
+
+
+def test_tag_add_empty_string_no_write(write_project):
+    """af tag add <ID> '' emits 'No valid tags provided.' and does not write."""
+    runner = CliRunner()
+    file_path = write_project / "rules" / "ALF-6001-REF-Write-Test.md"
+    before = file_path.read_text(encoding="utf-8")
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6001", "", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "No valid tags provided." in result.output
+    assert file_path.read_text(encoding="utf-8") == before
+
+
+def test_tag_add_comma_only_no_write(write_project):
+    """af tag add <ID> ',' emits 'No valid tags provided.' and does not write."""
+    runner = CliRunner()
+    file_path = write_project / "rules" / "ALF-6001-REF-Write-Test.md"
+    before = file_path.read_text(encoding="utf-8")
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6001", ",", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "No valid tags provided." in result.output
+    assert file_path.read_text(encoding="utf-8") == before
+
+
+def test_tag_add_empty_on_no_tags_doc_no_corrupt(write_project):
+    """af tag add on a doc with no Tags field and empty arg must not write a malformed field.
+
+    Without the guard, the code appends an empty Tags field (**Tags:** ) and
+    af validate then reports 'Tags field contains empty tag values'.  After the
+    fix the file is unchanged and the message 'No valid tags provided.' is printed.
+    """
+    runner = CliRunner()
+    file_path = write_project / "rules" / "ALF-6002-REF-No-Tags.md"
+    before = file_path.read_text(encoding="utf-8")
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6002", "", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "No valid tags provided." in result.output
+    assert file_path.read_text(encoding="utf-8") == before
+    assert "**Tags:**" not in file_path.read_text(encoding="utf-8")
+
+
+def test_tag_rm_empty_string_no_write(write_project):
+    """af tag rm <ID> '' emits 'No valid tags provided.' and does not write."""
+    runner = CliRunner()
+    file_path = write_project / "rules" / "ALF-6001-REF-Write-Test.md"
+    before = file_path.read_text(encoding="utf-8")
+    result = runner.invoke(
+        cli,
+        ["tag", "rm", "ALF-6001", "", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "No valid tags provided." in result.output
+    assert file_path.read_text(encoding="utf-8") == before
+
+
+# ── Fix 2: new Tags field in canonical metadata position ─────────────────────
+
+
+def test_tag_add_new_field_canonical_position(write_project):
+    """After tag add on a doc with no Tags field, Tags lands in canonical position.
+
+    ALF-6006 has a Custom-Field (unknown optional) after Status.  sort_metadata
+    places Tags (a known optional) BEFORE unknown fields, so Tags must appear
+    before Custom-Field.  The current append-at-end puts it AFTER, giving a
+    clear RED.  After fix, af fmt --check must also exit 0 (no reorder needed).
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6006", "maintain", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6006-REF-Full-No-Tags.md").read_text(
+        encoding="utf-8"
+    )
+    assert "**Tags:** maintain" in content
+
+    lines = content.splitlines()
+    tags_idx = next(
+        (i for i, ln in enumerate(lines) if ln.startswith("**Tags:**")), None
+    )
+    custom_idx = next(
+        (i for i, ln in enumerate(lines) if ln.startswith("**Custom-Field:**")), None
+    )
+    assert tags_idx is not None, "Tags field not found in output"
+    assert custom_idx is not None, "Custom-Field not found in output"
+    assert tags_idx < custom_idx, (
+        "Tags must appear before unknown Custom-Field in canonical order"
+    )
+
+    fmt_result = runner.invoke(
+        cli,
+        ["fmt", "ALF-6006", "--check", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert fmt_result.exit_code == 0, (
+        f"af fmt --check found reorder pending:\n{fmt_result.output}"
+    )
+
+
+# ── Fix 3: PKG_READONLY_MSG constant importable from _helpers ────────────────
+
+
+def test_pkg_readonly_msg_constant():
+    """PKG_READONLY_MSG is importable from _helpers with the exact expected text."""
+    from fx_alfred.commands._helpers import PKG_READONLY_MSG
+
+    assert PKG_READONLY_MSG == "Cannot update PKG layer documents. They are read-only."
+
+
+# ── Fix 4: Last updated bumped on successful add/rm ──────────────────────────
+
+
+def test_tag_add_bumps_last_updated(write_project):
+    """After af tag add, Last updated is set to today's date.
+
+    ALF-6004 has Last updated: 2025-01-01.  After add, it must become today.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6004", "xtag-b", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6004-REF-Date-Test.md").read_text(
+        encoding="utf-8"
+    )
+    assert f"**Last updated:** {date.today().isoformat()}" in content
+    assert "**Last updated:** 2025-01-01" not in content
+
+
+def test_tag_rm_bumps_last_updated(write_project):
+    """After af tag rm, Last updated is set to today's date.
+
+    ALF-6004 has Last updated: 2025-01-01.  After rm, it must become today.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "rm", "ALF-6004", "xtag-a", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6004-REF-Date-Test.md").read_text(
+        encoding="utf-8"
+    )
+    assert f"**Last updated:** {date.today().isoformat()}" in content
+    assert "**Last updated:** 2025-01-01" not in content
+
+
+# ── Fix 5: out-of-vocabulary tag warning on add ───────────────────────────────
+
+
+def test_tag_add_out_of_vocab_warns_stderr(write_project):
+    """Adding an OOV tag emits a warning to stderr but still writes (advisory-only).
+
+    'bogus-tag-zzz' is not in CONTROLLED_TAGS so a warning must appear on stderr.
+    The tag must also be written to the doc and the exit code must be 0.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6001", "bogus-tag-zzz", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "bogus-tag-zzz" in result.stderr
+    assert "warning" in result.stderr.lower()
+    content = (write_project / "rules" / "ALF-6001-REF-Write-Test.md").read_text(
+        encoding="utf-8"
+    )
+    assert "bogus-tag-zzz" in content
+
+
+def test_tag_add_in_vocab_no_warning(write_project):
+    """Adding a tag in CONTROLLED_TAGS produces no stderr warning."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6001", "maintain", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert result.stderr == ""

--- a/tests/test_tag_cmd.py
+++ b/tests/test_tag_cmd.py
@@ -1,4 +1,4 @@
-"""Tests for `af tag` command (tag_cmd.py)."""
+"""Tests for `af tag` command group (tag_cmd.py)."""
 
 import json
 from unittest.mock import MagicMock, patch
@@ -49,32 +49,85 @@ def tagged_project(tmp_path):
     return tmp_path
 
 
-# ── No-arg form: list all tags with counts ───────────────────────────────────
+@pytest.fixture
+def write_project(tmp_path):
+    """Project with writable PRJ-layer REF documents for tag add/rm tests.
+
+    Doc inventory:
+      ALF-6001-REF  tags: xtag-existing   (single tag; fully valid for af validate)
+      ALF-6002-REF  (no Tags field)
+      ALF-6003-REF  tags: xtag-a, xtag-b  (multiple tags for rm-one tests)
+    """
+    rules = tmp_path / "rules"
+    rules.mkdir()
+
+    # ALF-6001: properly structured REF doc — passes af validate ALF-6001
+    (rules / "ALF-6001-REF-Write-Test.md").write_text(
+        "# REF-6001: Write Test\n\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2026-06-28\n"
+        "**Last reviewed:** 2026-06-28\n"
+        "**Status:** Active\n"
+        "**Tags:** xtag-existing\n\n"
+        "---\n\n"
+        "## What Is It?\n\n"
+        "A test reference document for tag write tests.\n\n"
+        "## Change History\n\n"
+        "| Date | Change | By |\n"
+        "|------|--------|----|",
+        encoding="utf-8",
+    )
+
+    # ALF-6002: minimal REF doc with NO Tags field
+    (rules / "ALF-6002-REF-No-Tags.md").write_text(
+        "# REF-6002: No Tags\n\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2026-06-28\n"
+        "**Last reviewed:** 2026-06-28\n"
+        "**Status:** Active\n\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    # ALF-6003: REF doc with two tags (for removing one of them)
+    (rules / "ALF-6003-REF-Multi-Tags.md").write_text(
+        "# REF-6003: Multi Tags\n\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2026-06-28\n"
+        "**Last reviewed:** 2026-06-28\n"
+        "**Status:** Active\n"
+        "**Tags:** xtag-a, xtag-b\n\n"
+        "---\n",
+        encoding="utf-8",
+    )
+
+    return tmp_path
 
 
-def test_tag_no_arg_lists_tags_alphabetically(tagged_project):
-    """af tag lists all distinct tags sorted alphabetically."""
+# ── af tag ls: list all tags with counts ──────────────────────────────────────
+
+
+def test_tag_ls_lists_tags_alphabetically(tagged_project):
+    """af tag ls lists all distinct tags sorted alphabetically."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["tag", "--root", str(tagged_project)], catch_exceptions=False
+        cli, ["tag", "ls", "--root", str(tagged_project)], catch_exceptions=False
     )
     assert result.exit_code == 0
     lines = result.output.strip().splitlines()
-    # Extract tag names from first column
     tag_names = [line.split()[0] for line in lines]
     assert tag_names == sorted(tag_names), "Tags must be sorted alphabetically"
-    # fixture-specific tags must appear (xtag- prefix avoids PKG collisions)
     assert "xtag-alpha" in tag_names
     assert "xtag-beta" in tag_names
     assert "xtag-common" in tag_names
     assert "xtag-gamma" in tag_names
 
 
-def test_tag_no_arg_shows_correct_counts(tagged_project):
-    """af tag shows accurate usage counts per unique-to-fixture tag."""
+def test_tag_ls_shows_correct_counts(tagged_project):
+    """af tag ls shows accurate usage counts per unique-to-fixture tag."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["tag", "--root", str(tagged_project)], catch_exceptions=False
+        cli, ["tag", "ls", "--root", str(tagged_project)], catch_exceptions=False
     )
     assert result.exit_code == 0
     lines_map: dict[str, int] = {}
@@ -83,32 +136,30 @@ def test_tag_no_arg_shows_correct_counts(tagged_project):
         if len(parts) >= 2:
             lines_map[parts[0]] = int(parts[1])
 
-    # xtag-* tags are unique to the fixture; counts are exact
-    assert lines_map["xtag-common"] == 3  # ALF-1001, 1002, 1003
-    assert lines_map["xtag-alpha"] == 2  # ALF-1001, 1004
+    assert lines_map["xtag-common"] == 3
+    assert lines_map["xtag-alpha"] == 2
     assert lines_map["xtag-beta"] == 1
     assert lines_map["xtag-gamma"] == 1
 
 
-def test_tag_no_arg_json(tagged_project):
-    """af tag --json emits sorted JSON array of {tag, count}."""
+def test_tag_ls_json(tagged_project):
+    """af tag ls --json emits sorted JSON array of {tag, count}."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["tag", "--json", "--root", str(tagged_project)], catch_exceptions=False
+        cli,
+        ["tag", "ls", "--json", "--root", str(tagged_project)],
+        catch_exceptions=False,
     )
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert isinstance(data, list)
-    # Each element has tag and count keys
     for item in data:
         assert "tag" in item
         assert "count" in item
         assert isinstance(item["tag"], str)
         assert isinstance(item["count"], int)
-    # Sorted alphabetically
     tag_names = [item["tag"] for item in data]
     assert tag_names == sorted(tag_names)
-    # Exact counts for xtag-* tags (unique to fixture, no PKG collision)
     by_tag = {item["tag"]: item["count"] for item in data}
     assert by_tag["xtag-common"] == 3
     assert by_tag["xtag-alpha"] == 2
@@ -116,31 +167,30 @@ def test_tag_no_arg_json(tagged_project):
     assert by_tag["xtag-gamma"] == 1
 
 
-# ── With-name form: list docs for a given tag ────────────────────────────────
+# ── af tag show: list docs for a given tag ────────────────────────────────────
 
 
-def test_tag_with_name_lists_matching_docs(tagged_project):
-    """af tag xtag-common lists all documents tagged with xtag-common."""
+def test_tag_show_lists_matching_docs(tagged_project):
+    """af tag show xtag-common lists all documents tagged with xtag-common."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "xtag-common", "--root", str(tagged_project)],
+        ["tag", "show", "xtag-common", "--root", str(tagged_project)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
     assert "ALF-1001" in result.output
     assert "ALF-1002" in result.output
     assert "ALF-1003" in result.output
-    # ALF-1004 does NOT have xtag-common
     assert "ALF-1004" not in result.output
 
 
-def test_tag_with_name_multiple_types(tagged_project):
-    """af tag xtag-common returns docs of multiple types (SOP, PRP, CHG)."""
+def test_tag_show_multiple_types(tagged_project):
+    """af tag show xtag-common returns docs of multiple types (SOP, PRP, CHG)."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "xtag-common", "--root", str(tagged_project)],
+        ["tag", "show", "xtag-common", "--root", str(tagged_project)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -149,25 +199,24 @@ def test_tag_with_name_multiple_types(tagged_project):
     assert "CHG" in result.output
 
 
-def test_tag_with_name_output_format(tagged_project):
-    """af tag <name> uses same row format as af list (LABEL  PREFIX-ACID  TYPE  TITLE)."""
+def test_tag_show_output_format(tagged_project):
+    """af tag show <name> uses same row format as af list (LABEL  PREFIX-ACID  TYPE  TITLE)."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "xtag-alpha", "--root", str(tagged_project)],
+        ["tag", "show", "xtag-alpha", "--root", str(tagged_project)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    # Each line has source label and document ID
     assert "PRJ" in result.output
 
 
-def test_tag_with_name_case_insensitive(tagged_project):
+def test_tag_show_case_insensitive(tagged_project):
     """Tag name matching is case-insensitive (XTAG-COMMON matches xtag-common-tagged docs)."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "XTAG-COMMON", "--root", str(tagged_project)],
+        ["tag", "show", "XTAG-COMMON", "--root", str(tagged_project)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -176,42 +225,41 @@ def test_tag_with_name_case_insensitive(tagged_project):
     assert "ALF-1003" in result.output
 
 
-def test_tag_with_name_mixed_case(tagged_project):
+def test_tag_show_mixed_case(tagged_project):
     """Tag name matching is case-insensitive (Xtag-Common matches xtag-common-tagged docs)."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "Xtag-Common", "--root", str(tagged_project)],
+        ["tag", "show", "Xtag-Common", "--root", str(tagged_project)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
     assert "ALF-1001" in result.output
 
 
-def test_tag_with_name_unknown_tag_no_docs(tagged_project):
-    """af tag nonexistent-tag prints 'No documents found.' when no match."""
+def test_tag_show_unknown_tag_no_docs(tagged_project):
+    """af tag show nonexistent-tag prints 'No documents found.' when no match."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "nonexistent-tag", "--root", str(tagged_project)],
+        ["tag", "show", "nonexistent-tag", "--root", str(tagged_project)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
     assert "No documents found." in result.output
 
 
-def test_tag_with_name_json(tagged_project):
-    """af tag xtag-common --json emits same shape as af list --json."""
+def test_tag_show_json(tagged_project):
+    """af tag show xtag-common --json emits same shape as af list --json."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "xtag-common", "--json", "--root", str(tagged_project)],
+        ["tag", "show", "xtag-common", "--json", "--root", str(tagged_project)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
     data = json.loads(result.output)
     assert isinstance(data, list)
-    # xtag-common is unique to fixture; exactly 3 docs match
     assert len(data) == 3
     for item in data:
         assert "prefix" in item
@@ -226,12 +274,12 @@ def test_tag_with_name_json(tagged_project):
     assert "1003" in acids
 
 
-def test_tag_with_name_json_unknown_tag_empty_array(tagged_project):
-    """af tag nonexistent --json emits [] when no match."""
+def test_tag_show_json_unknown_tag_empty_array(tagged_project):
+    """af tag show nonexistent --json emits [] when no match."""
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "nonexistent", "--json", "--root", str(tagged_project)],
+        ["tag", "show", "nonexistent", "--json", "--root", str(tagged_project)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -243,30 +291,30 @@ def test_tag_with_name_json_unknown_tag_empty_array(tagged_project):
 
 
 def test_tag_root_before_subcommand(tagged_project):
-    """af --root <path> tag works (root before subcommand)."""
+    """af --root <path> tag ls works (root before subcommand)."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["--root", str(tagged_project), "tag"], catch_exceptions=False
+        cli, ["--root", str(tagged_project), "tag", "ls"], catch_exceptions=False
     )
     assert result.exit_code == 0
     assert "xtag-common" in result.output
 
 
 def test_tag_root_after_subcommand(tagged_project):
-    """af tag --root <path> works (root after subcommand)."""
+    """af tag ls --root <path> works (root after subcommand)."""
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["tag", "--root", str(tagged_project)], catch_exceptions=False
+        cli, ["tag", "ls", "--root", str(tagged_project)], catch_exceptions=False
     )
     assert result.exit_code == 0
     assert "xtag-alpha" in result.output
 
 
-def test_tag_no_arg_with_root_monkeypatched(tagged_project, monkeypatch):
-    """af tag picks up documents from the specified root."""
+def test_tag_ls_with_root_monkeypatched(tagged_project, monkeypatch):
+    """af tag ls picks up documents from the specified root."""
     monkeypatch.chdir(tagged_project)
     runner = CliRunner()
-    result = runner.invoke(cli, ["tag"], catch_exceptions=False)
+    result = runner.invoke(cli, ["tag", "ls"], catch_exceptions=False)
     assert result.exit_code == 0
     assert "xtag-common" in result.output
     assert "xtag-alpha" in result.output
@@ -275,8 +323,8 @@ def test_tag_no_arg_with_root_monkeypatched(tagged_project, monkeypatch):
 # ── Fix 1: duplicate-tag count dedup within a single doc ─────────────────────
 
 
-def test_tag_no_arg_dedupes_within_doc(tmp_path):
-    """A doc with duplicate tags (xtag-duped, xtag-duped) must count xtag-duped only once."""
+def test_tag_ls_dedupes_within_doc(tmp_path):
+    """A doc with duplicate tags (xtag-duped, xtag-duped) counts xtag-duped only once."""
     rules = tmp_path / "rules"
     rules.mkdir()
     (rules / "ALF-2001-SOP-Dedup-Test.md").write_text(
@@ -285,7 +333,7 @@ def test_tag_no_arg_dedupes_within_doc(tmp_path):
     )
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["tag", "--root", str(tmp_path)], catch_exceptions=False
+        cli, ["tag", "ls", "--root", str(tmp_path)], catch_exceptions=False
     )
     assert result.exit_code == 0
     for line in result.output.strip().splitlines():
@@ -301,8 +349,8 @@ def test_tag_no_arg_dedupes_within_doc(tmp_path):
 # ── Fix 2: no-arg empty branch message when docs exist but carry no tags ──────
 
 
-def test_tag_no_arg_no_tags_prints_no_tags_found():
-    """af tag (no arg) prints 'No tags found.' when all docs carry no Tags field.
+def test_tag_ls_no_tags_prints_no_tags_found():
+    """af tag ls prints 'No tags found.' when all docs carry no Tags field.
 
     PKG layer always provides tagged docs in integration scans, so scan_or_fail
     is mocked to isolate the zero-tag empty branch.
@@ -312,15 +360,15 @@ def test_tag_no_arg_no_tags_prints_no_tags_found():
 
     runner = CliRunner()
     with patch("fx_alfred.commands.tag_cmd.scan_or_fail", return_value=[mock_doc]):
-        result = runner.invoke(cli, ["tag"], catch_exceptions=False)
+        result = runner.invoke(cli, ["tag", "ls"], catch_exceptions=False)
 
     assert result.exit_code == 0
     assert "No tags found." in result.output
     assert "No documents found." not in result.output
 
 
-def test_tag_with_name_unknown_still_prints_no_documents_found(tmp_path):
-    """af tag <unknown> still prints 'No documents found.' (named form unchanged)."""
+def test_tag_show_unknown_still_prints_no_documents_found(tmp_path):
+    """af tag show <unknown> still prints 'No documents found.' (named form unchanged)."""
     rules = tmp_path / "rules"
     rules.mkdir()
     (rules / "ALF-3001-SOP-No-Tags.md").write_text(
@@ -330,7 +378,7 @@ def test_tag_with_name_unknown_still_prints_no_documents_found(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "xtag-nonexistent", "--root", str(tmp_path)],
+        ["tag", "show", "xtag-nonexistent", "--root", str(tmp_path)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
@@ -340,8 +388,8 @@ def test_tag_with_name_unknown_still_prints_no_documents_found(tmp_path):
 # ── Fix 3: coverage gaps ──────────────────────────────────────────────────────
 
 
-def test_tag_no_arg_doc_without_tags_field_is_absent(tmp_path):
-    """A doc with no Tags field is absent from the no-arg listing and causes no error."""
+def test_tag_ls_doc_without_tags_field_is_absent(tmp_path):
+    """A doc with no Tags field is absent from the ls listing and causes no error."""
     rules = tmp_path / "rules"
     rules.mkdir()
     (rules / "ALF-4001-SOP-With-Tag.md").write_text(
@@ -354,15 +402,15 @@ def test_tag_no_arg_doc_without_tags_field_is_absent(tmp_path):
     )
     runner = CliRunner()
     result = runner.invoke(
-        cli, ["tag", "--root", str(tmp_path)], catch_exceptions=False
+        cli, ["tag", "ls", "--root", str(tmp_path)], catch_exceptions=False
     )
     assert result.exit_code == 0
     assert "xtag-present" in result.output
     assert "ALF-4002" not in result.output
 
 
-def test_tag_with_name_exact_match_not_substring(tmp_path):
-    """af tag common must NOT match a doc tagged only xtag-common (membership, not substring)."""
+def test_tag_show_exact_match_not_substring(tmp_path):
+    """af tag show common must NOT match a doc tagged only xtag-common (membership not substring)."""
     rules = tmp_path / "rules"
     rules.mkdir()
     (rules / "ALF-5001-SOP-Tag-Test.md").write_text(
@@ -372,8 +420,183 @@ def test_tag_with_name_exact_match_not_substring(tmp_path):
     runner = CliRunner()
     result = runner.invoke(
         cli,
-        ["tag", "common", "--root", str(tmp_path)],
+        ["tag", "show", "common", "--root", str(tmp_path)],
         catch_exceptions=False,
     )
     assert result.exit_code == 0
     assert "ALF-5001" not in result.output
+
+
+# ── af tag add: write tags ─────────────────────────────────────────────────────
+
+
+def test_tag_add_writes_tags_to_existing(write_project):
+    """af tag add ALF-6001 xtag-new adds a tag to the existing Tags field."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6001", "xtag-new", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6001-REF-Write-Test.md").read_text(
+        encoding="utf-8"
+    )
+    assert "xtag-existing" in content
+    assert "xtag-new" in content
+    assert "ALF-6001 tags:" in result.output
+
+
+def test_tag_add_dedupes_against_existing(write_project):
+    """Re-adding an existing tag is idempotent — no duplicate in Tags field."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6001", "xtag-existing", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6001-REF-Write-Test.md").read_text(
+        encoding="utf-8"
+    )
+    tag_line = next(
+        (line for line in content.splitlines() if line.startswith("**Tags:**")), None
+    )
+    assert tag_line is not None
+    # Count occurrences of xtag-existing — must be exactly 1
+    assert tag_line.count("xtag-existing") == 1
+
+
+def test_tag_add_creates_tags_field_when_absent(write_project):
+    """af tag add on a doc with no Tags field creates the field."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6002", "xtag-new", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6002-REF-No-Tags.md").read_text(
+        encoding="utf-8"
+    )
+    assert "**Tags:** xtag-new" in content
+
+
+def test_tag_add_and_validate_stays_clean(write_project):
+    """After af tag add, af validate ALF-6001 reports 0 issues (exit 0)."""
+    runner = CliRunner()
+    # Add a controlled-vocabulary tag so there are no OV issues either
+    add_result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6001", "maintain", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert add_result.exit_code == 0
+
+    validate_result = runner.invoke(
+        cli,
+        ["validate", "ALF-6001", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert validate_result.exit_code == 0, (
+        f"af validate reported issues:\n{validate_result.output}"
+    )
+    assert "0 issues found" in validate_result.output
+
+
+def test_tag_add_comma_separated_and_multiple_args_flatten(write_project):
+    """af tag add ALF-6001 'xtag-x,xtag-y' xtag-z adds all three tags."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "tag",
+            "add",
+            "ALF-6001",
+            "xtag-x,xtag-y",
+            "xtag-z",
+            "--root",
+            str(write_project),
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6001-REF-Write-Test.md").read_text(
+        encoding="utf-8"
+    )
+    assert "xtag-x" in content
+    assert "xtag-y" in content
+    assert "xtag-z" in content
+
+
+# ── af tag rm: remove tags ────────────────────────────────────────────────────
+
+
+def test_tag_rm_removes_single_tag_from_multi(write_project):
+    """af tag rm ALF-6003 xtag-a removes xtag-a, leaving xtag-b."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "rm", "ALF-6003", "xtag-a", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6003-REF-Multi-Tags.md").read_text(
+        encoding="utf-8"
+    )
+    assert "xtag-b" in content
+    assert "xtag-a" not in content
+
+
+def test_tag_rm_absent_tag_is_idempotent(write_project):
+    """Removing a tag not present exits 0 with a friendly message."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "rm", "ALF-6001", "xtag-nonexistent", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "xtag-nonexistent" in result.output
+
+
+def test_tag_rm_last_tag_drops_field(write_project):
+    """Removing the last tag removes the Tags field entirely."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "rm", "ALF-6001", "xtag-existing", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    content = (write_project / "rules" / "ALF-6001-REF-Write-Test.md").read_text(
+        encoding="utf-8"
+    )
+    assert "**Tags:**" not in content
+
+
+# ── PKG guard ─────────────────────────────────────────────────────────────────
+
+
+def test_tag_add_pkg_doc_refused(tmp_path):
+    """af tag add on a PKG/COR doc is refused with a read-only error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "COR-1000", "maintain", "--root", str(tmp_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    assert "Cannot update PKG layer documents" in result.output
+
+
+def test_tag_rm_pkg_doc_refused(tmp_path):
+    """af tag rm on a PKG/COR doc is refused with a read-only error."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "rm", "COR-1000", "maintain", "--root", str(tmp_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0
+    assert "Cannot update PKG layer documents" in result.output

--- a/tests/test_tag_cmd.py
+++ b/tests/test_tag_cmd.py
@@ -838,3 +838,52 @@ def test_tag_add_in_vocab_no_warning(write_project):
     )
     assert result.exit_code == 0
     assert result.stderr == ""
+
+
+# ── Fix 6: add is a true no-op when all requested tags already present ────────
+
+
+def test_tag_add_noop_when_all_tags_already_present_file_unchanged(write_project):
+    """af tag add <tag-already-present> exits 0, prints 'unchanged', does NOT rewrite file.
+
+    ALF-6004 has Last updated: 2025-01-01 and tag xtag-a.  Without the fix,
+    mutate() returns the unchanged list and _edit_tags bumps Last updated to today
+    — spurious write.  With the fix, mutate returns None and _edit_tags skips
+    write entirely, so Last updated stays 2025-01-01 and file is byte-for-byte
+    unchanged.
+    """
+    runner = CliRunner()
+    file_path = write_project / "rules" / "ALF-6004-REF-Date-Test.md"
+    before = file_path.read_text(encoding="utf-8")
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6004", "xtag-a", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "unchanged" in result.output
+    after = file_path.read_text(encoding="utf-8")
+    assert after == before, (
+        "File must be byte-for-byte unchanged when all requested tags already exist"
+    )
+
+
+def test_tag_add_genuinely_new_tag_still_writes(write_project):
+    """af tag add with a new tag still writes the file and bumps Last updated.
+
+    Confirms the no-op guard does not suppress real writes: ALF-6004 has only
+    xtag-a; adding xtag-b must write the file and update Last updated.
+    """
+    runner = CliRunner()
+    file_path = write_project / "rules" / "ALF-6004-REF-Date-Test.md"
+    before = file_path.read_text(encoding="utf-8")
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-6004", "xtag-b", "--root", str(write_project)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    after = file_path.read_text(encoding="utf-8")
+    assert after != before, "File must be rewritten when a genuinely new tag is added"
+    assert "xtag-b" in after
+    assert f"**Last updated:** {date.today().isoformat()}" in after

--- a/tests/test_tag_cmd.py
+++ b/tests/test_tag_cmd.py
@@ -1048,6 +1048,97 @@ def test_tag_rm_result_is_sorted_and_fmt_clean(write_project):
     )
 
 
+def test_tag_add_leaves_aligned_history_table_unchanged(tmp_path):
+    """af tag add on a doc with an aligned history table must not churn the table.
+
+    Regression: render_document re-rendered rows from stripped cell values, losing
+    alignment padding that af fmt --write had produced.  After this fix, rows must
+    be emitted verbatim (raw_line round-trip), so a fmt-clean doc stays fmt-clean.
+    """
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    doc_path = rules / "ALF-9001-SOP-History-Roundtrip.md"
+    original = (
+        "# SOP-9001: History Roundtrip\n\n"
+        "**Applies to:** Test\n"
+        "**Last updated:** 2025-01-01\n"
+        "**Last reviewed:** 2025-01-01\n"
+        "**Status:** Active\n\n"
+        "---\n\n"
+        "## Change History\n\n"
+        "| Date       | Change                    | By          |\n"
+        "|------------|---------------------------|-------------|\n"
+        "| 2025-01-01 | Initial version           | Alice       |\n"
+        "| 2025-06-28 | A much longer description | Charlie Bob |\n"
+    )
+    doc_path.write_text(original, encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-9001", "xtag-new", "--root", str(tmp_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    after = doc_path.read_text(encoding="utf-8")
+
+    def _history_lines(text: str) -> list[str]:
+        lines = text.splitlines()
+        idx = next((i for i, ln in enumerate(lines) if ln == "## Change History"), None)
+        return lines[idx:] if idx is not None else []
+
+    assert _history_lines(after) == _history_lines(original), (
+        "History table must be byte-for-byte unchanged after af tag add\n"
+        f"Before: {_history_lines(original)}\nAfter:  {_history_lines(after)}"
+    )
+    assert "**Tags:** xtag-new" in after
+
+
+def test_tag_rm_leaves_aligned_history_table_unchanged(tmp_path):
+    """af tag rm on a doc with an aligned history table must not churn the table."""
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    doc_path = rules / "ALF-9002-SOP-Rm-History.md"
+    original = (
+        "# SOP-9002: Rm History\n\n"
+        "**Applies to:** Test\n"
+        "**Last updated:** 2025-01-01\n"
+        "**Last reviewed:** 2025-01-01\n"
+        "**Status:** Active\n"
+        "**Tags:** xtag-a, xtag-b\n\n"
+        "---\n\n"
+        "## Change History\n\n"
+        "| Date       | Change                    | By          |\n"
+        "|------------|---------------------------|-------------|\n"
+        "| 2025-01-01 | Initial version           | Alice       |\n"
+        "| 2025-06-28 | A much longer description | Charlie Bob |\n"
+    )
+    doc_path.write_text(original, encoding="utf-8")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "rm", "ALF-9002", "xtag-b", "--root", str(tmp_path)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    after = doc_path.read_text(encoding="utf-8")
+
+    def _history_lines(text: str) -> list[str]:
+        lines = text.splitlines()
+        idx = next((i for i, ln in enumerate(lines) if ln == "## Change History"), None)
+        return lines[idx:] if idx is not None else []
+
+    assert _history_lines(after) == _history_lines(original), (
+        "History table must be byte-for-byte unchanged after af tag rm\n"
+        f"Before: {_history_lines(original)}\nAfter:  {_history_lines(after)}"
+    )
+    assert "xtag-a" in after
+    assert "xtag-b" not in after
+
+
 def test_tag_add_noop_set_unchanged_with_unsorted_existing(write_project):
     """af tag add of an already-present tag on an unsorted doc is a no-op.
 

--- a/tests/test_tag_cmd.py
+++ b/tests/test_tag_cmd.py
@@ -346,6 +346,28 @@ def test_tag_root_after_subcommand(tagged_project):
     assert "xtag-alpha" in result.output
 
 
+def test_tag_root_at_group_level_ls(tagged_project):
+    """af tag --root <path> ls works (root at group level — P2 regression)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["tag", "--root", str(tagged_project), "ls"], catch_exceptions=False
+    )
+    assert result.exit_code == 0
+    assert "xtag-common" in result.output
+
+
+def test_tag_root_at_group_level_add(write_project):
+    """af tag --root <path> add <id> <tag> works (root at group level — P2 regression)."""
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["tag", "--root", str(write_project), "add", "ALF-6001", "xtag-new"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert "ALF-6001 tags:" in result.output
+
+
 def test_tag_ls_with_root_monkeypatched(tagged_project, monkeypatch):
     """af tag ls picks up documents from the specified root."""
     monkeypatch.chdir(tagged_project)


### PR DESCRIPTION
## Summary

Adds CLI write capability for tags by converting `af tag` into a Click group. Closes #252.

⚠️ **BREAKING** (the `af tag` read interface from #248 is renamed):
- `af tag` → **`af tag ls`** (list all tags + counts)
- `af tag <name>` → **`af tag show <name>`** (list docs carrying a tag)

New write subcommands:
- **`af tag add <ID> <tag>...`** — add tags to a doc's `Tags:` field (deduped, canonical position, comma/space separated; bumps `Last updated`; warns on out-of-vocabulary tags per FXA-2315).
- **`af tag rm <ID> <tag>...`** — remove tags (idempotent on absent; drops the field when the last tag is removed).

PKG/COR docs are refused with the shared read-only message (PR-only, per FXA-2315). Empty/comma-only args are rejected with "No valid tags provided." (no write). add/rm share a `_edit_tags` helper; the PKG-guard string is now a shared `PKG_READONLY_MSG` constant.

## Verification

- `pytest -q` → **1314 passed, 2 skipped** (+20 tests incl. RED-verified empty-arg regression)
- `ruff check` + `ruff format --check` clean; `pyright src/` 0 errors
- `af validate` → 0 issues; round-trip add/rm preserves the document; `af fmt --check` clean on new-field docs

## Review (FXA-2100 trinity panel — 2 rounds, combined COR-1610 weighted)

| Reviewer | R1 | R2 |
|----------|----|----|
| GLM-5.2 | 8.3 FIX | **9.8 PASS** |
| DeepSeek V4 | 6.45 FIX | **9.0 PASS** |
| MiniMax M3 | 7.7 FIX | **9.3 PASS** |

R1 found a verified **blocker** — an empty/comma-only arg wrote a malformed empty `Tags:` field and corrupted the doc — plus non-canonical field position, a missing `Last updated` bump, a triplicated PKG-guard string, and no out-of-vocab warning. All fixed in R2 with regression tests.

## Deferred (non-blocking advisories)

- `af tag add <ID> existing-tag` (no new tags) still rewrites + bumps `Last updated` — add an early-return when the added set ⊆ existing.
- No Change History row on tag mutations (`Last updated` bump partially covers audit).
- `parse_tags` lowercases hand-cased existing tags on write (canonical, but silent).

Builds on #248 (`af tag`) and #251 (`CONTROLLED_TAGS`). Follow-up #253 (AI tag backfill) can use `af tag add`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSNQ361V8ApCWPbMV81xne
