### PR TITLE
fix: clean sub-step ID in branch error + valid empty-label Mermaid edge

### DIFF
--- a/src/fx_alfred/core/mermaid.py
+++ b/src/fx_alfred/core/mermaid.py
@@ -180,6 +180,9 @@ def render_mermaid(phases: list[PhaseDict]) -> str:
             from_nid = f"{_node_id(phase_idx, lp.from_step)}{_suffix_for(lp.from_step)}"
             to_nid = f"{_node_id(phase_idx, lp.to_step)}{_suffix_for(lp.to_step)}"
             cond = _sanitize_condition(lp.condition)
-            lines.append(f"  {from_nid} -. {cond} .-> {to_nid}")
+            if cond:
+                lines.append(f"  {from_nid} -. {cond} .-> {to_nid}")
+            else:
+                lines.append(f"  {from_nid} -.-> {to_nid}")
 
     return "\n".join(lines)

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -493,7 +493,7 @@ def validate_branches(
                     BranchError(
                         msg=(
                             f"Workflow branches[{i}].to[{j}]: id "
-                            f"{tgt.parent}{tgt.branch!r} parent must be "
+                            f"{tgt.parent}{tgt.branch} parent must be "
                             f"{sig.from_step + 1} (from + 1), got {tgt.parent}"
                         ),
                         branch_idx=i,

--- a/tests/test_mermaid.py
+++ b/tests/test_mermaid.py
@@ -173,6 +173,27 @@ class TestLoopBackEdge:
         assert "-." in result
         assert ".->" in result
 
+    def test_loop_empty_sanitized_condition_uses_plain_dotted_arrow(self):
+        """Condition that sanitizes empty emits an unlabeled dotted arrow."""
+        loop = LoopSignature(
+            id="retry",
+            from_step=2,
+            to_step=1,
+            max_iterations=3,
+            condition="**",
+        )
+        phases = [
+            _make_phase(
+                "COR-1602",
+                _steps("Dispatch", "Check"),
+                loops=[loop],
+            ),
+        ]
+        result = render_mermaid(phases)
+
+        assert "S1_2 -.-> S1_1" in result
+        assert "-.  .->" not in result
+
 
 # ---------------------------------------------------------------------------
 # Test 4: Gate step — diamond shape

--- a/tests/test_workflow_branches_validate.py
+++ b/tests/test_workflow_branches_validate.py
@@ -144,6 +144,20 @@ def test_branches_to_parent_must_match_from_plus_one() -> None:
     assert any("from + 1" in e.msg or "must be 3" in e.msg for e in errors)
 
 
+def test_branches_parent_mismatch_message_renders_substep_id_cleanly() -> None:
+    """Parent-mismatch error renders `3a`, not `3'a'`."""
+    body = _doc(
+        "[{from: 3, to: [{id: 3a, label: x}]}]",
+        "1. A\n2. B\n3. C\n3a. wrong parent\n",
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    message = "\n".join(e.msg for e in errors)
+    assert "id 3a parent" in message
+    assert "3'a'" not in message
+
+
 def test_branches_substep_id_malformed_raises_at_parse() -> None:
     """`3aa` rejected at PARSE time (regex \\d+[a-z], not \\d+[a-z]+)."""
     body = _doc(


### PR DESCRIPTION
## Summary

- `workflow.py` `validate_branches`: remove the stray `!r` in the Rule-3 parent-mismatch message so it renders `id 3a parent must be 4`, not ``id 3'a' parent must be 4``.
- `mermaid.py` `render_mermaid`: when a loop condition sanitizes to empty (e.g. `**`), emit the plain dotted arrow `-.->` instead of the invalid labeled form `-.  .->` (Mermaid's `-. text .->` requires non-empty text).

## Why

Both bugs were found in the 2026-07-02 full-repo review and tracked in #278: a garbled validation message misleads SOP authors, and the empty-label edge makes `af plan --graph --graph-format=mermaid` output fail to render.

## Implementation notes

Implemented by a Codex worker (`codex exec`, GPT-5.5) under COR-1619 orchestrator/worker dispatch, TDD per COR-1500: both regression tests were written first and confirmed RED against the unfixed code, then the two one-line fixes turned them GREEN.

## Test plan

- `tests/test_workflow_branches_validate.py::test_branches_parent_mismatch_message_renders_substep_id_cleanly` (new)
- `tests/test_mermaid.py::TestLoopBackEdge::test_loop_empty_sanitized_condition_uses_plain_dotted_arrow` (new)
- `.venv/bin/pytest -q` — 1376 passed, 2 skipped (independently re-verified by the orchestrator)
- `.venv/bin/ruff check .` / `.venv/bin/ruff format --check .` / `.venv/bin/pyright src/` — all clean

## Scope hints

Only the two message/rendering call sites named in #278 plus their regression tests are in scope. No refactoring of `validate_branches` or `render_mermaid` beyond the two lines; broader graph-rendering cleanups are tracked separately (#277, #279).

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)