### PR TITLE
docs: promote sandboxed worker CLI dispatch (COR-1628) + loop config starter template (COR-1629)

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -230,6 +230,7 @@
 | 2317 | SOP | Add A Tag On Request | Active |
 | 2318 | SOP | Backfill Tags Across The Corpus | Active |
 | 2319 | CHG | Preserve Wide Change History Rows | Completed |
+| 2320 | CHG | Promote Sandboxed Worker CLI Dispatch To COR Layer | Completed |
 
 ---
 

--- a/rules/FXA-2320-CHG-Promote-Sandboxed-Worker-CLI-Dispatch-To-COR-Layer.md
+++ b/rules/FXA-2320-CHG-Promote-Sandboxed-Worker-CLI-Dispatch-To-COR-Layer.md
@@ -1,0 +1,58 @@
+# CHG-2320: Promote Sandboxed Worker CLI Dispatch To COR Layer
+
+**Applies to:** FXA project
+**Last updated:** 2026-07-03
+**Last reviewed:** 2026-07-03
+**Status:** Completed
+**Date:** 2026-07-03
+**Requested by:** Frank Xu (session request: make the codex-worker pipeline reusable across all GitHub projects)
+**Priority:** Medium
+**Change Type:** Normal
+**Targets:** src/fx_alfred/rules/COR-1628-SOP-Sandboxed-Worker-CLI-Dispatch.md (new), src/fx_alfred/rules/COR-1629-REF-Loop-Config-Starter-Template.md (new), src/fx_alfred/rules/COR-0000-REF-Document-Index.md
+
+---
+
+## What
+
+Two new PKG-layer documents promoting the validated codex-worker dispatch practice from session memory to the shared COR layer:
+
+- **COR-1628 SOP — Sandboxed Worker CLI Dispatch**: the dispatch contract for implementation workers running as external one-shot sandboxed CLIs (reference: `codex exec`). Invocation contract (6 rules), seven-block task-brief template, sandbox scope clause, orchestrator verification checklist, failure-mode table, guard rails.
+- **COR-1629 REF — Loop Config Starter Template**: a copy-paste blank instantiation form for COR-1622 with the COR-1628 worker lane and COR-1507 two-worker options pre-wired. Normative definitions stay in COR-1622; the template defers to it on conflict.
+
+
+## Why
+
+The alfred #282/#283 dispatches proved the lane works (first-try 2/2, triad 9.1–9.5, ~⅕–⅓ orchestrator token cost) but every hard-won operational rule lived only in one machine's session memory. Concretely observed and unrecoverable by other adopters without promotion:
+
+- `codex exec` hangs forever on inherited non-tty stdin (burned a 10-minute timeout)
+- foreground shells kill real-length runs
+- the sandboxed worker read the repo's orchestrator-facing CLAUDE.md (via the AGENTS.md symlink) and spent 3+ minutes retrying trinity review against a network it does not have
+- COR-1622 instantiation currently requires reading a 300-line schema doc with only a historical worked example as guidance
+
+PKG layer is the correct home: it ships with `pip install fx-alfred`, so every repo running `af` inherits both docs. Project-specific values (identities, providers) remain per-project via COR-1622 instantiation — the same separation COR-1622 itself established (its Why cites the identical promotion rationale from TRN-1008).
+
+
+## Impact Analysis
+
+- **Systems affected:** PKG rules corpus only (two new docs + COR-0000 index rows). No code paths change; `af` behavior identical.
+- **Consumers:** COR-1628/1629 are `optional-overlay` — adopters opt in by pointing `<worker-agent>` at a sandboxed CLI lane or using the starter template. Non-adopters see two extra `af list` rows.
+- **No cascade:** COR-1617/1619/1622 are referenced, not edited. COR-1628 specializes COR-1619's WORKER leaves without amending them.
+- **Rollback plan:** delete the two COR docs, revert the COR-0000 rows, revert this CHG to Rolled Back, `af index` to refresh the PRJ index.
+
+
+## Implementation Plan
+
+1. Author COR-1628 following COR-1619's section conventions; content sourced from the verified session evidence (alfred #282/#283 logs).
+2. Author COR-1629 with the complete COR-1622 key list (verified against the schema doc at authoring time).
+3. Add COR-0000 index rows + change-history entry.
+4. Validate: full pytest (docs drift/format tests), `af validate`, `af fmt --check` on the new docs.
+5. Triad review (COR-1602, COR-1609 rubric for this CHG + doc quality), then PR.
+
+---
+
+## Change History
+
+| Date       | Change                                                   | By          |
+|------------|----------------------------------------------------------|-------------|
+| 2026-07-03 | Initial version                                          | Claude Code |
+| 2026-07-03 | Implemented: COR-1628 + COR-1629 authored, index updated | Claude Code |

--- a/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
+++ b/src/fx_alfred/rules/COR-0000-REF-Document-Index.md
@@ -1,7 +1,7 @@
 # REF-0000: Document Index
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-06-26
+**Last updated:** 2026-07-03
 **Last reviewed:** 2026-05-09
 **Status:** Active
 **Disposition:** inherit-only
@@ -82,6 +82,8 @@ A reference index of all documents in the COR system.
 | 1625 | SOP | Loop — L2 Assisted + Gated |
 | 1626 | SOP | Loop — L3 Unattended (Draft) |
 | 1627 | SOP | Loop PDCA Run Audit |
+| 1628 | SOP | Sandboxed Worker CLI Dispatch |
+| 1629 | REF | Loop Config Starter Template |
 | 1700 | SOP | Initialize Project |
 | 1701 | SOP | Archive Project |
 | 1702 | SOP | Sync Project |
@@ -119,3 +121,4 @@ A reference index of all documents in the COR system.
 | 2026-06-19 | Added COR-1625 (Loop — L2 Assisted + Gated) and COR-1626 (Loop — L3 Unattended, Status: Draft) — completing the Loop autonomy ladder. | Claude Code |
 | 2026-06-26 | Added COR-1627 (Loop PDCA Run Audit) — report-only PDCA retrospective for L1/L2 runs. | Claude Code |
 | 2026-06-29 | Added COR-1003 (Tag Document) — COR-level tagging mechanism + process (optional-overlay); also backfilled the missing COR-1004 (Create Routing Document) index row. | Claude Code |
+| 2026-07-03 | Added COR-1628 (Sandboxed Worker CLI Dispatch) + COR-1629 (Loop Config Starter Template) — promoted from alfred #282/#283 codex-lane practice. | Claude Code |

--- a/src/fx_alfred/rules/COR-1628-SOP-Sandboxed-Worker-CLI-Dispatch.md
+++ b/src/fx_alfred/rules/COR-1628-SOP-Sandboxed-Worker-CLI-Dispatch.md
@@ -48,7 +48,8 @@ Six rules, each traced to an observed failure:
 Reference invocation (codex; flags verified on codex-cli 0.142.x — re-verify against your installed version):
 
 ```bash
-codex exec --skip-git-repo-check --sandbox workspace-write -C <repo> \
+codex exec --skip-git-repo-check --sandbox workspace-write \
+  --ask-for-approval never -C <repo> \
   -m <model> -c model_reasoning_effort=<medium|high> \
   "$(cat brief.md)" </dev/null > worker-log.txt 2>&1 &
 ```
@@ -118,6 +119,7 @@ Per COR-1619 §Verification, specialized:
 |---------|-------|-----|
 | CLI silent, "reading additional input from stdin" | inherited non-tty stdin | `</dev/null` (Invocation rule 1) |
 | Run killed at shell timeout mid-task | foreground execution cap | background + log file (rule 2) |
+| Background run stalls silently; log ends at a command the model wants to run | approval policy `on-request`/`untrusted` pauses for a confirmation no UI can deliver | pin `--ask-for-approval never` in the invocation |
 | Worker wastes minutes on ConnectionRefused, retrying external services | repo instructions mandate networked steps | Sandbox Scope Clause in brief + repo section (rule 5) |
 | Worker report claims green but diff touches undeclared files | brief lacked out-of-scope block | seven-block template; reject at scope check |
 | Report unusable (no RED evidence, no file list) | brief lacked report format | Constraints block mandates report shape |

--- a/src/fx_alfred/rules/COR-1628-SOP-Sandboxed-Worker-CLI-Dispatch.md
+++ b/src/fx_alfred/rules/COR-1628-SOP-Sandboxed-Worker-CLI-Dispatch.md
@@ -1,0 +1,144 @@
+# SOP-1628: Sandboxed Worker CLI Dispatch
+
+**Applies to:** All projects adopting COR-1617/COR-1619 whose `<worker-agent>` is an external one-shot CLI running in a sandbox (reference implementation: `codex exec`)
+**Last updated:** 2026-07-03
+**Last reviewed:** 2026-07-03
+**Status:** Active
+**Tags:** workflow
+**Related:** COR-1619 (worker dispatch contract — this SOP specializes its WORKER leaves), COR-1622 (parameter schema — `<worker-agent>`, `<worker-min-loc>`, `<test-writer-worker-agent>`), COR-1500 (TDD protocol the task brief enforces), COR-1507 (two-worker TDD split), COR-1629 (loop-config starter template)
+**Disposition:** optional-overlay
+
+---
+
+## What Is It?
+
+The dispatch contract for implementation workers that run as **external one-shot CLI processes inside a sandbox** — no network, no session UI, one prompt in, one working tree + report out. The orchestrator drives the CLI directly from its own shell (no intermediary subagent), then independently verifies the result before anything touches git history.
+
+This specializes COR-1619's Worker Dispatch Contract for the sandboxed-CLI case. COR-1619 decides *whether* to dispatch; this SOP defines *how* when the worker is a sandboxed CLI.
+
+## Why
+
+Validated on two dispatches (alfred #282 two-line fix, alfred #283 parser design work): both first-try correct, TDD-compliant with RED evidence, zero scope violations; the #283 diff scored 9.5/9.5/9.1 in triad review. Orchestrator-side token cost was roughly ⅕–⅓ of direct implementation.
+
+Every observed failure was in the **orchestration layer**, not implementation quality — and each is mechanical to prevent (see §Failure Modes). Without this SOP each adopter rediscovers them one burned timeout at a time.
+
+## When to Use
+
+- COR-1619's decision tree routed to a WORKER leaf, and `<worker-agent>` is a sandboxed CLI
+- The task is fully specifiable up front: named files, acceptance criteria, local verification commands
+- The change exceeds `<worker-min-loc>` or carries a design decision worth an isolated implementer
+
+## When NOT to Use
+
+- COR-1619's orchestrator-direct leaves (O1–O4), e.g. trivial edits or generator re-runs — cheaper done directly
+- Tasks that require network, git history mutation, GitHub state, or interactive input — the sandbox cannot do these and the worker must never try
+- Review of the worker's own output (see Guard Rails)
+
+## Invocation Contract
+
+Six rules, each traced to an observed failure:
+
+1. **Close stdin.** Append `</dev/null`. With inherited non-tty stdin the CLI blocks on "reading additional input" forever.
+2. **Always run in the background** with output redirected to a log file. Foreground shells cap execution time below real task duration; the log file keeps the worker transcript out of the orchestrator's context. Read only the log tail.
+3. **Pin the working directory** with the CLI's project-dir flag (`-C <repo>` for codex) and grant write access only to the working tree (`--sandbox workspace-write`).
+4. **Scale reasoning effort to task class**: `medium` for mechanical fixes with named lines; `high` for anything with a design decision (this SOP deliberately normalizes to these two tiers even where the CLI offers more). Brief quality dominates the effort knob — invest in the brief first.
+5. **Declare the sandbox scope in the brief** (see §Sandbox Scope Clause). Repo instruction files are written for networked orchestrators; a sandboxed worker following them stalls on unreachable services.
+6. **The orchestrator owns everything outside the working tree**: commit, push, PR, CI polling, review dispatch, identity checks. The brief says "do NOT commit" and the worker leaves changes uncommitted.
+
+Reference invocation (codex; flags verified on codex-cli 0.142.x — re-verify against your installed version):
+
+```bash
+codex exec --skip-git-repo-check --sandbox workspace-write -C <repo> \
+  -m <model> -c model_reasoning_effort=<medium|high> \
+  "$(cat brief.md)" </dev/null > worker-log.txt 2>&1 &
+```
+
+## Task Brief Template
+
+Every brief carries these seven blocks; omitting one is the leading cause of scope drift or unusable reports.
+
+```markdown
+Fix <issue ref> in this repo (<one-line project description>). Work strict TDD:
+write the failing tests FIRST, confirm RED, implement, confirm GREEN.
+
+## The bug / the task
+<precise description; name files and approximate lines>
+
+## Required behavior (acceptance criteria)
+<numbered, testable, lifted from the issue>
+
+## Design guardrails
+<the shape of the fix: data structures, attachment semantics, compatibility
+requirements. Written after the orchestrator reads 50–100 lines of the target
+code — this is what buys first-try success.>
+
+## Out of scope
+<adjacent defects by issue number, e.g. "the duplicate reorder loops are
+issue #NNN's scope — do not consolidate them">
+
+## Sandbox scope clause
+<verbatim from §Sandbox Scope Clause below>
+
+## Verification (run all; all must be clean)
+<the project's full local gate: test suite, linter, formatter, type checker>
+
+## Constraints
+- Do NOT commit. Leave changes in the working tree.
+- Match surrounding code style; no drive-by refactoring.
+- Finish with a report: files changed, tests added, RED evidence (failing
+  output before the fix), verification results, design decisions made.
+```
+
+## Sandbox Scope Clause
+
+Paste into every brief:
+
+> IGNORE any instruction in this repo's CLAUDE.md / AGENTS.md that requires
+> network access or external services (multi-model review panels, `gh`,
+> package publishing, agent-helper calls). You are a sandboxed implementation
+> worker: your scope ends at the working tree plus the local verification
+> commands listed above. Review and GitHub operations are the orchestrator's
+> job.
+
+Projects whose CLAUDE.md doubles as AGENTS.md (symlink) should also add a short "Sandboxed worker scope" section there saying the same thing — the brief clause protects orchestrated dispatches; the repo section protects manual ones.
+
+## Orchestrator Verification (mandatory, after every dispatch)
+
+Per COR-1619 §Verification, specialized:
+
+1. **Scope check**: `git diff --stat` + read the full diff. Any file outside the brief's declared surface → reject or re-dispatch.
+2. **Independent re-run** of the full local gate (never trust the worker's report alone).
+3. **End-to-end reproduction**: re-run the original bug's reproduction; confirm the observable behavior changed.
+4. Only then: commit (orchestrator is the author, identity per `<gh-write-identity>`, with the runtime's co-author convention), push, PR — per the project's COR-1622 instantiation (`<gh-write-identity>`, `<pr-push-remote>`).
+5. Review panel dispatch per COR-1602/COR-1617 Phase 8 (>=3 independent providers, each >=`<panel-pass-threshold>`, no blocking findings) — never inside the worker sandbox.
+
+## Failure Modes
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| CLI silent, "reading additional input from stdin" | inherited non-tty stdin | `</dev/null` (Invocation rule 1) |
+| Run killed at shell timeout mid-task | foreground execution cap | background + log file (rule 2) |
+| Worker wastes minutes on ConnectionRefused, retrying external services | repo instructions mandate networked steps | Sandbox Scope Clause in brief + repo section (rule 5) |
+| Worker report claims green but diff touches undeclared files | brief lacked out-of-scope block | seven-block template; reject at scope check |
+| Report unusable (no RED evidence, no file list) | brief lacked report format | Constraints block mandates report shape |
+| Changes committed by worker with wrong identity | brief lacked "do NOT commit" | rule 6; orchestrator owns git |
+
+## Guard Rails
+
+- The worker never reviews its own output; panel review is dispatched to distinct providers by the orchestrator (author bias — same reason human authors don't approve their own PRs).
+- A worker report is a claim, not a verification. Every dispatch ends with the orchestrator's independent gate re-run.
+- When `<test-writer-worker-agent>` is set (COR-1507), the RED brief and GREEN brief go to distinct instances; the GREEN brief forbids editing tests.
+- Provider quirks discovered during dispatch (degenerate responses, session bugs) belong in the project's calibration notes, not silently worked around.
+
+## Examples
+
+- alfred #282: two one-line output fixes + 2 regression tests, effort=medium, first-try, merged.
+- alfred #283: metadata-block round-trip preservation (new dataclass field + render path), effort=high, design guardrails in brief, first-try, triad 9.5/9.5/9.1, zero blocking.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-07-03 | Initial version — promoted from alfred session practice (#282/#283 dispatches) | Claude Code |

--- a/src/fx_alfred/rules/COR-1628-SOP-Sandboxed-Worker-CLI-Dispatch.md
+++ b/src/fx_alfred/rules/COR-1628-SOP-Sandboxed-Worker-CLI-Dispatch.md
@@ -40,7 +40,7 @@ Six rules, each traced to an observed failure:
 
 1. **Close stdin.** Append `</dev/null`. With inherited non-tty stdin the CLI blocks on "reading additional input" forever.
 2. **Always run in the background** with output redirected to a log file. Foreground shells cap execution time below real task duration; the log file keeps the worker transcript out of the orchestrator's context. Read only the log tail.
-3. **Pin the working directory** with the CLI's project-dir flag (`-C <repo>` for codex) and grant write access only to the working tree (`--sandbox workspace-write`).
+3. **Pin the working directory** with the CLI's project-dir flag (`-C <local-repo-dir>` for codex; this is the local checkout path — NOT COR-1622's `<repo>`, which is the GitHub `owner/name`) and grant write access only to the working tree (`--sandbox workspace-write`).
 4. **Scale reasoning effort to task class**: `medium` for mechanical fixes with named lines; `high` for anything with a design decision (this SOP deliberately normalizes to these two tiers even where the CLI offers more). Brief quality dominates the effort knob — invest in the brief first.
 5. **Declare the sandbox scope in the brief** (see §Sandbox Scope Clause). Repo instruction files are written for networked orchestrators; a sandboxed worker following them stalls on unreachable services.
 6. **The orchestrator owns everything outside the working tree**: commit, push, PR, CI polling, review dispatch, identity checks. The brief says "do NOT commit" and the worker leaves changes uncommitted.
@@ -49,7 +49,7 @@ Reference invocation (codex; flags verified on codex-cli 0.142.x — re-verify a
 
 ```bash
 codex exec --skip-git-repo-check --sandbox workspace-write \
-  --ask-for-approval never -C <repo> \
+  --ask-for-approval never -C <local-repo-dir> \
   -m <model> -c model_reasoning_effort=<medium|high> \
   "$(cat brief.md)" </dev/null > worker-log.txt 2>&1 &
 ```

--- a/src/fx_alfred/rules/COR-1629-REF-Loop-Config-Starter-Template.md
+++ b/src/fx_alfred/rules/COR-1629-REF-Loop-Config-Starter-Template.md
@@ -1,0 +1,109 @@
+# REF-1629: Loop Config Starter Template
+
+**Applies to:** Any project adopting the COR-1617 Multi-Agent Workflow Loop
+**Last updated:** 2026-07-03
+**Last reviewed:** 2026-07-03
+**Status:** Active
+**Tags:** workflow
+**Related:** COR-1622 (parameter schema — normative key definitions), COR-1617 (umbrella SOP), COR-1628 (sandboxed worker CLI lane), COR-1507 (two-worker TDD)
+**Disposition:** optional-overlay
+
+---
+
+## What Is It?
+
+A copy-paste starter for the PRJ-layer instantiation document that COR-1622 requires of every adopting project. COR-1622 defines the keys normatively and shows a worked example with one project's historical values; this REF is the blank form: every key, a placeholder, and a short prompt for what to put there — with the sandboxed-worker (COR-1628) and two-worker-TDD (COR-1507) options pre-wired as commented choices.
+
+Time to instantiate a new repo: about ten minutes with `af create`.
+
+## How to Use
+
+1. `af create REF --prefix <PRJ-PREFIX> --area workflow --title "Multi-Agent Loop Configuration" --layer project`
+2. Paste the template below into the created document; replace every `⟨…⟩` placeholder.
+3. Delete the option comments you did not take.
+4. `af validate --root .` and reference the doc's ACID from your project's routing doc.
+
+Key definitions, valid enums, and defaults are normative in COR-1622 — when this template and COR-1622 disagree, COR-1622 wins.
+
+## Template
+
+```markdown
+## Identity & Repo
+
+| Key | Value |
+|-----|-------|
+| `<repo>` | ⟨owner/name⟩ |
+| `<repo-owner>` | ⟨owner⟩ |
+| `<repo-trusted-reactor-list>` | [⟨owner⟩] |
+| `<gh-write-identity>` | ⟨gh account for all public writes; verify via gh auth status⟩ |
+| `<pr-push-remote>` | ⟨origin for single-remote repos; fork name otherwise; default: fork⟩ |
+
+## Intake
+
+| Key | Value |
+|-----|-------|
+| `<consent-signal>` | rocket ⟨default; enum per COR-1622: rocket, +1, heart, hooray, eyes⟩ |
+| `<intake-quality-mode>` | ⟨default: 1FA; 2FA if an intake bot applies quality labels⟩ |
+| `<intake-quality-label>` | ⟨unset, or e.g. blueprint-ready⟩ |
+| `<intake-quality-applier-set>` | ⟨unset, or [bot-login, owner]⟩ |
+
+## Review Panel
+
+| Key | Value |
+|-----|-------|
+| `<panel-providers>` | ⟨e.g. [glm, deepseek, minimax]; ≥3 viable verdicts required⟩ |
+| `<weights-doc>` | ⟨scalar ACID, or map {CHG: …, ADR: …, RFC: …, inline-PR-body: …}⟩ |
+| `<spec-format>` | ⟨default: CHG; or ADR / RFC / inline-PR-body⟩ |
+| `<panel-pass-threshold>` | 9.0 |
+
+## Workers
+
+| Key | Value |
+|-----|-------|
+| `<worker-agent>` | ⟨option A: subagent worker, e.g. "trinity-glm via droid exec"⟩ |
+|  | ⟨option B: sandboxed CLI per COR-1628, e.g. "codex exec (COR-1628 lane)" — brief template, invocation contract, and verification checklist in COR-1628⟩ |
+| `<worker-min-loc>` | 30 |
+| `<test-writer-worker-agent>` | ⟨unset = two-worker split OFF; set to a different model or a verified-fresh :instance suffix to enable COR-1507, e.g. "trinity-glm:writer"⟩ |
+
+## Convergence & Retry
+
+| Key | Value |
+|-----|-------|
+| `<max-r-count>` | 10 |
+| `<max-r-count-extension>` | 3 |
+| `<convergence-severity>` | advisory |
+| `<cli-retry-attempts>` | 3 |
+| `<cli-retry-backoff-seconds>` | 600 |
+| `<cli-retry-on-failure>` | ⟨default: pause-and-ask; or mark-non-viable / abort-loop⟩ |
+
+## Bots & Readiness
+
+| Key | Value |
+|-----|-------|
+| `<bot-actors>` | ⟨e.g. [chatgpt-codex-connector[bot]]; [] if none⟩ |
+| `<required-check-policy>` | branch-protection-required-or-all-statusCheckRollup |
+| `<review-decision-policy>` | APPROVED_OR_NULL |
+| `<merge-state-policy>` | CLEAN |
+| `<human-gate-owner>` | ⟨default: repo-owner; change only if delegated⟩ |
+
+## Runtime
+
+| Key | Value |
+|-----|-------|
+| `<wakeup-tool>` | ScheduleWakeup |
+| `<idle-cap>` | 12 |
+| `<merge-watch-cap>` | 24 |
+```
+
+## Recommended Repo Additions (non-loop)
+
+- **CLAUDE.md "Sandboxed worker scope" section** (if `<worker-agent>` is a COR-1628 lane and AGENTS.md symlinks to CLAUDE.md): the clause text is in COR-1628 §Sandbox Scope Clause.
+- **Provider calibration notes**: known CLI quirks (degenerate responses, retry recipes) — keep in a project or user-level doc the orchestrator reads before writing worker prompts.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-07-03 | Initial version — extracted from FXA-2276 instantiation experience + COR-1628 lane | Claude Code |

--- a/src/fx_alfred/rules/COR-1629-REF-Loop-Config-Starter-Template.md
+++ b/src/fx_alfred/rules/COR-1629-REF-Loop-Config-Starter-Template.md
@@ -60,8 +60,7 @@ Key definitions, valid enums, and defaults are normative in COR-1622 — when th
 
 | Key | Value |
 |-----|-------|
-| `<worker-agent>` | ⟨option A: subagent worker, e.g. "trinity-glm via droid exec"⟩ |
-|  | ⟨option B: sandboxed CLI per COR-1628, e.g. "codex exec (COR-1628 lane)" — brief template, invocation contract, and verification checklist in COR-1628⟩ |
+| `<worker-agent>` | ⟨pick one — option A: subagent worker, e.g. "trinity-glm via droid exec"; option B: sandboxed CLI per COR-1628, e.g. "codex exec (COR-1628 lane)" (brief template, invocation contract, and verification checklist in COR-1628)⟩ |
 | `<worker-min-loc>` | 30 |
 | `<test-writer-worker-agent>` | ⟨unset = two-worker split OFF; set to a different model or a verified-fresh :instance suffix to enable COR-1507, e.g. "trinity-glm:writer"⟩ |
 

--- a/src/fx_alfred/rules/COR-1629-REF-Loop-Config-Starter-Template.md
+++ b/src/fx_alfred/rules/COR-1629-REF-Loop-Config-Starter-Template.md
@@ -18,7 +18,7 @@ Time to instantiate a new repo: about ten minutes with `af create`.
 
 ## How to Use
 
-1. `af create REF --prefix <PRJ-PREFIX> --area workflow --title "Multi-Agent Loop Configuration" --layer project`
+1. `af create REF --prefix <PRJ-PREFIX> --acid <NNNN> --title "Multi-Agent Loop Configuration" --layer project` (`--acid` takes the full 4-digit ID; the alternative `--area` flag wants a 2-digit area code, not a label)
 2. Paste the template below into the created document; replace every `⟨…⟩` placeholder.
 3. Delete the option comments you did not take.
 4. `af validate --root .` and reference the doc's ACID from your project's routing doc.


### PR DESCRIPTION
## Summary

- **COR-1628 SOP — Sandboxed Worker CLI Dispatch**: the dispatch contract for implementation workers running as external one-shot sandboxed CLIs (reference implementation: `codex exec`). Six-rule invocation contract, seven-block task-brief template, sandbox scope clause (with recommended CLAUDE.md snippet), orchestrator verification checklist, failure-mode table, guard rails.
- **COR-1629 REF — Loop Config Starter Template**: copy-paste blank instantiation form for the COR-1622 parameter schema (30/30 keys, verified exact) with the COR-1628 worker lane and COR-1507 two-worker TDD options pre-wired. Defers to COR-1622 on any conflict.
- COR-0000 index rows + PRJ CHG **FXA-2320** recording the promotion rationale.

## Why

The codex-worker pipeline validated on #282/#283 (first-try 2/2, triad 9.1–9.5, ~⅕–⅓ orchestrator token cost) lived only in one machine's session memory. Every operational rule was earned by a real failure: stdin hang (burned a 10-minute timeout), foreground-cap kill, and the sandboxed worker spending 3+ minutes retrying network services because it read the orchestrator-facing CLAUDE.md via the AGENTS.md symlink. PKG layer ships with `pip install fx-alfred`, so every adopting repo inherits the lane; project-specific values stay per-project via COR-1622 instantiation — the same separation COR-1622 itself established when promoting from TRN-1008.

## Review

COR-1602 triad, COR-1609 rubric: **GLM-5.2 PASS 9.2**, **MiniMax M3 PASS 9.2**, **DeepSeek PASS 9.0** — zero blocking findings. All convergent advisories applied before this PR: invalid `Rejected` CHG status → `Rolled Back` (GLM), COR-0000 change-history chronology (GLM+MiniMax), default-vs-choice markers on 7 template keys incl. the `<consent-signal>` enum (MiniMax), undefined "authorship trailer" term (MiniMax), effort-tier normalization footnote (MiniMax), O1–O4 leaf wording (MiniMax).

## Test plan

- `.venv/bin/pytest -q` — 1392 passed, 2 skipped (docs drift/format suites included)
- `af validate --root .` — 0 issues (2 pre-existing warnings: FXA-2271 CTX type, FXA-2315 tag vocab)
- `af fmt --check` clean on FXA-2320; PKG docs follow COR-1619's section conventions

## Scope hints

Docs-only: two new PKG documents, COR-0000 index rows, one PRJ CHG. No code paths change; `af` behavior identical. COR-1617/1619/1622 are referenced, not edited. FXA-2276 (alfred's own loop config) adoption of the new lane is a deliberate follow-up, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)