### PR TITLE
fix(fxa-262): unify fence handling across write/scan paths onto shared iterator

### DIFF
--- a/src/fx_alfred/commands/fmt_cmd.py
+++ b/src/fx_alfred/commands/fmt_cmd.py
@@ -15,6 +15,7 @@ from fx_alfred.core.parser import (
     MalformedDocumentError,
     MetadataField,
     ParsedDocument,
+    iter_lines_with_fence_state,
     parse_metadata,
     render_document,
 )
@@ -121,19 +122,11 @@ def normalize_blank_lines_in_body(parsed: ParsedDocument) -> bool:
     if not parsed.body:
         return False
 
-    lines = parsed.body.split("\n")
     result: list[str] = []
-    in_fence = False
 
-    for line in lines:
-        # Track fence state (lines starting with ```)
-        if line.strip().startswith("```"):
-            in_fence = not in_fence
-            result.append(line)
-            continue
-
+    for line, fenced in iter_lines_with_fence_state(parsed.body):
         # Inside fence: pass through unchanged
-        if in_fence:
+        if fenced:
             result.append(line)
             continue
 

--- a/src/fx_alfred/commands/update_cmd.py
+++ b/src/fx_alfred/commands/update_cmd.py
@@ -26,6 +26,7 @@ from fx_alfred.core.document import FILENAME_PATTERN
 from fx_alfred.core.parser import (
     MalformedDocumentError,
     MetadataField,
+    iter_lines_with_fence_state,
     parse_metadata,
     render_document,
 )
@@ -58,19 +59,37 @@ def _replace_section_in_body(
     Returns tuple of (modified body, found flag). If section not found,
     returns (original body, False).
     """
-    # Match the section heading and capture everything until next heading or end
-    pattern = rf"^(##\s+{re.escape(section_name)}\s*\n)(.*?)(?=\n##\s|\n---\s*$|\Z)"
-    match = re.search(pattern, body, re.MULTILINE | re.DOTALL)
+    lines = body.split("\n")
+    annotated = list(iter_lines_with_fence_state(body))
+    heading_re = re.compile(rf"^##\s+{re.escape(section_name)}\s*$")
 
-    if match:
-        # Replace the content after the heading
-        before = body[: match.start()]
-        heading = match.group(1)
-        after = body[match.end() :]
-        return before + heading + new_content + "\n" + after, True
-    else:
-        # Section not found
+    start_idx = next(
+        (
+            i
+            for i, (line, fenced) in enumerate(annotated)
+            if not fenced and heading_re.match(line)
+        ),
+        None,
+    )
+    if start_idx is None:
         return body, False
+
+    boundary_re = re.compile(r"^##\s+")
+    end_idx = next(
+        (
+            i
+            for i in range(start_idx + 1, len(annotated))
+            if not annotated[i][1]
+            and (boundary_re.match(annotated[i][0]) or annotated[i][0].strip() == "---")
+        ),
+        len(lines),
+    )
+
+    replacement_lines = lines[: start_idx + 1]
+    replacement_lines.extend(new_content.split("\n"))
+    replacement_lines.append("")
+    replacement_lines.extend(lines[end_idx:])
+    return "\n".join(replacement_lines), True
 
 
 _EPILOG = """\

--- a/src/fx_alfred/core/parser.py
+++ b/src/fx_alfred/core/parser.py
@@ -173,11 +173,12 @@ def parse_metadata(content: str) -> ParsedDocument:
     # Everything from first --- onward is body + change history
     rest_lines = lines[sep_index:]
     rest_text = "\n".join(rest_lines)
+    annotated = list(iter_lines_with_fence_state(rest_text))
 
     # Try to find "## Change History" section
     history_section_idx = None
-    for i, line in enumerate(rest_lines):
-        if line.strip() == "## Change History":
+    for i, (line, fenced) in enumerate(annotated):
+        if not fenced and line.strip() == "## Change History":
             history_section_idx = i
             break
 
@@ -207,7 +208,8 @@ def parse_metadata(content: str) -> ParsedDocument:
     table_header_end = None
     for i in range(1, len(history_lines)):
         stripped = history_lines[i].strip()
-        if stripped.startswith("|") and "---" in stripped:
+        fenced = annotated[history_section_idx + i][1]
+        if not fenced and stripped.startswith("|") and "---" in stripped:
             table_header_end = i
             break
 

--- a/tests/test_fmt_cmd.py
+++ b/tests/test_fmt_cmd.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from fx_alfred.cli import cli
+from fx_alfred.commands.fmt_cmd import normalize_blank_lines_in_body
 from fx_alfred.core.parser import parse_metadata
 
 
@@ -460,6 +461,62 @@ def test_fmt_blank_line_normalization(tmp_path):
     assert (
         "\n\n\n\n" not in content.split("## Change History")[0]
     )  # No triple blanks before history
+
+
+def test_normalize_blank_lines_preserves_tilde_and_long_backtick_fences():
+    """Blank-line normalization must leave all fence contents byte-identical."""
+    tilde_block = """~~~markdown
+## Inside tilde fence
+
+
+body
+~~~"""
+    long_backtick_block = """````markdown
+```python
+## Inside long backtick fence
+
+
+body
+```
+````"""
+    doc = f"""# TST-2107: Fence Blank Lines
+
+**Applies to:** All projects
+**Last updated:** 2026-01-01
+**Last reviewed:** 2026-01-01
+**Status:** Draft
+
+---
+
+
+## What Is It?
+
+Before.
+
+{tilde_block}
+
+Between.
+
+{long_backtick_block}
+
+
+## Steps
+
+After.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-01-01 | Initial version | Author |
+"""
+    parsed = parse_metadata(doc)
+
+    assert normalize_blank_lines_in_body(parsed) is True
+    assert tilde_block in parsed.body
+    assert long_backtick_block in parsed.body
 
 
 # ── Unit Tests: Table Alignment ──────────────────────────────────────────────

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -61,6 +61,36 @@ def test_parse_metadata_change_history_heading_without_table():
     assert "Change History" in parsed.body
 
 
+def test_parse_metadata_ignores_fenced_change_history_example():
+    """Fenced Change History examples must not bind the parsed history table."""
+    content = (
+        "# SOP-2101: Test\n\n"
+        "**Applies to:** Test\n"
+        "**Status:** Active\n\n"
+        "---\n\n"
+        "## What Is It?\n\n"
+        "Example:\n\n"
+        "```markdown\n"
+        "## Change History\n\n"
+        "| Date | Change | By |\n"
+        "|------|--------|----|\n"
+        "| 1999-01-01 | Fenced example | Nobody |\n"
+        "```\n\n"
+        "---\n\n"
+        "## Change History\n\n"
+        "| Date | Change | By |\n"
+        "|------|--------|----|\n"
+        "| 2026-01-01 | Real row | Author |\n"
+    )
+
+    parsed = parse_metadata(content)
+
+    assert len(parsed.history_rows) == 1
+    assert parsed.history_rows[0].date == "2026-01-01"
+    assert parsed.history_rows[0].change == "Real row"
+    assert "Fenced example" in parsed.body
+
+
 # --- extract_section fence-awareness (CHG-2294) ---
 
 

--- a/tests/test_spec_cmd.py
+++ b/tests/test_spec_cmd.py
@@ -6,6 +6,7 @@ import pytest
 from click.testing import CliRunner
 
 from fx_alfred.cli import cli
+from fx_alfred.commands.update_cmd import _replace_section_in_body
 
 
 pytestmark = [pytest.mark.cli, pytest.mark.integration]
@@ -411,6 +412,124 @@ When not to use content.
     # Unchanged sections preserved
     assert "Original why." in content
     assert "Original content." in content
+
+
+def test_replace_section_ignores_fenced_headings_and_separators():
+    """Section replacement ignores boundary lookalikes inside fences."""
+    body = """---
+
+## Steps
+
+Before example.
+
+```markdown
+## Steps
+
+---
+```
+
+After example.
+
+## Why
+
+Sibling section.
+"""
+
+    updated, found = _replace_section_in_body(body, "Steps", "Replacement.")
+
+    assert found is True
+    assert (
+        updated
+        == """---
+
+## Steps
+Replacement.
+
+## Why
+
+Sibling section.
+"""
+    )
+
+
+def test_update_spec_patch_section_with_fenced_boundaries_preserves_sibling(
+    spec_project, monkeypatch
+):
+    """Patch replaces the whole target section and preserves fenced sibling content."""
+    monkeypatch.chdir(spec_project)
+
+    rules = spec_project / "rules"
+    doc = rules / "TST-2100-SOP-Test-Document.md"
+    doc.write_text(
+        """# SOP-2100: Test Document
+
+**Applies to:** All
+**Last updated:** 2026-01-01
+**Last reviewed:** 2026-01-01
+**Status:** Draft
+
+---
+
+## What Is It?
+
+Original content.
+
+## Why
+
+Sibling before.
+
+```markdown
+## Steps
+
+---
+```
+
+Sibling after.
+
+## Steps
+
+Old step before fence.
+
+```markdown
+## Steps
+
+---
+```
+
+Old step after fence.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-01-01 | Initial version | Author |
+"""
+    )
+
+    spec_file = spec_project / "patch.yaml"
+    spec_file.write_text(
+        """sections:
+  Steps: New step content.
+"""
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--spec", str(spec_file)],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0, f"Output: {result.output}"
+    content = doc.read_text()
+    assert "New step content." in content
+    assert "Old step before fence." not in content
+    assert "Old step after fence." not in content
+    assert "Sibling before." in content
+    assert "Sibling after." in content
+    assert content.count("```markdown\n## Steps\n\n---\n```") == 1
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -295,6 +295,54 @@ def test_update_history_pipe_escaping(tmp_path, monkeypatch):
     assert "X\\|Y" in content
 
 
+def test_update_history_ignores_fenced_change_history_example(tmp_path, monkeypatch):
+    """Append history to the real table, not a fenced example table."""
+    project = _make_project(
+        tmp_path,
+        """# TST-2100: Test Document
+
+**Applies to:** All projects
+**Status:** Draft
+**Last updated:** 2026-01-01
+
+---
+
+## What Is It?
+
+Example:
+
+```markdown
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 1999-01-01 | Fenced example | Nobody |
+```
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-01-01 | Initial version | Author |
+""",
+    )
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--history", "Real change", "--by", "Frank"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    content = (project / "rules" / "TST-2100-SOP-Test-Document.md").read_text()
+    assert content.rfind("## Change History") < content.rfind("Real change")
+    assert content.count("| 1999-01-01 | Fenced example | Nobody |") == 1
+
+
 # ── PRJ layer: rename ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fixes #262. Three write/scan paths hand-rolled Markdown fence logic and corrupted fenced document content. This routes all three through the existing fence-aware iterator `iter_lines_with_fence_state` (`core/parser.py`, CHG-2294), deleting the bespoke toggles/regex — one shared iterator replaces the whole defect class.

| Mode | Site | Before | After |
|------|------|--------|-------|
| 1 | `update_cmd._replace_section_in_body` | regex lookahead stopped at first `## `/`---` **inside a fence** → section truncated mid-fence | fence-aware start/end scan; a section containing fenced `## `/`---` is replaced whole, sibling fences untouched |
| 2 | `fmt_cmd.normalize_blank_lines_in_body` | naive triple-backtick toggle — blind to `~~~`, mis-toggles on 4-backtick fences | `(line, fenced)` iteration; fenced content passes through byte-identical |
| 3 | `parser.parse_metadata` | plain `## Change History` + table-separator line scans | non-fenced-only matches; a fenced example table no longer binds `history_rows` |

## Acceptance criteria (issue #262)

- [x] `af update --spec` replacing a section containing fenced `## `/`---` replaces the whole section and nothing else
- [x] `af fmt --write` leaves `~~~` and 4-backtick fence contents byte-identical
- [x] `af update --history` appends to the real Change History table, ignoring fenced example tables
- [x] Hand-rolled fence toggles/regexes deleted in favor of the shared iterator
- [x] Existing suite still passes

## Testing

- 5 new regression tests, one+ per mode; all **fail on pre-fix source** and pass after (TDD red→green verified by reverse-applying the source patch).
- Full suite: `1397 passed, 2 skipped`. `ruff check` / `ruff format --check` / `pyright src/` clean. `af validate` 0 issues.

## Scope hints

On-scope: correctness of the three fence-aware rewrites, index alignment between the annotated fence-state lists and raw line lists (`parser.py`, `update_cmd.py`), preserved non-fenced behavior/spacing vs the old regex/toggle, and regression-test adequacy. The data-row parse loop in `parse_metadata` is intentionally left non-fence-aware (no realistic fenced content mid-history-table; out of issue scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
