### PR TITLE
fix(fxa-264): archive merges same-named member instead of replacing it

### DIFF
--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -652,7 +652,10 @@ def iter_records(path: Path) -> Iterator[tuple[str, int, dict[str, Any]]]:
         loose_files = _jsonl_files(path)
         shadowed: dict[str, Counter[bytes]] = {}
         for file_path in loose_files:
-            payload = file_path.read_bytes()
+            try:
+                payload = file_path.read_bytes()
+            except FileNotFoundError:
+                continue
             shadowed[file_path.name] = _shadow_line_counts(payload)
             yield from _iter_jsonl_payload_records(str(file_path), payload)
         archive = path / "archive.zip"

--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -545,37 +545,47 @@ def _shadow_line_counts(loose_path: Path) -> Counter[bytes]:
     )
 
 
+def _iter_member_lines(
+    zf: zipfile.ZipFile, member: str, suppress: Counter[bytes] | None
+) -> Iterator[tuple[int, bytes]]:
+    """Yield ``(lineno, raw)`` member rows, skipping blanks and shadowed rows.
+
+    ``suppress`` counts rows a same-named loose file already yielded; each
+    match consumes one occurrence so only rows the loose copy lacks remain
+    (merge-then-failed-unlink or restore-before-re-archive states).
+    """
+
+    with zf.open(member) as fh:
+        for lineno, raw in enumerate(fh, start=1):
+            if not raw.strip():
+                continue
+            if suppress is not None and suppress[raw.rstrip(b"\r\n")] > 0:
+                suppress[raw.rstrip(b"\r\n")] -= 1
+                continue
+            yield lineno, raw
+
+
+def _iter_zip_members(
+    zf: zipfile.ZipFile, shadow: dict[str, Path]
+) -> Iterator[tuple[str, Counter[bytes] | None]]:
+    """Yield each ``.jsonl`` member once, with its shadow-suppression counts."""
+
+    seen: set[str] = set()
+    for member in sorted(zf.namelist()):
+        if not member.endswith(".jsonl") or member in seen:
+            continue
+        seen.add(member)
+        yield member, _shadow_line_counts(shadow[member]) if member in shadow else None
+
+
 def _iter_zip_records(
     path: Path, *, shadowed: dict[str, Path] | None = None
 ) -> Iterator[tuple[str, int, dict[str, Any]]]:
-    shadow = shadowed or {}
-    seen: set[str] = set()
     with zipfile.ZipFile(path) as zf:
-        for member in sorted(zf.namelist()):
-            if not member.endswith(".jsonl") or member in seen:
-                continue
-            seen.add(member)
-            # A same-named loose file already yielded its rows; suppress
-            # those and yield only member rows the loose copy lacks
-            # (merge-then-failed-unlink or restore-before-re-archive).
-            suppress = (
-                _shadow_line_counts(shadow[member]) if member in shadow else None
-            )
-            with zf.open(member) as fh:
-                for lineno, raw in enumerate(fh, start=1):
-                    if not raw.strip():
-                        continue
-                    if suppress is not None:
-                        key = raw.rstrip(b"\r\n")
-                        if suppress[key] > 0:
-                            suppress[key] -= 1
-                            continue
-                    record = _parse_jsonl_record(f"{path}::{member}", lineno, raw)
-                    yield (
-                        f"{path}::{member}",
-                        lineno,
-                        record,
-                    )
+        for member, suppress in _iter_zip_members(zf, shadowed or {}):
+            source = f"{path}::{member}"
+            for lineno, raw in _iter_member_lines(zf, member, suppress):
+                yield (source, lineno, _parse_jsonl_record(source, lineno, raw))
 
 
 def _parse_jsonl_record(source: str, lineno: int, raw: bytes) -> dict[str, Any]:
@@ -652,38 +662,15 @@ def iter_records(path: Path) -> Iterator[tuple[str, int, dict[str, Any]]]:
 def _iter_zip_records_best_effort(
     path: Path, *, shadowed: dict[str, Path] | None = None
 ) -> Iterator[tuple[str, int, dict[str, Any]]]:
-    shadow = shadowed or {}
-    seen: set[str] = set()
     try:
         with zipfile.ZipFile(path) as zf:
-            for member in sorted(zf.namelist()):
-                if not member.endswith(".jsonl") or member in seen:
-                    continue
-                seen.add(member)
-                suppress: Counter[bytes] | None = None
-                if member in shadow:
+            for member, suppress in _iter_zip_members(zf, shadowed or {}):
+                source = f"{path}::{member}"
+                for lineno, raw in _iter_member_lines(zf, member, suppress):
                     try:
-                        suppress = _shadow_line_counts(shadow[member])
-                    except OSError:
-                        suppress = None
-                with zf.open(member) as fh:
-                    for lineno, raw in enumerate(fh, start=1):
-                        if not raw.strip():
-                            continue
-                        if suppress is not None:
-                            key = raw.rstrip(b"\r\n")
-                            if suppress[key] > 0:
-                                suppress[key] -= 1
-                                continue
-                        source = f"{path}::{member}"
-                        try:
-                            yield (
-                                source,
-                                lineno,
-                                _parse_jsonl_record(source, lineno, raw),
-                            )
-                        except ActivityLogLineError:
-                            continue
+                        yield (source, lineno, _parse_jsonl_record(source, lineno, raw))
+                    except ActivityLogLineError:
+                        continue
     except (OSError, zipfile.BadZipFile):
         return
 

--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -510,6 +510,20 @@ def _jsonl_files(directory: Path) -> list[Path]:
     return sorted(p for p in directory.glob("*.jsonl") if p.is_file())
 
 
+def _merge_jsonl_payloads(existing: bytes, loose: bytes) -> bytes:
+    rows: list[bytes] = []
+    seen: set[bytes] = set()
+    for payload in (existing, loose):
+        for row in payload.splitlines():
+            if not row.strip() or row in seen:
+                continue
+            rows.append(row)
+            seen.add(row)
+    if not rows:
+        return b""
+    return b"\n".join(rows) + b"\n"
+
+
 def _iter_zip_records(
     path: Path, *, skip_members: set[str] | None = None
 ) -> Iterator[tuple[str, int, dict[str, Any]]]:
@@ -719,11 +733,18 @@ def archive_directory(
         try:
             with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
                 closed_names = {file_path.name for file_path in closed}
+                closed_by_name = {file_path.name: file_path for file_path in closed}
+                merged_names: set[str] = set()
                 for name, payload in sorted(existing.items()):
                     if name in closed_names:
+                        loose_payload = closed_by_name[name].read_bytes()
+                        zf.writestr(name, _merge_jsonl_payloads(payload, loose_payload))
+                        merged_names.add(name)
                         continue
                     zf.writestr(name, payload)
                 for file_path in closed:
+                    if file_path.name in merged_names:
+                        continue
                     zf.write(file_path, arcname=file_path.name)
             os.replace(tmp_path, archive)
             for file_path in closed:

--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -14,6 +14,7 @@ import re
 import tempfile
 import uuid
 import zipfile
+from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -511,47 +512,70 @@ def _jsonl_files(directory: Path) -> list[Path]:
 
 
 def _merge_jsonl_payloads(existing: bytes, loose: bytes) -> bytes:
-    """Union two JSONL payloads: existing rows first, deduped by raw line bytes.
+    """Multiset-union two JSONL payloads, existing rows first, by raw line bytes.
 
-    Identity is byte-level (``splitlines()`` content), so a restored
-    byte-identical file merges to an unchanged member and CRLF/LF variants
-    of one row count as the same row.  Caveat: ``ts`` is second-resolution
-    and ``session_id`` may be env-pinned, so two genuinely distinct events
-    emitted in the same second with identical fields collide into one row —
-    accepted byte-dedupe semantics per issue #264.
+    Existing rows are preserved verbatim (including byte-identical
+    duplicates — a legitimate ledger state given second-resolution ``ts``
+    and env-pinned ``session_id``); each loose row suppresses at most one
+    matching existing occurrence, so per-row multiplicity is
+    ``max(existing_count, loose_count)``.  Identity is byte-level
+    (``splitlines()`` content), so a restored byte-identical file merges to
+    an unchanged member and CRLF/LF variants of one row count as the same
+    row.
     """
-    rows: list[bytes] = []
-    seen: set[bytes] = set()
-    for payload in (existing, loose):
-        for row in payload.splitlines():
-            if not row.strip() or row in seen:
-                continue
-            rows.append(row)
-            seen.add(row)
+    rows = [row for row in existing.splitlines() if row.strip()]
+    remaining = Counter(rows)
+    for row in loose.splitlines():
+        if not row.strip():
+            continue
+        if remaining[row] > 0:
+            remaining[row] -= 1
+            continue
+        rows.append(row)
     if not rows:
         return b""
     return b"\n".join(rows) + b"\n"
 
 
+def _shadow_line_counts(loose_path: Path) -> Counter[bytes]:
+    """Count the loose file's non-blank raw lines (terminator-stripped)."""
+
+    return Counter(
+        row for row in loose_path.read_bytes().splitlines() if row.strip()
+    )
+
+
 def _iter_zip_records(
-    path: Path, *, skip_members: set[str] | None = None
+    path: Path, *, shadowed: dict[str, Path] | None = None
 ) -> Iterator[tuple[str, int, dict[str, Any]]]:
-    skipped = skip_members or set()
+    shadow = shadowed or {}
     seen: set[str] = set()
     with zipfile.ZipFile(path) as zf:
         for member in sorted(zf.namelist()):
-            if not member.endswith(".jsonl") or member in skipped or member in seen:
+            if not member.endswith(".jsonl") or member in seen:
                 continue
             seen.add(member)
+            # A same-named loose file already yielded its rows; suppress
+            # those and yield only member rows the loose copy lacks
+            # (merge-then-failed-unlink or restore-before-re-archive).
+            suppress = (
+                _shadow_line_counts(shadow[member]) if member in shadow else None
+            )
             with zf.open(member) as fh:
                 for lineno, raw in enumerate(fh, start=1):
-                    if raw.strip():
-                        record = _parse_jsonl_record(f"{path}::{member}", lineno, raw)
-                        yield (
-                            f"{path}::{member}",
-                            lineno,
-                            record,
-                        )
+                    if not raw.strip():
+                        continue
+                    if suppress is not None:
+                        key = raw.rstrip(b"\r\n")
+                        if suppress[key] > 0:
+                            suppress[key] -= 1
+                            continue
+                    record = _parse_jsonl_record(f"{path}::{member}", lineno, raw)
+                    yield (
+                        f"{path}::{member}",
+                        lineno,
+                        record,
+                    )
 
 
 def _parse_jsonl_record(source: str, lineno: int, raw: bytes) -> dict[str, Any]:
@@ -609,7 +633,7 @@ def iter_records(path: Path) -> Iterator[tuple[str, int, dict[str, Any]]]:
         archive = path / "archive.zip"
         if archive.exists():
             yield from _iter_zip_records(
-                archive, skip_members={file_path.name for file_path in loose_files}
+                archive, shadowed={file_path.name: file_path for file_path in loose_files}
             )
         return
     if path.suffix == ".zip":
@@ -626,20 +650,31 @@ def iter_records(path: Path) -> Iterator[tuple[str, int, dict[str, Any]]]:
 
 
 def _iter_zip_records_best_effort(
-    path: Path, *, skip_members: set[str] | None = None
+    path: Path, *, shadowed: dict[str, Path] | None = None
 ) -> Iterator[tuple[str, int, dict[str, Any]]]:
-    skipped = skip_members or set()
+    shadow = shadowed or {}
     seen: set[str] = set()
     try:
         with zipfile.ZipFile(path) as zf:
             for member in sorted(zf.namelist()):
-                if not member.endswith(".jsonl") or member in skipped or member in seen:
+                if not member.endswith(".jsonl") or member in seen:
                     continue
                 seen.add(member)
+                suppress: Counter[bytes] | None = None
+                if member in shadow:
+                    try:
+                        suppress = _shadow_line_counts(shadow[member])
+                    except OSError:
+                        suppress = None
                 with zf.open(member) as fh:
                     for lineno, raw in enumerate(fh, start=1):
                         if not raw.strip():
                             continue
+                        if suppress is not None:
+                            key = raw.rstrip(b"\r\n")
+                            if suppress[key] > 0:
+                                suppress[key] -= 1
+                                continue
                         source = f"{path}::{member}"
                         try:
                             yield (
@@ -667,7 +702,7 @@ def _iter_records_best_effort(
         archive = path / "archive.zip"
         if archive.exists():
             yield from _iter_zip_records_best_effort(
-                archive, skip_members={file_path.name for file_path in loose_files}
+                archive, shadowed={file_path.name: file_path for file_path in loose_files}
             )
         return
     if path.suffix == ".zip":

--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -540,9 +540,7 @@ def _merge_jsonl_payloads(existing: bytes, loose: bytes) -> bytes:
 def _shadow_line_counts(loose_path: Path) -> Counter[bytes]:
     """Count the loose file's non-blank raw lines (terminator-stripped)."""
 
-    return Counter(
-        row for row in loose_path.read_bytes().splitlines() if row.strip()
-    )
+    return Counter(row for row in loose_path.read_bytes().splitlines() if row.strip())
 
 
 def _iter_member_lines(
@@ -575,7 +573,16 @@ def _iter_zip_members(
         if not member.endswith(".jsonl") or member in seen:
             continue
         seen.add(member)
-        yield member, _shadow_line_counts(shadow[member]) if member in shadow else None
+        suppress: Counter[bytes] | None = None
+        if member in shadow:
+            try:
+                suppress = _shadow_line_counts(shadow[member])
+            except OSError:
+                # Shadow file vanished mid-iteration (e.g. a concurrent
+                # archiver's unlink); its rows are already merged into the
+                # member, so read the member unshadowed.
+                suppress = None
+        yield member, suppress
 
 
 def _iter_zip_records(
@@ -643,7 +650,8 @@ def iter_records(path: Path) -> Iterator[tuple[str, int, dict[str, Any]]]:
         archive = path / "archive.zip"
         if archive.exists():
             yield from _iter_zip_records(
-                archive, shadowed={file_path.name: file_path for file_path in loose_files}
+                archive,
+                shadowed={file_path.name: file_path for file_path in loose_files},
             )
         return
     if path.suffix == ".zip":
@@ -689,7 +697,8 @@ def _iter_records_best_effort(
         archive = path / "archive.zip"
         if archive.exists():
             yield from _iter_zip_records_best_effort(
-                archive, shadowed={file_path.name: file_path for file_path in loose_files}
+                archive,
+                shadowed={file_path.name: file_path for file_path in loose_files},
             )
         return
     if path.suffix == ".zip":

--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -537,10 +537,10 @@ def _merge_jsonl_payloads(existing: bytes, loose: bytes) -> bytes:
     return b"\n".join(rows) + b"\n"
 
 
-def _shadow_line_counts(loose_path: Path) -> Counter[bytes]:
-    """Count the loose file's non-blank raw lines (terminator-stripped)."""
+def _shadow_line_counts(payload: bytes) -> Counter[bytes]:
+    """Count non-blank raw lines (terminator-stripped)."""
 
-    return Counter(row for row in loose_path.read_bytes().splitlines() if row.strip())
+    return Counter(row for row in payload.splitlines() if row.strip())
 
 
 def _iter_member_lines(
@@ -564,7 +564,7 @@ def _iter_member_lines(
 
 
 def _iter_zip_members(
-    zf: zipfile.ZipFile, shadow: dict[str, Path]
+    zf: zipfile.ZipFile, shadow: dict[str, Counter[bytes]]
 ) -> Iterator[tuple[str, Counter[bytes] | None]]:
     """Yield each ``.jsonl`` member once, with its shadow-suppression counts."""
 
@@ -573,26 +573,31 @@ def _iter_zip_members(
         if not member.endswith(".jsonl") or member in seen:
             continue
         seen.add(member)
-        suppress: Counter[bytes] | None = None
-        if member in shadow:
-            try:
-                suppress = _shadow_line_counts(shadow[member])
-            except OSError:
-                # Shadow file vanished mid-iteration (e.g. a concurrent
-                # archiver's unlink); its rows are already merged into the
-                # member, so read the member unshadowed.
-                suppress = None
-        yield member, suppress
+        yield member, shadow.get(member)
 
 
 def _iter_zip_records(
-    path: Path, *, shadowed: dict[str, Path] | None = None
+    path: Path, *, shadowed: dict[str, Counter[bytes]] | None = None
 ) -> Iterator[tuple[str, int, dict[str, Any]]]:
     with zipfile.ZipFile(path) as zf:
         for member, suppress in _iter_zip_members(zf, shadowed or {}):
             source = f"{path}::{member}"
             for lineno, raw in _iter_member_lines(zf, member, suppress):
                 yield (source, lineno, _parse_jsonl_record(source, lineno, raw))
+
+
+def _iter_jsonl_payload_records(
+    source: str, payload: bytes, *, best_effort: bool = False
+) -> Iterator[tuple[str, int, dict[str, Any]]]:
+    for lineno, raw in enumerate(payload.splitlines(keepends=True), start=1):
+        if not raw.strip():
+            continue
+        try:
+            yield (source, lineno, _parse_jsonl_record(source, lineno, raw))
+        except ActivityLogLineError:
+            if best_effort:
+                continue
+            raise
 
 
 def _parse_jsonl_record(source: str, lineno: int, raw: bytes) -> dict[str, Any]:
@@ -645,14 +650,14 @@ def iter_records(path: Path) -> Iterator[tuple[str, int, dict[str, Any]]]:
         return
     if path.is_dir():
         loose_files = _jsonl_files(path)
+        shadowed: dict[str, Counter[bytes]] = {}
         for file_path in loose_files:
-            yield from iter_records(file_path)
+            payload = file_path.read_bytes()
+            shadowed[file_path.name] = _shadow_line_counts(payload)
+            yield from _iter_jsonl_payload_records(str(file_path), payload)
         archive = path / "archive.zip"
         if archive.exists():
-            yield from _iter_zip_records(
-                archive,
-                shadowed={file_path.name: file_path for file_path in loose_files},
-            )
+            yield from _iter_zip_records(archive, shadowed=shadowed)
         return
     if path.suffix == ".zip":
         yield from _iter_zip_records(path)
@@ -668,7 +673,7 @@ def iter_records(path: Path) -> Iterator[tuple[str, int, dict[str, Any]]]:
 
 
 def _iter_zip_records_best_effort(
-    path: Path, *, shadowed: dict[str, Path] | None = None
+    path: Path, *, shadowed: dict[str, Counter[bytes]] | None = None
 ) -> Iterator[tuple[str, int, dict[str, Any]]]:
     try:
         with zipfile.ZipFile(path) as zf:
@@ -692,14 +697,19 @@ def _iter_records_best_effort(
         return
     if path.is_dir():
         loose_files = _jsonl_files(path)
+        shadowed: dict[str, Counter[bytes]] = {}
         for file_path in loose_files:
-            yield from _iter_records_best_effort(file_path)
+            try:
+                payload = file_path.read_bytes()
+            except OSError:
+                continue
+            shadowed[file_path.name] = _shadow_line_counts(payload)
+            yield from _iter_jsonl_payload_records(
+                str(file_path), payload, best_effort=True
+            )
         archive = path / "archive.zip"
         if archive.exists():
-            yield from _iter_zip_records_best_effort(
-                archive,
-                shadowed={file_path.name: file_path for file_path in loose_files},
-            )
+            yield from _iter_zip_records_best_effort(archive, shadowed=shadowed)
         return
     if path.suffix == ".zip":
         yield from _iter_zip_records_best_effort(path)

--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -511,6 +511,15 @@ def _jsonl_files(directory: Path) -> list[Path]:
 
 
 def _merge_jsonl_payloads(existing: bytes, loose: bytes) -> bytes:
+    """Union two JSONL payloads: existing rows first, deduped by raw line bytes.
+
+    Identity is byte-level (``splitlines()`` content), so a restored
+    byte-identical file merges to an unchanged member and CRLF/LF variants
+    of one row count as the same row.  Caveat: ``ts`` is second-resolution
+    and ``session_id`` may be env-pinned, so two genuinely distinct events
+    emitted in the same second with identical fields collide into one row —
+    accepted byte-dedupe semantics per issue #264.
+    """
     rows: list[bytes] = []
     seen: set[bytes] = set()
     for payload in (existing, loose):

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -1060,3 +1060,26 @@ def test_archive_and_append_succeed_when_fcntl_unavailable(tmp_path, monkeypatch
     summaries = {r[2]["summary"] for r in records}
     assert "old" in summaries
     assert "portable-append" in summaries
+
+
+def test_iter_records_treats_vanished_shadow_file_as_unshadowed(tmp_path):
+    """PR #290 R3: a shadow loose file removed mid-iteration must not raise.
+
+    A concurrent archiver can unlink the loose file between the directory
+    listing and zip iteration; its rows are already folded into the member,
+    so the member is read unshadowed instead of raising FileNotFoundError.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    row = json.dumps(activity_log.compose_record(summary="archived")) + "\n"
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", row)
+    vanished = log_dir / "2026-06-20.jsonl"  # never created on disk
+
+    records = list(
+        activity_log._iter_zip_records(
+            log_dir / "archive.zip", shadowed={"2026-06-20.jsonl": vanished}
+        )
+    )
+
+    assert [rec[2]["summary"] for rec in records] == ["archived"]

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -504,6 +504,31 @@ def test_iter_records_does_not_double_count_shadowed_identical_member(tmp_path):
     assert records[0][2]["summary"] == "loose"
 
 
+def test_iter_records_does_not_duplicate_rows_when_shadow_vanishes_after_read(
+    tmp_path,
+):
+    """PR #290 R4: shadowing is based on loose bytes already yielded."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    loose_record = activity_log.compose_record(summary="loose")
+    archived_record = activity_log.compose_record(summary="archived")
+    loose_line = _record_line(loose_record)
+    archived_line = _record_line(archived_record)
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_bytes(loose_line)
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", loose_line + archived_line)
+
+    gen = activity_log.iter_records(log_dir)
+    first = next(gen)
+    loose.unlink()
+    records = [first, *gen]
+
+    assert [rec[2]["summary"] for rec in records] == ["loose", "archived"]
+    assert records[0][0] == str(loose)
+    assert records[1][0].endswith("archive.zip::2026-06-20.jsonl")
+
+
 def test_iter_records_best_effort_unions_shadowed_archive_member(tmp_path):
     """PR #290 R2: best-effort reader also unions shadowed members."""
     log_dir = tmp_path / "logs"
@@ -523,6 +548,31 @@ def test_iter_records_best_effort_unions_shadowed_archive_member(tmp_path):
 
     summaries = [rec[2]["summary"] for rec in records]
     assert sorted(summaries) == ["archived", "loose"]
+
+
+def test_iter_records_best_effort_does_not_duplicate_rows_when_shadow_vanishes_after_read(
+    tmp_path,
+):
+    """PR #290 R4: best-effort shadowing uses bytes already yielded."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    loose_record = activity_log.compose_record(summary="loose")
+    archived_record = activity_log.compose_record(summary="archived")
+    loose_line = _record_line(loose_record)
+    archived_line = _record_line(archived_record)
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_bytes(loose_line)
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", loose_line + archived_line)
+
+    gen = activity_log._iter_records_best_effort(log_dir)
+    first = next(gen)
+    loose.unlink()
+    records = [first, *gen]
+
+    assert [rec[2]["summary"] for rec in records] == ["loose", "archived"]
+    assert records[0][0] == str(loose)
+    assert records[1][0].endswith("archive.zip::2026-06-20.jsonl")
 
 
 def test_merge_preserves_existing_member_duplicate_rows(tmp_path):
@@ -1062,24 +1112,18 @@ def test_archive_and_append_succeed_when_fcntl_unavailable(tmp_path, monkeypatch
     assert "portable-append" in summaries
 
 
-def test_iter_records_treats_vanished_shadow_file_as_unshadowed(tmp_path):
-    """PR #290 R3: a shadow loose file removed mid-iteration must not raise.
-
-    A concurrent archiver can unlink the loose file between the directory
-    listing and zip iteration; its rows are already folded into the member,
-    so the member is read unshadowed instead of raising FileNotFoundError.
-    """
+def test_iter_records_best_effort_treats_shadow_vanished_before_read_as_unshadowed(
+    tmp_path, monkeypatch
+):
+    """PR #290 R4: if no loose rows were emitted, the member is unshadowed."""
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     row = json.dumps(activity_log.compose_record(summary="archived")) + "\n"
     with ZipFile(log_dir / "archive.zip", "w") as zf:
         zf.writestr("2026-06-20.jsonl", row)
     vanished = log_dir / "2026-06-20.jsonl"  # never created on disk
+    monkeypatch.setattr(activity_log, "_jsonl_files", lambda _path: [vanished])
 
-    records = list(
-        activity_log._iter_zip_records(
-            log_dir / "archive.zip", shadowed={"2026-06-20.jsonl": vanished}
-        )
-    )
+    records = list(activity_log._iter_records_best_effort(log_dir))
 
     assert [rec[2]["summary"] for rec in records] == ["archived"]

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -504,6 +504,28 @@ def test_iter_records_does_not_double_count_shadowed_identical_member(tmp_path):
     assert records[0][2]["summary"] == "loose"
 
 
+def test_iter_records_skips_loose_file_vanished_before_read(tmp_path, monkeypatch):
+    """PR #290 R5: a vanished loose file must not shadow the archive member."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    loose_record = activity_log.compose_record(summary="loose")
+    archived_record = activity_log.compose_record(summary="archived")
+    loose_line = _record_line(loose_record)
+    archived_line = _record_line(archived_record)
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_bytes(loose_line)
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", loose_line + archived_line)
+    listing = activity_log._jsonl_files(log_dir)
+    loose.unlink()
+    monkeypatch.setattr(activity_log, "_jsonl_files", lambda _path: listing)
+
+    records = list(activity_log.iter_records(log_dir))
+
+    assert [rec[2]["summary"] for rec in records] == ["loose", "archived"]
+    assert all(rec[0].endswith("archive.zip::2026-06-20.jsonl") for rec in records)
+
+
 def test_iter_records_does_not_duplicate_rows_when_shadow_vanishes_after_read(
     tmp_path,
 ):

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -17,6 +17,35 @@ from fx_alfred.core.scanner import scan_documents
 pytestmark = pytest.mark.unit
 
 
+# ---------------------------------------------------------------------------
+# Helpers for archive-merge tests (FXA-264)
+# ---------------------------------------------------------------------------
+
+
+def _make_test_record(summary, ts="2026-06-20T12:00:00Z", session_id="test-session-1"):
+    """Build a minimal valid record with deterministic fields for merge tests."""
+    return {
+        "schema": "alfred.activity/v1",
+        "ts": ts,
+        "agent": "other",
+        "agent_name": "af",
+        "agent_version": "test",
+        "event": "note",
+        "summary": summary,
+        "session_id": session_id,
+    }
+
+
+def _record_line(record):
+    """Serialize one record to its JSONL line bytes (with trailing newline).
+
+    Matches the format produced by ``activity_log._line_bytes``.
+    """
+    return (
+        json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+
+
 def test_compose_and_append_user_usage_record_round_trips():
     log_dir = activity_log.user_log_dir()
     record = activity_log.compose_record(
@@ -453,7 +482,8 @@ def test_iter_records_skips_archive_member_when_loose_file_exists(tmp_path):
     assert records[0][2]["summary"] == "loose"
 
 
-def test_archive_directory_replaces_existing_member_once(tmp_path):
+def test_archive_directory_merges_existing_member_once(tmp_path):
+    """Colliding member + loose file → both rows preserved, member listed once."""
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     old_file = log_dir / "2026-06-20.jsonl"
@@ -471,8 +501,142 @@ def test_archive_directory_replaces_existing_member_once(tmp_path):
 
     with ZipFile(log_dir / "archive.zip") as zf:
         assert zf.namelist() == ["2026-06-20.jsonl"]
-        payload = json.loads(zf.read("2026-06-20.jsonl"))
-    assert payload["summary"] == "new"
+        payload = zf.read("2026-06-20.jsonl")
+    # Merge contract (FXA-264): both "old" and "new" rows preserved,
+    # existing-member-first order, member appears exactly once.
+    lines = payload.decode("utf-8").splitlines()
+    summaries = [json.loads(line)["summary"] for line in lines]
+    assert summaries == ["old", "new"]
+
+
+# ---------------------------------------------------------------------------
+# FXA-264: archive merge-member tests (RED on current unfixed code)
+# ---------------------------------------------------------------------------
+
+
+def test_archive_directory_merges_divergent_rows(tmp_path):
+    """archive.zip[r1,r2] + reappeared-loose[r2,r3] → merged r1,r2,r3 (deduped)."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    r1 = _make_test_record("row1")
+    r2 = _make_test_record("row2")
+    r3 = _make_test_record("row3")
+    r1_line = _record_line(r1)
+    r2_line = _record_line(r2)
+    r3_line = _record_line(r3)
+
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", r1_line + r2_line)
+
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_bytes(r2_line + r3_line)
+
+    result = activity_log.archive_directory(log_dir, today="2026-06-21")
+
+    assert result.archived_files == ["2026-06-20.jsonl"]
+    assert not loose.exists()
+
+    with ZipFile(log_dir / "archive.zip") as zf:
+        assert zf.namelist() == ["2026-06-20.jsonl"]
+        payload = zf.read("2026-06-20.jsonl")
+
+    # Must contain r1,r2,r3 in existing-first order, each exactly once.
+    lines = payload.splitlines()
+    summaries = [json.loads(line)["summary"] for line in lines]
+    assert summaries == ["row1", "row2", "row3"]
+
+
+def test_archive_directory_noop_on_identical_restore(tmp_path):
+    """Byte-identical loose file → content unchanged, rows NOT duplicated.
+
+    On current (unfixed) code the existing member is replaced with the
+    identical loose-file bytes, so this test passes today.  It is kept as a
+    contract guard to ensure the merge path does not accidentally duplicate.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    r1 = _make_test_record("row1")
+    r2 = _make_test_record("row2")
+    r3 = _make_test_record("row3")
+    content = _record_line(r1) + _record_line(r2) + _record_line(r3)
+
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", content)
+
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_bytes(content)
+
+    activity_log.archive_directory(log_dir, today="2026-06-21")
+
+    assert not loose.exists()
+    with ZipFile(log_dir / "archive.zip") as zf:
+        payload = zf.read("2026-06-20.jsonl")
+
+    lines = payload.splitlines()
+    assert len(lines) == 3
+    summaries = [json.loads(line)["summary"] for line in lines]
+    assert summaries == ["row1", "row2", "row3"]
+
+
+def test_archive_directory_handles_missing_trailing_newline_in_existing_member(
+    tmp_path,
+):
+    """Existing member without trailing newline still merges — no concatenated row."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    r_old = _make_test_record("old-row")
+    r_new = _make_test_record("new-row")
+
+    # Write existing member payload WITHOUT trailing newline via zipfile.
+    old_bytes = json.dumps(r_old, ensure_ascii=False, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", old_bytes)
+
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_bytes(_record_line(r_new))
+
+    activity_log.archive_directory(log_dir, today="2026-06-21")
+
+    assert not loose.exists()
+
+    archive_path = log_dir / "archive.zip"
+    records = list(activity_log.iter_records(archive_path))
+    summaries = {r[2]["summary"] for r in records}
+
+    assert len(records) == 2
+    assert summaries == {"old-row", "new-row"}
+    for _, _, rec in records:
+        assert activity_log.validate_record(rec) == []
+
+
+def test_archive_directory_merged_records_pass_validation(tmp_path):
+    """Every record yielded by iter_records on merged archive passes validate_record."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+
+    r1 = _make_test_record("row1")
+    r2 = _make_test_record("row2")
+    r3 = _make_test_record("row3")
+
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", _record_line(r1) + _record_line(r2))
+
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_bytes(_record_line(r2) + _record_line(r3))
+
+    activity_log.archive_directory(log_dir, today="2026-06-21")
+
+    archive_path = log_dir / "archive.zip"
+    records = list(activity_log.iter_records(archive_path))
+
+    assert len(records) == 3
+    for _, _, rec in records:
+        assert activity_log.validate_record(rec) == []
 
 
 def test_archive_directory_treats_unlink_failure_as_best_effort(tmp_path, monkeypatch):

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -462,24 +462,90 @@ def test_compose_record_generates_session_id_when_missing(monkeypatch):
     )
 
 
-def test_iter_records_skips_archive_member_when_loose_file_exists(tmp_path):
+def test_iter_records_unions_shadowed_archive_member(tmp_path):
+    """PR #290 R2: a shadowed member yields rows the loose file lacks.
+
+    After a merge-then-failed-unlink (or a restore before re-archive), the
+    member can hold rows that exist only in the archive; hiding the whole
+    member behind the loose file would lose them from every reader.
+    """
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
+    shared_line = json.dumps(activity_log.compose_record(summary="loose")) + "\n"
     loose = log_dir / "2026-06-20.jsonl"
-    loose.write_text(
-        json.dumps(activity_log.compose_record(summary="loose")) + "\n",
-        encoding="utf-8",
-    )
+    loose.write_text(shared_line, encoding="utf-8")
     with ZipFile(log_dir / "archive.zip", "w") as zf:
         zf.writestr(
             "2026-06-20.jsonl",
-            json.dumps(activity_log.compose_record(summary="archived")) + "\n",
+            shared_line
+            + json.dumps(activity_log.compose_record(summary="archived"))
+            + "\n",
         )
+
+    records = list(activity_log.iter_records(log_dir))
+
+    summaries = [rec[2]["summary"] for rec in records]
+    assert sorted(summaries) == ["archived", "loose"]
+
+
+def test_iter_records_does_not_double_count_shadowed_identical_member(tmp_path):
+    """Guard: loose row also present in the member is yielded exactly once."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    shared_line = json.dumps(activity_log.compose_record(summary="loose")) + "\n"
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_text(shared_line, encoding="utf-8")
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", shared_line)
 
     records = list(activity_log.iter_records(log_dir))
 
     assert len(records) == 1
     assert records[0][2]["summary"] == "loose"
+
+
+def test_iter_records_best_effort_unions_shadowed_archive_member(tmp_path):
+    """PR #290 R2: best-effort reader also unions shadowed members."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    shared_line = json.dumps(activity_log.compose_record(summary="loose")) + "\n"
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_text(shared_line, encoding="utf-8")
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr(
+            "2026-06-20.jsonl",
+            shared_line
+            + json.dumps(activity_log.compose_record(summary="archived"))
+            + "\n",
+        )
+
+    records = list(activity_log._iter_records_best_effort(log_dir))
+
+    summaries = [rec[2]["summary"] for rec in records]
+    assert sorted(summaries) == ["archived", "loose"]
+
+
+def test_merge_preserves_existing_member_duplicate_rows(tmp_path):
+    """PR #290 R2: existing member's duplicate identical rows survive a merge.
+
+    Byte-identical rows are a legitimate ledger state (second-resolution ts,
+    env-pinned session_id); the merge must not collapse the archive's own
+    multiplicity — only suppress loose copies already covered by existing.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    row = json.dumps(activity_log.compose_record(summary="dup")) + "\n"
+    with ZipFile(log_dir / "archive.zip", "w") as zf:
+        zf.writestr("2026-06-20.jsonl", row + row)
+    loose = log_dir / "2026-06-20.jsonl"
+    loose.write_text(row, encoding="utf-8")
+
+    activity_log.archive_directory(log_dir, today="2026-06-21")
+
+    with ZipFile(log_dir / "archive.zip") as zf:
+        assert zf.namelist() == ["2026-06-20.jsonl"]
+        payload = zf.read("2026-06-20.jsonl")
+    assert payload == row.encode("utf-8") * 2
 
 
 def test_archive_directory_merges_existing_member_once(tmp_path):


### PR DESCRIPTION
## What

When a loose closed-day JSONL file reappears with the same name as a member already inside `archive.zip` (clock rollback, file-sync restore of `~/.alfred/logs`, manual extraction), `archive_directory` skipped the existing member and wrote the loose file in its place — silently destroying previously archived rows for that day.

Name collisions now **merge**: a new `_merge_jsonl_payloads` helper writes the existing member's rows first (order preserved), then loose-file rows not already present.

- Row identity for dedupe = `bytes.splitlines()` line content — terminator-independent, so a byte-identical restored file leaves the member unchanged and CRLF/LF variants of the same row dedupe.
- Missing trailing newline on the existing payload cannot concatenate rows (joined with `\n` + trailing newline).
- Blank/whitespace-only lines are dropped; no JSON parsing in the merge path (corrupt rows pass through as-is, reader layer already skips them best-effort).
- Each member name is written to the new zip exactly once; non-colliding members/files and the unlink discipline are unchanged.
- The corrupt-archive `--force` path is unchanged (an unreadable archive has nothing to merge).

## Tests (TDD, two-worker split)

Failing tests written first by a separate test-writer; RED independently verified before implementation (4 failed / 43 passed):

- `test_archive_directory_merges_divergent_rows` — archive r1,r2 + reappeared r2,r3 → member is r1,r2,r3 exactly once, existing-first.
- `test_archive_directory_handles_missing_trailing_newline_in_existing_member`
- `test_archive_directory_merged_records_pass_validation` — every merged record passes `validate_record` via `iter_records` on the archive.
- `test_archive_directory_merges_existing_member_once` — updated from the old replace-behavior test (`test_archive_directory_replaces_existing_member_once`), which pinned the buggy contract.
- `test_archive_directory_noop_on_identical_restore` — guard: byte-identical restore leaves the member unchanged, no duplicated rows.

## Verification

- `pytest`: 1404 passed, 2 skipped
- `ruff check` / `ruff format --check`: clean
- `pyright src/`: 0 errors
- `af validate`: 0 issues
- Plan pre-reviewed by trinity triad (COR-1609): GLM 9.1 / DeepSeek 9.0 / MiniMax 9.3, zero blocking

## Scope hints

In scope: `_merge_jsonl_payloads` + the collision branch of the zip-write loop in `src/fx_alfred/core/activity_log.py`; the five tests above.
Out of scope: locking (issue #263, merged in #289); semantic/JSON-identity dedupe; timestamp reordering across sources; `--force` corrupt-archive recovery semantics.

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)