### PR TITLE
docs(cor-1003): promote tagging governance to COR layer + retag project SOPs

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -226,8 +226,9 @@
 | 2313 | REF | Case Study Loop Governance Of The PR Review Fix Loop | Active |
 | 2314 | CHG | USR Sub Project Layer Via Projects JSON Mapping | Approved |
 | 2315 | SOP | Tag Documents For Filtering | Active |
-| 2316 | CHG | Document Tagging Vocabulary And AF Tag Command | Proposed |
+| 2316 | CHG | Document Tagging Vocabulary And AF Tag Command | Completed |
 | 2317 | SOP | Add A Tag On Request | Active |
+| 2318 | SOP | Backfill Tags Across The Corpus | Active |
 
 ---
 

--- a/rules/FXA-2100-SOP-Leader-Mediated-Development.md
+++ b/rules/FXA-2100-SOP-Leader-Mediated-Development.md
@@ -1,10 +1,10 @@
 # SOP-2100: Leader Mediated Development
 
 **Applies to:** FXA project
-**Last updated:** 2026-06-28
+**Last updated:** 2026-06-29
 **Last reviewed:** 2026-03-17
 **Status:** Active
-**Tags:** workflow, implement
+**Tags:** implement, review, workflow
 
 ---
 

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -1,10 +1,10 @@
 # SOP-2102: Release To PyPI
 
 **Applies to:** FXA project
-**Last updated:** 2026-05-07
+**Last updated:** 2026-06-29
 **Last reviewed:** 2026-03-17
 **Status:** Active
-**Tags:** ship
+**Tags:** release, ship
 **Task tags:** release, pypi
 
 ---

--- a/rules/FXA-2127-SOP-Commit-Alfred-Ops.md
+++ b/rules/FXA-2127-SOP-Commit-Alfred-Ops.md
@@ -1,10 +1,10 @@
 # SOP-2127: Commit Alfred Ops
 
 **Applies to:** FXA project
-**Last updated:** 2026-03-20
+**Last updated:** 2026-06-29
 **Last reviewed:** 2026-03-20
 **Status:** Deprecated
-**Tags:** git, ship
+**Tags:** commit, git
 
 ---
 

--- a/rules/FXA-2148-SOP-Evolve-SOP.md
+++ b/rules/FXA-2148-SOP-Evolve-SOP.md
@@ -1,10 +1,10 @@
 # SOP-2148: Evolve-SOP
 
 **Applies to:** FXA project
-**Last updated:** 2026-06-21
+**Last updated:** 2026-06-29
 **Last reviewed:** 2026-06-21
 **Status:** Active
-**Tags:** evolution
+**Tags:** evolution, loop
 **Workflow loops:** [{id: review-retry, from: 10, to: 9, max_iterations: 3, condition: "CI not green or unresolved comments"}]
 **Task tags:** [evolve, sop, refactor-sop, improve-sop]
 

--- a/rules/FXA-2149-SOP-Evolve-CLI.md
+++ b/rules/FXA-2149-SOP-Evolve-CLI.md
@@ -1,10 +1,10 @@
 # SOP-2149: Evolve-CLI
 
 **Applies to:** FXA project
-**Last updated:** 2026-06-21
+**Last updated:** 2026-06-29
 **Last reviewed:** 2026-06-21
 **Status:** Active
-**Tags:** evolution
+**Tags:** evolution, loop
 **Workflow loops:** [{id: review-retry, from: 10, to: 9, max_iterations: 3, condition: "CI not green or unresolved comments"}]
 **Task tags:** [evolve, cli, refactor-cli, improve-cli]
 

--- a/rules/FXA-2309-SOP-Evolve-Engine.md
+++ b/rules/FXA-2309-SOP-Evolve-Engine.md
@@ -1,10 +1,10 @@
 # SOP-2309: Evolve Engine
 
 **Applies to:** FXA project
-**Last updated:** 2026-06-21
+**Last updated:** 2026-06-29
 **Last reviewed:** 2026-06-21
 **Status:** Active
-**Tags:** evolution
+**Tags:** evolution, maintain
 
 ---
 

--- a/rules/FXA-2315-SOP-Tag-Documents-For-Filtering.md
+++ b/rules/FXA-2315-SOP-Tag-Documents-For-Filtering.md
@@ -5,6 +5,7 @@
 **Last reviewed:** 2026-06-28
 **Status:** Active
 **Tags:** document, maintain
+**Overlays:** COR-1003
 
 ---
 
@@ -14,6 +15,12 @@ Procedure for assigning the **`Tags:`** metadata field to documents so they
 can be filtered with `af list --tag <tag>`. Tags are a flat, controlled
 vocabulary drawn from two dimensions — lifecycle stage and functional domain.
 Each document carries 1–3 tags.
+
+This is the **FXA project's instance of COR-1003 (Tag Document)** — COR-1003
+defines the general mechanism and process; this SOP pins the FXA controlled
+vocabulary below. FXA-2317 (add a tag on request) and FXA-2318 (corpus backfill)
+are the project-level runbooks for COR-1003's vocabulary-extension and backfill
+sub-flows.
 
 `Tags:` is read by `Document.tags` and consumed by `af list --tag`
 (case-insensitive exact match). It is **distinct from `Task tags:`**, which
@@ -106,14 +113,16 @@ curating every entry.
 - `COR-1103 Workflow Routing` → `routing, plan`
 - `COR-1500 TDD Development Workflow` → `tdd, implement`
 - `COR-1608 PRP Review Scoring` → `review, scoring, proposal`
-- `FXA-2102 Release To PyPI` → `ship`
-- `FXA-2148 Evolve SOP` → `evolution`
+- `FXA-2102 Release To PyPI` → `release, ship`
+- `FXA-2148 Evolve SOP` → `evolution, loop`
 
 ---
 
 ## Change History
 
-| Date       | Change                                                                        | By          |
-|------------|-------------------------------------------------------------------------------|-------------|
-| 2026-06-28 | Initial version                                                               | —           |
-| 2026-06-29 | Add user-level custom_tags soft-extension note; cross-link SOP-2317 (FXA-256) | Claude Code |
+| Date       | Change                                                                                  | By          |
+|------------|-----------------------------------------------------------------------------------------|-------------|
+| 2026-06-28 | Initial version                                                                         | —           |
+| 2026-06-29 | Add user-level custom_tags soft-extension note; cross-link SOP-2317 (FXA-256)           | Claude Code |
+| 2026-06-29 | Note FXA-2315 as the FXA instance of COR-1003 (Tag Document)                            | Claude Code |
+| 2026-06-29 | Add **Overlays:** COR-1003 binding (FXA-2315 overlays COR-1003 with the FXA vocabulary) | Claude Code |

--- a/rules/FXA-2317-SOP-Add-A-Tag-On-Request.md
+++ b/rules/FXA-2317-SOP-Add-A-Tag-On-Request.md
@@ -51,7 +51,7 @@ the user can just name a tag and trust the agent to place it correctly.
 - **Applying an already-allowed tag to a document.** That is plain
   [[FXA-2315]] §Steps (`af tag add <DOC> <tag>`) — no vocabulary change needed.
 - **Backfilling many documents with existing-vocabulary tags.** Use the
-  AI-assisted backfill flow (issue #253 / its SOP), not this one.
+  AI-assisted backfill flow in [[FXA-2318]], not this one.
 - **The `Task tags:` field** — governed by COR-1202 / `af plan --task`, never
   this SOP.
 
@@ -100,3 +100,4 @@ the user can just name a tag and trust the agent to place it correctly.
 | Date       | Change                                                        | By          |
 |------------|---------------------------------------------------------------|-------------|
 | 2026-06-29 | Initial version — operational runbook for FXA-256 custom_tags | Claude Code |
+| 2026-06-29 | Update #253 backfill cross-ref to [[FXA-2318]]                | Claude Code |

--- a/rules/FXA-2318-SOP-Backfill-Tags-Across-The-Corpus.md
+++ b/rules/FXA-2318-SOP-Backfill-Tags-Across-The-Corpus.md
@@ -90,11 +90,18 @@ every entry.
 
 5. **Write** the approved tags:
    ```bash
+   # Untagged / under-tagged document — add the approved tags
    af tag add <PREFIX-ACID> <tag> [<tag> ...] --root <project-root>
+
+   # REPLACING an out-of-vocabulary tag — remove the bad one, then add the fix
+   af tag rm  <PREFIX-ACID> <bad-tag>  --root <project-root>
+   af tag add <PREFIX-ACID> <good-tag> --root <project-root>
    ```
-   Or set the full `Tags:` value in one operation with `af update --spec`. PKG/COR
-   documents are read-only — prepare those as a PR per [[FXA-2315]], never a direct
-   write.
+   `af tag add` only **appends** — it does not drop the existing value. For an
+   out-of-vocabulary correction you must `af tag rm` the bad tag (otherwise Step 6
+   keeps reporting the same warning). Alternatively, `af update --spec` sets the
+   full `Tags:` value in one operation (replace, not merge). PKG/COR documents are
+   read-only — prepare those as a PR per [[FXA-2315]], never a direct write.
 
 6. **Re-confirm coverage.** Re-run the Step 1 finders; both must come back empty:
    ```bash

--- a/rules/FXA-2318-SOP-Backfill-Tags-Across-The-Corpus.md
+++ b/rules/FXA-2318-SOP-Backfill-Tags-Across-The-Corpus.md
@@ -1,0 +1,131 @@
+# SOP-2318: Backfill Tags Across The Corpus
+
+**Applies to:** FXA project (and any PRJ/USR document corpus with a Status field)
+**Last updated:** 2026-06-29
+**Last reviewed:** 2026-06-29
+**Status:** Active
+**Tags:** document, maintain
+
+---
+
+## What Is It?
+
+A repeatable, AI-assisted loop for keeping the document corpus **completely and
+correctly tagged**: scan for documents that are missing tags or carry
+out-of-vocabulary tags, read each candidate to understand its purpose, propose
+1–3 controlled-vocabulary tags with rationale, get human confirmation, write the
+tags, and re-validate.
+
+It is the *batch* complement to the two single-document tag SOPs:
+
+- [[FXA-2315]] — the vocabulary and how to tag **one** document.
+- [[FXA-2317]] — how to **add a new tag** to the allowed set on request.
+- **This SOP (FXA-2318)** — how to **find and fill gaps** across the **whole**
+  corpus.
+
+
+## Why
+
+Correct backfilling cannot be done purely mechanically: choosing the right tag
+requires reading each document's purpose (`routing` for a router, `scoring` for
+a review rubric, `loop` for an autonomous loop, …). Left to ad-hoc effort,
+coverage drifts — new documents ship untagged and `af list --tag` silently
+misses them. This SOP turns backfill into a deterministic, confirmable loop an
+AI agent can drive, so the corpus stays filterable without a human curating
+every entry.
+
+
+## When to Use
+
+- After a batch of documents is created or imported and needs tags.
+- Periodically, to close coverage gaps (untagged SOPs, out-of-vocabulary tags).
+- When `af validate` reports out-of-vocabulary tag instances or untagged SOPs
+  and you want them reconciled against the controlled vocabulary.
+
+
+## When NOT to Use
+
+- **Single-document tagging** — just use [[FXA-2315]] §Steps directly.
+- **Registering a brand-new personal/workflow tag** (e.g. `todo`, or USR-layer
+  domain terms like machine/network names) — that is [[FXA-2317]]; do **not**
+  rewrite those documents to force-fit the system vocabulary. Out-of-vocabulary
+  tags on **personal USR documents** are usually intentional and should be
+  registered with `af tag vocab add`, not backfilled.
+- **PKG / COR documents** — read-only; tag changes go through a PR per
+  [[FXA-2315]]. Propose the edit, never land it outside review.
+
+
+## Steps
+
+1. **Find candidates** using the `af validate` checks as the candidate-finders:
+   ```bash
+   # untagged SOP documents (missing the Tags: field) — SOP type only
+   af validate --root <project-root> --warn-untagged-sops
+   # out-of-vocabulary tags on ANY document type
+   af validate --root <project-root> --tag-warnings detail
+   ```
+   Build a working list of `(document, gap-type)` pairs. Note the asymmetry: the
+   out-of-vocabulary check is corpus-wide, but untagged-detection currently covers
+   **SOP documents only** — there is no built-in untagged finder for PRP/CHG/REF/
+   etc. (a known tooling gap; extend this SOP if one is added). An empty result
+   from both finders means the covered surface is fully tagged — stop here.
+
+2. **Triage each candidate by layer / intent** before proposing anything:
+   - *Untagged PRJ/USR document* → propose tags (Step 3).
+   - *Out-of-vocabulary tag on a **personal** USR document* → this is an
+     [[FXA-2317]] case, not a backfill. Route to `af tag vocab add <tag>` (register
+     the personal term) rather than re-tagging. Record it and move on.
+   - *Out-of-vocabulary tag on a **PRJ/COR** document* → the tag is genuinely
+     wrong; propose a correct controlled-vocabulary replacement (Step 3).
+
+3. **Read and propose.** For each document that needs tags, read its content and
+   propose **1–3** tags from the controlled vocabulary in [[FXA-2315]] (favour one
+   lifecycle tag + one or two domain tags), each with a one-line rationale tied to
+   the document's purpose. Never invent a tag here — if no vocabulary tag fits,
+   the vocabulary itself is the gap: stop and route to [[FXA-2317]] (system-tag PR).
+
+4. **Confirm with the human.** Present the full proposal list (document → proposed
+   tags + rationale) and wait for explicit approval. Do not write on assumption.
+   The human may accept, amend, or reject per document.
+
+5. **Write** the approved tags:
+   ```bash
+   af tag add <PREFIX-ACID> <tag> [<tag> ...] --root <project-root>
+   ```
+   Or set the full `Tags:` value in one operation with `af update --spec`. PKG/COR
+   documents are read-only — prepare those as a PR per [[FXA-2315]], never a direct
+   write.
+
+6. **Re-confirm coverage.** Re-run the Step 1 finders; both must come back empty:
+   ```bash
+   af validate --root <project-root> --warn-untagged-sops --tag-warnings detail
+   ```
+   Gate on these finders, **not** on the plain `af validate` "0 issues" line — tag
+   gaps are *warnings*, not issues, so that line stays green even on an untagged
+   corpus. Personal USR tags you registered with `af tag vocab add` in Step 2 are
+   now *in* the vocabulary and produce **no** warning; any out-of-vocabulary
+   warning that remains is a genuine unhandled candidate — loop back to Step 2.
+
+
+## Examples
+
+```bash
+# 1. Scan
+af validate --root . --warn-untagged-sops --tag-warnings detail
+
+# 3-5. After reading FXA-2400 (a hypothetical new PRJ router) and confirming:
+af tag add FXA-2400 routing plan --root .
+#   A PKG/COR doc (e.g. COR-1103) cannot be written directly — af tag add
+#   refuses it as read-only; prepare those as a PR per FXA-2315.
+
+# 6. Confirm coverage with the finders (not a plain validate)
+af validate --root . --warn-untagged-sops --tag-warnings detail
+```
+
+---
+
+## Change History
+
+| Date       | Change                                                                | By          |
+|------------|-----------------------------------------------------------------------|-------------|
+| 2026-06-29 | Initial version — AI-assisted corpus-wide tag backfill loop (FXA-253) | Claude Code |

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -6,10 +6,12 @@
 
 - **COR-1003 (Tag Document) — COR-level tagging SOP.** Promotes the document-tagging
   mechanism and process to the bundled PKG layer so `af guide` routes it in every
-  project, not just this repo. `Disposition: optional-overlay`; a project pins its
-  own controlled vocabulary via a PRJ SOP that declares `**Overlays:** COR-1003`
-  (FXA-2315 is the FXA instance). The `af validate` Overlays/Disposition binding
-  check enforces the pairing. Also backfilled the missing COR-1004 index row.
+  project, not just this repo. `Disposition: optional-overlay`; a project documents
+  its vocabulary and conventions in a PRJ SOP that declares `**Overlays:** COR-1003`
+  (FXA-2315 is the FXA instance, drift-synced to the built-in `CONTROLLED_TAGS`).
+  The `af validate` Overlays/Disposition binding check enforces the pairing.
+  COR-1103's intent router now routes tag/retag requests to COR-1003. Also
+  backfilled the missing COR-1004 index row.
 
 ## v1.23.0 (2026-06-29)
 

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### New Features
+
+- **COR-1003 (Tag Document) — COR-level tagging SOP.** Promotes the document-tagging
+  mechanism and process to the bundled PKG layer so `af guide` routes it in every
+  project, not just this repo. `Disposition: optional-overlay`; a project pins its
+  own controlled vocabulary via a PRJ SOP that declares `**Overlays:** COR-1003`
+  (FXA-2315 is the FXA instance). The `af validate` Overlays/Disposition binding
+  check enforces the pairing. Also backfilled the missing COR-1004 index row.
+
 ## v1.23.0 (2026-06-29)
 
 Document tagging release: a full `af tag` toolchain for filtering the corpus by

--- a/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
+++ b/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
@@ -21,6 +21,8 @@ A reference index of all documents in the COR system.
 | 1000 | SOP | Create SOP |
 | 1001 | SOP | Create Document |
 | 1002 | SOP | Read Document |
+| 1003 | SOP | Tag Document |
+| 1004 | SOP | Create Routing Document |
 | 1100 | SOP | Create Decision Record |
 | 1101 | SOP | Submit Change Request |
 | 1102 | SOP | Create Proposal |
@@ -116,3 +118,4 @@ A reference index of all documents in the COR system.
 | 2026-06-19 | Added COR-1624 (Loop — L1 Report-Only) — first rung of the Loop autonomy ladder (L1/L2/L3), adapted from loop-engineering's phased-rollout model. | Claude Code |
 | 2026-06-19 | Added COR-1625 (Loop — L2 Assisted + Gated) and COR-1626 (Loop — L3 Unattended, Status: Draft) — completing the Loop autonomy ladder. | Claude Code |
 | 2026-06-26 | Added COR-1627 (Loop PDCA Run Audit) — report-only PDCA retrospective for L1/L2 runs. | Claude Code |
+| 2026-06-29 | Added COR-1003 (Tag Document) — COR-level tagging mechanism + process (optional-overlay); also backfilled the missing COR-1004 (Create Routing Document) index row. | Claude Code |

--- a/src/fx_alfred/rules/COR-1003-SOP-Tag-Document.md
+++ b/src/fx_alfred/rules/COR-1003-SOP-Tag-Document.md
@@ -1,0 +1,113 @@
+# SOP-1003: Tag Document
+
+**Applies to:** All projects using the COR document system
+**Last updated:** 2026-06-29
+**Last reviewed:** 2026-06-29
+**Status:** Active
+**Tags:** document, maintain
+**Disposition:** optional-overlay
+
+---
+
+## What Is It?
+
+The standard process for assigning **tags** to documents so they can be filtered
+with `af list --tag <tag>`. Tags are a flat, controlled vocabulary written to the
+`Tags:` metadata field (1–3 per document, distinct from `Task tags:`). This SOP
+defines the **mechanism and process** that work in every project; the controlled
+vocabulary itself is defined per project by a PRJ-layer SOP that overlays this one
+(declared with `**Overlays:** COR-1003`).
+
+It has three sub-flows, each with a dedicated tool:
+
+- **Tag a document** — put existing-vocabulary tags on one document (`af tag add`).
+- **Extend the vocabulary** — register a new allowed tag (`af tag vocab add` for a
+  personal tag; a PR for a shared/system tag).
+- **Backfill the corpus** — find and fill gaps across many documents.
+
+---
+
+## Why
+
+Without a controlled vocabulary and a fixed write process, tags drift into
+synonyms (`review` / `reviewing` / `code-review`) and filtering silently breaks.
+A single source of truth for the tag set, plus the `af tag` commands as the write
+path, keeps `af list --tag` reliable and lets agents self-serve tag maintenance
+without a human curating every entry.
+
+---
+
+## When to Use
+
+- A new document is created and needs tags for discovery.
+- An existing document is missing `Tags:` or carries stale/wrong tags.
+- The user asks to "tag", "retag", or "make documents filterable", or to add a
+  new tag to the allowed set.
+
+---
+
+## When NOT to Use
+
+- **PKG / COR documents.** `af tag add`/`af update` refuse them ("read-only").
+  Their tag changes edit package source and **must go through a PR**. An agent may
+  prepare the edit but must not land it outside review.
+- **The `Task tags:` field** — that drives plan composition (`af plan --task`),
+  not document filtering; it is governed separately.
+- **Inventing a tag not in the vocabulary** — first extend the vocabulary (Step 2),
+  then apply it.
+
+---
+
+## Steps
+
+1. **Tag a document (existing vocabulary).** Pick 1–3 tags from the project's
+   controlled vocabulary — favour one lifecycle tag + one or two domain tags. The
+   vocabulary lives in the project's PRJ-layer tagging SOP (the doc that overlays
+   this one), not in a CLI command. Then write:
+   ```bash
+   af tag add  <PREFIX-ACID> <tag> [<tag> ...] --root <project-root>
+   af tag rm   <PREFIX-ACID> <tag>             --root <project-root>   # remove (replace = rm then add)
+   af tag ls                                                            # list tags already IN USE, with counts
+   af tag show <tag>                                                    # documents carrying a tag
+   ```
+   `af tag add` is idempotent and only **appends**; to fix a wrong tag, `af tag rm`
+   it (or set the full value with `af update --spec`).
+
+2. **Extend the vocabulary** when no existing tag fits:
+   - *Personal / workflow tag* (meaningful to one user: `todo`, `wip`, …) →
+     `af tag vocab add <tag>`. This registers it in the user's
+     `~/.alfred/preferences.yaml` `custom_tags`, which the vocabulary check unions
+     with the system set — no PR, no warning afterward. `af tag vocab ls` lists the
+     user's custom tags.
+   - *Shared / system tag* (meaningful to anyone filtering the corpus) → add it to
+     the project's controlled-vocabulary source (the PRJ overlay SOP and any code
+     it pins) and submit a **PR**.
+
+3. **Backfill the corpus.** To close coverage gaps across many documents, scan for
+   candidates, read each, propose tags, confirm, write, and re-scan:
+   ```bash
+   af validate --root <project-root> --warn-untagged-sops --tag-warnings detail
+   ```
+   Gate completion on the finders coming back empty — tag gaps are *warnings*, not
+   issues, so a plain `af validate` "0 issues" line does not prove coverage.
+
+4. **Verify.** `af validate --root <project-root>` reports 0 issues; `af list --tag
+   <tag> --root <project-root>` returns the document; and for a newly registered
+   personal tag, `af tag add`/`af validate` no longer warn about it.
+
+---
+
+## Examples
+
+- A new router SOP → `routing, plan`
+- A TDD workflow SOP → `tdd, implement`
+- A release SOP → `release, ship`
+- Registering a personal marker: `af tag vocab add todo` → `todo` stops warning.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-06-29 | Initial version — COR-level tagging mechanism + process | Claude Code |

--- a/src/fx_alfred/rules/COR-1003-SOP-Tag-Document.md
+++ b/src/fx_alfred/rules/COR-1003-SOP-Tag-Document.md
@@ -14,9 +14,14 @@
 The standard process for assigning **tags** to documents so they can be filtered
 with `af list --tag <tag>`. Tags are a flat, controlled vocabulary written to the
 `Tags:` metadata field (1–3 per document, distinct from `Task tags:`). This SOP
-defines the **mechanism and process** that work in every project; the controlled
-vocabulary itself is defined per project by a PRJ-layer SOP that overlays this one
-(declared with `**Overlays:** COR-1003`).
+defines the **mechanism and process** that work in every project.
+
+The *enforced* allowed set is the built-in `CONTROLLED_TAGS` (in package source
+`core/schema.py`) unioned with each user's personal `custom_tags` — the CLI does
+not read any SOP to determine it. A project records its recommended vocabulary and
+conventions in a PRJ-layer SOP that overlays this one (declared with
+`**Overlays:** COR-1003`); for the FXA project that overlay is FXA-2315, kept in
+sync with `CONTROLLED_TAGS` by a drift test.
 
 It has three sub-flows, each with a dedicated tool:
 
@@ -60,10 +65,11 @@ without a human curating every entry.
 
 ## Steps
 
-1. **Tag a document (existing vocabulary).** Pick 1–3 tags from the project's
-   controlled vocabulary — favour one lifecycle tag + one or two domain tags. The
-   vocabulary lives in the project's PRJ-layer tagging SOP (the doc that overlays
-   this one), not in a CLI command. Then write:
+1. **Tag a document (existing vocabulary).** Pick 1–3 tags from the allowed set —
+   the built-in `CONTROLLED_TAGS` plus any registered personal `custom_tags` —
+   favouring one lifecycle tag + one or two domain tags. The project's PRJ overlay
+   SOP documents the recommended vocabulary (the CLI enforces `CONTROLLED_TAGS`,
+   not the SOP text). Then write:
    ```bash
    af tag add  <PREFIX-ACID> <tag> [<tag> ...] --root <project-root>
    af tag rm   <PREFIX-ACID> <tag>             --root <project-root>   # remove (replace = rm then add)
@@ -80,8 +86,9 @@ without a human curating every entry.
      with the system set — no PR, no warning afterward. `af tag vocab ls` lists the
      user's custom tags.
    - *Shared / system tag* (meaningful to anyone filtering the corpus) → add it to
-     the project's controlled-vocabulary source (the PRJ overlay SOP and any code
-     it pins) and submit a **PR**.
+     `CONTROLLED_TAGS` in package source (`core/schema.py`) **and** the project's
+     overlay SOP, then submit a **PR**. The CLI enforces the built-in set, so a tag
+     only listed in the SOP still warns until it is in `CONTROLLED_TAGS`.
 
 3. **Backfill the corpus.** To close coverage gaps across many documents, scan for
    candidates, read each, propose tags, confirm, write, and re-scan:

--- a/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
+++ b/src/fx_alfred/rules/COR-1103-SOP-Workflow-Routing.md
@@ -97,6 +97,7 @@ like PRP, CHG, ADR, PLN, INC. Those match branches 2-6.
    ├── Promote PRJ pattern to PKG → COR-1801, then CHG/PRP as required
    ├── New SOP               → COR-1000
    ├── New reference doc     → COR-1001
+   ├── Tag / retag / make filterable → COR-1003
    └── Update existing doc   → COR-1300
 
 2. Something broken/failing/unexpected?


### PR DESCRIPTION
## Summary

Two related changes from the tag-governance review:

1. **Promote tagging governance to the COR (PKG) layer** — new `COR-1003 "Tag Document"`. The `af tag`/`af tag vocab` capability already ships in the CLI and works in every project, but the *governance SOP* only existed at the FXA PRJ layer. COR-1003 makes the tagging mechanism + process route via `af guide` in **any** project.
2. **Retag 6 of this project's SOPs** from a corpus tag-review.

## COR-1003 design

- `Disposition: optional-overlay` — COR-1003 defines the general mechanism (tag a doc / extend the vocabulary / backfill the corpus); each project pins its own controlled vocabulary via a PRJ SOP that declares `**Overlays:** COR-1003`.
- **FXA-2315** is the FXA instance — now carries `**Overlays:** COR-1003`. The binding is **machine-enforced**: `af validate` errors if an `Overlays:` target's Disposition isn't `optional-overlay`.
- COR-0000 index: added the COR-1003 row + a Change History entry, and backfilled the previously-missing **COR-1004** row.

## Retag (6 PRJ SOPs)

| SOP | before | after | why |
|---|---|---|---|
| FXA-2102 Release To PyPI | `ship` | `release, ship` | it's the release process |
| FXA-2100 Leader Mediated Dev | `workflow, implement` | `+review` | 3-reviewer panel is central |
| FXA-2127 Commit Alfred Ops | `git, ship` | `git, commit` | local-only; commit ≠ release |
| FXA-2148 / FXA-2149 Evolve-SOP/CLI | `evolution` | `+loop` | they carry `Workflow loops:` metadata |
| FXA-2309 Evolve Engine | `evolution` | `+maintain` | no loop metadata; adds a lifecycle tag |

## Verification

- `af validate` 0 issues · 1374 passed · COR-1003 parses + appears in `af list --source pkg`.
- Reviewed via FXA-2100 trinity panel — **GLM 9.85 / DeepSeek 10.0 / MiniMax 9.50**, 2 rounds, all ≥ 9.0. Round 1 caught the `inherit-only` vs `optional-overlay` governance defect (Leader arbitrated to optional-overlay per COR-0002; both dissenting reviewers conceded on re-review), a wrong `af tag ls` description, missing section rules, and an index Change-History gap — all fixed and re-verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
