### PR TITLE
fix: preserve non-field lines in the metadata block through parse/render

### DIFF
--- a/src/fx_alfred/core/parser.py
+++ b/src/fx_alfred/core/parser.py
@@ -24,6 +24,7 @@ class MetadataField:
     prefix_style: str  # "bold" for "**Key:** value", "list" for "- **Key:** value"
     raw_line: str  # original line for round-trip fidelity
     dirty: bool = False  # True when value has been modified (forces re-render)
+    leading_lines: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -61,6 +62,7 @@ class ParsedDocument:
     blank_after_metadata: int = (
         0  # number of blank lines between last field and first ---
     )
+    trailing_metadata_lines: list[str] = field(default_factory=list)
     body: str = (
         ""  # everything between first --- and Change History (inclusive of separators)
     )
@@ -124,47 +126,49 @@ def parse_metadata(content: str) -> ParsedDocument:
 
     # Parse metadata fields between H1 and first ---
     metadata_fields: list[MetadataField] = []
-    blank_lines_before_sep: list[str] = []
+    pending_leading_lines: list[str] = []
 
     for i in range(first_non_blank, sep_index):
         line = lines[i]
         stripped = line.strip()
-        if not stripped:
-            blank_lines_before_sep.append(line)
-            continue
 
         list_match = _LIST_FIELD.match(stripped)
         bold_match = _BOLD_FIELD.match(stripped)
 
         if list_match:
-            # Drain any accumulated blank lines (they were between fields)
-            blank_lines_before_sep.clear()
             metadata_fields.append(
                 MetadataField(
                     key=list_match.group(1),
                     value=list_match.group(2),
                     prefix_style="list",
                     raw_line=line,
+                    leading_lines=pending_leading_lines,
                 )
             )
+            pending_leading_lines = []
         elif bold_match:
-            blank_lines_before_sep.clear()
             metadata_fields.append(
                 MetadataField(
                     key=bold_match.group(1),
                     value=bold_match.group(2),
                     prefix_style="bold",
                     raw_line=line,
+                    leading_lines=pending_leading_lines,
                 )
             )
+            pending_leading_lines = []
         else:
-            # Non-blank, non-field line in metadata block — skip
-            blank_lines_before_sep.clear()
+            pending_leading_lines.append(line)
 
     if not metadata_fields:
         raise MalformedDocumentError("No metadata fields found in document")
 
-    blank_after_metadata_count = len(blank_lines_before_sep)
+    trailing_metadata_lines = pending_leading_lines
+    blank_after_metadata_count = 0
+    for line in reversed(trailing_metadata_lines):
+        if line.strip():
+            break
+        blank_after_metadata_count += 1
 
     # Everything from first --- onward is body + change history
     rest_lines = lines[sep_index:]
@@ -184,6 +188,7 @@ def parse_metadata(content: str) -> ParsedDocument:
             metadata_fields=metadata_fields,
             blank_after_h1=blank_after_h1_count,
             blank_after_metadata=blank_after_metadata_count,
+            trailing_metadata_lines=trailing_metadata_lines,
             body=rest_text,
             history_header="",
             history_rows=[],
@@ -213,6 +218,7 @@ def parse_metadata(content: str) -> ParsedDocument:
             metadata_fields=metadata_fields,
             blank_after_h1=blank_after_h1_count,
             blank_after_metadata=blank_after_metadata_count,
+            trailing_metadata_lines=trailing_metadata_lines,
             body=rest_text,
             history_header="",
             history_rows=[],
@@ -253,6 +259,7 @@ def parse_metadata(content: str) -> ParsedDocument:
         metadata_fields=metadata_fields,
         blank_after_h1=blank_after_h1_count,
         blank_after_metadata=blank_after_metadata_count,
+        trailing_metadata_lines=trailing_metadata_lines,
         body=body,
         history_header=history_header,
         history_rows=rows,
@@ -278,6 +285,7 @@ def render_document(parsed: ParsedDocument) -> str:
 
     # Metadata fields — use raw_line for unmodified fields, regenerate for dirty ones
     for mf in parsed.metadata_fields:
+        lines.extend(mf.leading_lines)
         if mf.dirty:
             if mf.prefix_style == "list":
                 lines.append(f"- **{mf.key}:** {mf.value}")
@@ -286,9 +294,12 @@ def render_document(parsed: ParsedDocument) -> str:
         else:
             lines.append(mf.raw_line)
 
-    # Blank lines between metadata and separator
-    for _ in range(parsed.blank_after_metadata):
-        lines.append("")
+    if parsed.trailing_metadata_lines:
+        lines.extend(parsed.trailing_metadata_lines)
+    else:
+        # Blank lines between metadata and separator
+        for _ in range(parsed.blank_after_metadata):
+            lines.append("")
 
     # Body (starts with first --- separator)
     if parsed.body:

--- a/tests/test_fmt_cmd.py
+++ b/tests/test_fmt_cmd.py
@@ -597,6 +597,38 @@ def test_fmt_idempotent(tmp_path):
     assert "All documents already formatted" in result2.output
 
 
+def test_fmt_write_preserves_metadata_comment_and_blank_lines_when_reordering(tmp_path):
+    """Metadata leading lines travel with their field through fmt reordering."""
+    doc = (
+        "# REF-2114: Metadata Comment\n\n"
+        "**Status:** Active\n"
+        "<!-- reviewer note -->\n"
+        "\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2026-06-28\n"
+        "**Last reviewed:** 2026-06-28\n"
+        "\n"
+        "---\n"
+    )
+    project = _make_project(
+        tmp_path,
+        ("TST-2114-REF-Metadata-Comment.md", doc),
+    )
+    path = project / "rules" / "TST-2114-REF-Metadata-Comment.md"
+    runner = CliRunner()
+
+    result1 = runner.invoke(cli, ["fmt", "--root", str(project), "--write", "TST-2114"])
+    assert result1.exit_code == 0
+    content1 = path.read_text()
+    assert "<!-- reviewer note -->\n\n**Applies to:** ALF project" in content1
+
+    result2 = runner.invoke(cli, ["fmt", "--root", str(project), "--write", "TST-2114"])
+    assert result2.exit_code == 0
+    content2 = path.read_text()
+    assert content2 == content1
+    assert "All documents already formatted" in result2.output
+
+
 # ── Fence-aware ───────────────────────────────────────────────────────────────
 
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -258,6 +258,63 @@ def test_parse_metadata_stores_raw_line_on_history_rows():
     )
 
 
+# --- Metadata-block raw line preservation (issue #261) ---
+
+
+def test_metadata_roundtrip_preserves_comment_between_fields():
+    content = (
+        "# REF-9002: Test\n\n"
+        "**Applies to:** Test\n"
+        "<!-- reviewer note -->\n"
+        "**Status:** Active\n"
+        "\n---\n"
+    )
+
+    parsed = parse_metadata(content)
+
+    assert render_document(parsed) == content
+
+
+def test_metadata_roundtrip_preserves_blank_line_between_fields():
+    content = "# REF-9003: Test\n\n**Applies to:** Test\n\n**Status:** Active\n\n---\n"
+
+    parsed = parse_metadata(content)
+
+    assert render_document(parsed) == content
+
+
+def test_metadata_roundtrip_preserves_comment_and_blanks_after_last_field():
+    content = (
+        "# REF-9004: Test\n\n"
+        "**Applies to:** Test\n"
+        "**Status:** Active\n"
+        "\n"
+        "<!-- reviewer note -->\n"
+        "\n"
+        "---\n"
+    )
+
+    parsed = parse_metadata(content)
+
+    assert render_document(parsed) == content
+
+
+def test_metadata_roundtrip_preserves_consecutive_comments_before_field():
+    content = (
+        "# REF-9005: Test\n\n"
+        "**Applies to:** Test\n"
+        "<!-- note a -->\n"
+        "<!-- note b -->\n"
+        "\n"
+        "**Status:** Active\n"
+        "\n---\n"
+    )
+
+    parsed = parse_metadata(content)
+
+    assert render_document(parsed) == content
+
+
 def test_parse_metadata_history_row_retains_all_cells():
     content = (
         "# REF-9002: Wide History\n\n"

--- a/tests/test_tag_cmd.py
+++ b/tests/test_tag_cmd.py
@@ -573,6 +573,35 @@ def test_tag_add_creates_tags_field_when_absent(write_project):
     assert "**Tags:** xtag-new" in content
 
 
+def test_tag_add_preserves_metadata_comment_attached_to_reordered_field(tmp_path):
+    """Creating Tags reorders metadata without dropping a comment before a field."""
+    rules = tmp_path / "rules"
+    rules.mkdir()
+    path = rules / "ALF-7001-REF-Metadata-Comment.md"
+    path.write_text(
+        "# REF-7001: Metadata Comment\n\n"
+        "**Status:** Active\n"
+        "<!-- reviewer note -->\n"
+        "**Applies to:** ALF project\n"
+        "**Last updated:** 2026-06-28\n"
+        "**Last reviewed:** 2026-06-28\n\n"
+        "---\n",
+        encoding="utf-8",
+    )
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["tag", "add", "ALF-7001", "maintain", "--root", str(tmp_path)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    content = path.read_text(encoding="utf-8")
+    assert "<!-- reviewer note -->\n**Applies to:** ALF project" in content
+    assert content.index("<!-- reviewer note -->") < content.index("**Applies to:**")
+
+
 def test_tag_add_and_validate_stays_clean(write_project):
     """After af tag add, af validate ALF-6001 reports 0 issues (exit 0)."""
     runner = CliRunner()

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -957,6 +957,37 @@ def test_update_roundtrip_preserves_trailing_newline(tmp_path, monkeypatch):
     assert content.endswith("\n")
 
 
+def test_update_status_preserves_metadata_comment(tmp_path, monkeypatch):
+    """Updating Status must not erase non-field lines in the metadata block."""
+    doc = (
+        "# TST-2100: Test Document\n"
+        "\n"
+        "**Applies to:** All projects\n"
+        "**Status:** Draft\n"
+        "<!-- reviewer note -->\n"
+        "**Last updated:** 2026-01-01\n"
+        "\n"
+        "---\n"
+        "\n"
+        "## What Is It?\n"
+        "\n"
+        "A test document body.\n"
+    )
+    project = _make_project(tmp_path, doc)
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--status", "Active"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    content = (project / "rules" / "TST-2100-SOP-Test-Document.md").read_text()
+    assert "<!-- reviewer note -->\n**Last updated:**" in content
+
+
 # ── Fix 3: Rename H1 uses type_code, not prefix ────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- `parse_metadata` now stores raw unrecognized metadata-block lines (HTML comments, interior blank lines) instead of dropping them: `MetadataField.leading_lines` carries lines that precede a field (traveling with it through fmt/tag metadata reorder), and `ParsedDocument.trailing_metadata_lines` preserves lines between the last field and the `---` separator (`blank_after_metadata` stays derived for backward compatibility).
- `render_document` re-emits those lines, making parse → render byte-identical.
- 7 regression tests: four pure round-trips (comment between fields, blank line between fields, trailing comment+blanks, consecutive comments before a field) and three command paths (`af update --status`, `af tag add` reorder, `af fmt --write` reorder + idempotence).

## Why

#261: any write command (`af update`, `af tag add/rm`, `af fmt --write`) permanently erased comments and blank lines inside the metadata block even when touching an unrelated field — silent data loss contradicting the parser's raw-line-fidelity design.

## Implementation & review

- Implemented by a Codex worker (`codex exec`, GPT-5.5) under COR-1619 dispatch, TDD per COR-1500 (6 RED tests confirmed failing before the fix; orchestrator added a 7th per review advisory).
- Independently re-verified by the orchestrator: 1392 passed / 2 skipped, ruff, ruff format, pyright all clean; original #261 reproduction now round-trips byte-identically.
- COR-1602 triad review (COR-1610 rubric): **GLM-5.2 PASS 9.5**, **DeepSeek PASS 9.1**, **MiniMax M3 PASS 9.5** (recovered from an initial degenerate droid response via the documented `-f` prompt-file + fresh-session workaround; provenance in review thread). Full triad PASS, zero blocking findings.
- Convergent advisory (both reviewers, explicitly non-blocking): `trailing_metadata_lines` / `blank_after_metadata` dual representation kept for compatibility; a future cleanup may fold them. DeepSeek's advisory test gap (consecutive comments) was addressed in this PR.

## Scope hints

Only the metadata-block parse/render path and its regression tests are in scope. The two near-duplicate metadata reorder loops (`fmt_cmd` / `tag_cmd`) are deliberately untouched — consolidation is #279. History-row alias design is a separate follow-up recorded on PR #281.

Closes #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
