### PR TITLE
fix(fxa-265): af create refuses titles whose filename fails FILENAME_PATTERN

### DIFF
--- a/src/fx_alfred/commands/create_cmd.py
+++ b/src/fx_alfred/commands/create_cmd.py
@@ -14,6 +14,7 @@ from fx_alfred.commands._helpers import (
     validate_spec_status,
 )
 from fx_alfred.context import get_root, root_option
+from fx_alfred.core.document import FILENAME_PATTERN
 from fx_alfred.core.normalize import slugify
 from fx_alfred.core.projects import project_layer_dir
 from fx_alfred.core.schema import (
@@ -42,6 +43,15 @@ def validate_acid(ctx, param, value):
     if not re.match(r"^\d{4}$", value):
         raise click.BadParameter("must be exactly 4 digits (e.g., 2100)")
     return value
+
+
+def _validate_generated_filename(filename: str, title: str) -> str:
+    if not FILENAME_PATTERN.match(filename):
+        raise click.ClickException(
+            f"Title {title!r} generated invalid filename {filename!r}. "
+            "Choose a title with at least one alphanumeric character so the slug is not empty."
+        )
+    return filename
 
 
 def _next_acid_in_area(docs: list, prefix: str, area: str) -> str:
@@ -139,6 +149,112 @@ def _validate_spec_required_sections(
             raise click.ClickException(
                 f"Required section '{section}' missing for {doc_type.value}"
             )
+
+
+def _resolve_spec_fields(
+    spec: dict[str, Any],
+    prefix: str | None,
+    acid: str | None,
+    area: str | None,
+    title: str | None,
+) -> tuple[DocType, str, str | None, str | None, str, dict[str, Any], dict[str, Any]]:
+    """Extract, override with CLI args, and validate spec fields for --spec mode."""
+    if not isinstance(spec, dict):
+        raise click.ClickException("Spec file must contain a YAML mapping")
+
+    # Extract and validate type
+    type_str = spec.get("type")
+    if type_str is None:
+        raise click.ClickException("Spec file missing 'type' field")
+    doc_type_enum = _validate_spec_doc_type(type_str)
+
+    # Extract prefix, acid, title from spec if not given via CLI
+    spec_prefix = spec.get("prefix")
+    spec_acid = spec.get("acid")
+    spec_title = spec.get("title")
+    spec_area = spec.get("area")
+
+    # CLI args override spec
+    final_prefix = prefix if prefix is not None else spec_prefix
+    final_acid = acid if acid is not None else spec_acid
+    final_title = title if title is not None else spec_title
+    final_area = area if area is not None else spec_area
+
+    # Enforce acid/area mutual exclusivity from spec
+    if spec_acid is not None and spec_area is not None:
+        raise click.ClickException("Spec cannot contain both 'acid' and 'area'")
+
+    # Enforce acid/area mutual exclusivity across all sources (CLI + spec)
+    if final_acid is not None and final_area is not None:
+        raise click.ClickException("Cannot specify both acid and area")
+
+    # Validate required fields
+    if final_prefix is None:
+        raise click.ClickException("Prefix required (via --prefix or spec file)")
+    if final_title is None:
+        raise click.ClickException("Title required (via --title or spec file)")
+    if final_acid is None and final_area is None:
+        raise click.ClickException(
+            "ACID or area required (via --acid/--area or spec file)"
+        )
+
+    # Validate prefix format (reuse callback logic)
+    if not re.match(r"^[A-Z]{3}$", final_prefix):
+        raise click.ClickException("Prefix must be exactly 3 uppercase letters")
+    if final_prefix == "COR":
+        raise click.ClickException("COR prefix is reserved for PKG layer")
+
+    # Validate ACID format if provided
+    if final_acid is not None:
+        if not re.match(r"^\d{4}$", str(final_acid)):
+            raise click.ClickException("ACID must be exactly 4 digits")
+        final_acid = str(final_acid)
+        if final_acid == "0000":
+            raise click.ClickException(
+                "ACID 0000 is reserved for generated index files"
+            )
+
+    # Validate area format if provided
+    if final_area is not None:
+        if not re.match(r"^\d{2}$", str(final_area)):
+            raise click.ClickException("Area must be exactly 2 digits")
+
+    # Extract and validate metadata
+    spec_metadata = spec.get("metadata", {})
+    spec_sections = spec.get("sections", {})
+
+    if not isinstance(spec_metadata, dict):
+        raise click.ClickException(
+            "Spec 'metadata' must be a mapping (key: value pairs)"
+        )
+    if not isinstance(spec_sections, dict):
+        raise click.ClickException(
+            "Spec 'sections' must be a mapping (key: value pairs)"
+        )
+
+    # Auto-fill Last updated if not provided (before validation)
+    if "Last updated" not in spec_metadata:
+        spec_metadata["Last updated"] = date.today().isoformat()
+
+    # Validate required metadata
+    _validate_spec_required_metadata(doc_type_enum, spec_metadata)
+
+    # Validate required sections
+    _validate_spec_required_sections(doc_type_enum, spec_sections)
+
+    # Validate status if provided
+    if "Status" in spec_metadata:
+        validate_spec_status(doc_type_enum, spec_metadata["Status"])
+
+    return (
+        doc_type_enum,
+        final_prefix,
+        final_acid,
+        final_area,
+        final_title,
+        spec_metadata,
+        spec_sections,
+    )
 
 
 def _generate_spec_document(
@@ -282,92 +398,15 @@ def create_cmd(
         except yaml.YAMLError as e:
             raise click.ClickException(f"Invalid YAML in spec file: {e}")
 
-        if not isinstance(spec, dict):
-            raise click.ClickException("Spec file must contain a YAML mapping")
-
-        # Extract and validate type
-        type_str = spec.get("type")
-        if type_str is None:
-            raise click.ClickException("Spec file missing 'type' field")
-        doc_type_enum = _validate_spec_doc_type(type_str)
-
-        # Extract prefix, acid, title from spec if not given via CLI
-        spec_prefix = spec.get("prefix")
-        spec_acid = spec.get("acid")
-        spec_title = spec.get("title")
-        spec_area = spec.get("area")
-
-        # CLI args override spec
-        final_prefix = prefix if prefix is not None else spec_prefix
-        final_acid = acid if acid is not None else spec_acid
-        final_title = title if title is not None else spec_title
-        final_area = area if area is not None else spec_area
-
-        # Enforce acid/area mutual exclusivity from spec
-        if spec_acid is not None and spec_area is not None:
-            raise click.ClickException("Spec cannot contain both 'acid' and 'area'")
-
-        # Enforce acid/area mutual exclusivity across all sources (CLI + spec)
-        if final_acid is not None and final_area is not None:
-            raise click.ClickException("Cannot specify both acid and area")
-
-        # Validate required fields
-        if final_prefix is None:
-            raise click.ClickException("Prefix required (via --prefix or spec file)")
-        if final_title is None:
-            raise click.ClickException("Title required (via --title or spec file)")
-        if final_acid is None and final_area is None:
-            raise click.ClickException(
-                "ACID or area required (via --acid/--area or spec file)"
-            )
-
-        # Validate prefix format (reuse callback logic)
-        if not re.match(r"^[A-Z]{3}$", final_prefix):
-            raise click.ClickException("Prefix must be exactly 3 uppercase letters")
-        if final_prefix == "COR":
-            raise click.ClickException("COR prefix is reserved for PKG layer")
-
-        # Validate ACID format if provided
-        if final_acid is not None:
-            if not re.match(r"^\d{4}$", str(final_acid)):
-                raise click.ClickException("ACID must be exactly 4 digits")
-            final_acid = str(final_acid)
-            if final_acid == "0000":
-                raise click.ClickException(
-                    "ACID 0000 is reserved for generated index files"
-                )
-
-        # Validate area format if provided
-        if final_area is not None:
-            if not re.match(r"^\d{2}$", str(final_area)):
-                raise click.ClickException("Area must be exactly 2 digits")
-
-        # Extract and validate metadata
-        spec_metadata = spec.get("metadata", {})
-        spec_sections = spec.get("sections", {})
-
-        if not isinstance(spec_metadata, dict):
-            raise click.ClickException(
-                "Spec 'metadata' must be a mapping (key: value pairs)"
-            )
-        if not isinstance(spec_sections, dict):
-            raise click.ClickException(
-                "Spec 'sections' must be a mapping (key: value pairs)"
-            )
-
-        # Auto-fill Last updated if not provided (before validation)
-        if "Last updated" not in spec_metadata:
-            spec_metadata["Last updated"] = date.today().isoformat()
-
-        # Validate required metadata
-        _validate_spec_required_metadata(doc_type_enum, spec_metadata)
-
-        # Validate required sections
-        _validate_spec_required_sections(doc_type_enum, spec_sections)
-
-        # Validate status if provided
-        if "Status" in spec_metadata:
-            validate_spec_status(doc_type_enum, spec_metadata["Status"])
+        (
+            doc_type_enum,
+            final_prefix,
+            final_acid,
+            final_area,
+            final_title,
+            spec_metadata,
+            spec_sections,
+        ) = _resolve_spec_fields(spec, prefix, acid, area, title)
 
         # Resolve write base
         write_base = _resolve_write_base(ctx, layer, subdir)
@@ -404,7 +443,10 @@ def create_cmd(
             spec_sections,
         )
 
-        filename = f"{final_prefix}-{final_acid}-{doc_type_enum.value}-{slugify(final_title)}.md"
+        filename = _validate_generated_filename(
+            f"{final_prefix}-{final_acid}-{doc_type_enum.value}-{slugify(final_title)}.md",
+            final_title,
+        )
         output_path = write_base / filename
 
         if dry_run:
@@ -465,7 +507,9 @@ def create_cmd(
                 f"{doc.filename}. "
                 "Try --area to auto-assign the next available ACID."
             )
-    filename = f"{prefix}-{acid}-{doc_type_lower.upper()}-{slugify(title)}.md"
+    filename = _validate_generated_filename(
+        f"{prefix}-{acid}-{doc_type_lower.upper()}-{slugify(title)}.md", title
+    )
     output_path = write_base / filename
 
     template_file = resources.files("fx_alfred.templates").joinpath(

--- a/tests/test_create_cmd.py
+++ b/tests/test_create_cmd.py
@@ -1245,6 +1245,45 @@ def test_create_rejects_title_dashes_and_spaces(tmp_path, monkeypatch):
     assert not bad_path.exists(), f"File was created at {bad_path} but should not exist"
 
 
+def test_create_rejects_whitespace_only_title(tmp_path):
+    """Title '   ' slugifies to "" via the early-return branch in slugify().
+
+    slugify("   ") → strip() → empty string → return "" immediately (line 12-13).
+    This is a distinct code path from "???" (unsafe chars stripped) and "- - -"
+    (hyphens collapsed after whitespace replacement), so it deserves its own
+    coverage pin.
+    """
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--root",
+            str(tmp_path),
+            "create",
+            "sop",
+            "--prefix",
+            "TST",
+            "--acid",
+            "9995",
+            "--title",
+            "   ",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit for whitespace-only title, got 0. "
+        f"Output: {result.output}"
+    )
+    # Error message must be actionable
+    combined = result.output.lower()
+    assert any(
+        word in combined for word in ("slug", "filename", "title", "empty", "invalid")
+    ), f"Error should mention the title or slug issue. Output: {result.output}"
+    # No file should exist on disk
+    bad_path = tmp_path / "rules" / "TST-9995-SOP-.md"
+    assert not bad_path.exists(), f"File was created at {bad_path} but should not exist"
+
+
 def test_create_allows_title_with_unsafe_chars_that_slugify_nonempty(
     tmp_path, monkeypatch
 ):
@@ -1266,3 +1305,103 @@ def test_create_allows_title_with_unsafe_chars_that_slugify_nonempty(
     )
     expected = tmp_path / "rules" / "TST-9997-SOP-ab.md"
     assert expected.exists(), f"Expected file at {expected} but it does not exist"
+
+
+def test_create_dry_run_rejects_title_that_slugifies_to_empty(tmp_path, monkeypatch):
+    """Guard-before-dry-run: title '???' slugifies to empty — reject before echoing content.
+
+    The filename validation fires before the dry-run block, so we expect:
+    - non-zero exit
+    - actionable error referencing the title or slug
+    - no file written to disk
+    - no dry-run content echoed ("Dry run", "Created", document body absent)
+    """
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "create",
+            "sop",
+            "--prefix",
+            "TST",
+            "--acid",
+            "9996",
+            "--title",
+            "???",
+            "--dry-run",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit for empty-slug title with --dry-run, got 0. "
+        f"Output: {result.output}"
+    )
+    # Error message must mention the offending title or slug
+    assert "???" in result.output or "slug" in result.output.lower(), (
+        f"Error should mention the title or slug issue. Output: {result.output}"
+    )
+    # No file should exist on disk (validation fires before filesystem IO)
+    bad_path = tmp_path / "rules" / "TST-9996-SOP-.md"
+    assert not bad_path.exists(), f"File was created at {bad_path} but should not exist"
+    # Dry-run content MUST NOT be echoed — the guard fires before it
+    assert "Dry run" not in result.output, (
+        f"Dry-run content was echoed despite failed validation. Output: {result.output}"
+    )
+    assert "Created" not in result.output, (
+        f"'Created' appeared in output despite failed validation. Output: {result.output}"
+    )
+
+
+def test_create_spec_dry_run_rejects_title_that_slugifies_to_empty(
+    tmp_path, monkeypatch
+):
+    """Guard-before-dry-run spec path: title '???' slugifies to empty — reject before echo.
+
+    Same contract as the non-spec dry-run test but via --spec with --dry-run flag.
+    """
+    monkeypatch.chdir(tmp_path)
+
+    spec_file = tmp_path / "spec.yaml"
+    spec_file.write_text(
+        "type: SOP\n"
+        "prefix: TST\n"
+        "acid: '9996'\n"
+        "title: '???'\n"
+        "metadata:\n"
+        "  Applies to: test\n"
+        "  Last updated: '2026-01-01'\n"
+        "  Last reviewed: '2026-01-01'\n"
+        "  Status: Active\n"
+        "sections:\n"
+        "  What Is It?: Test\n"
+        "  Why: Test\n"
+        "  When to Use: Test\n"
+        "  When NOT to Use: Test\n"
+        "  Steps: Test\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["create", "--spec", str(spec_file), "--dry-run"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit for spec with empty-slug title + --dry-run, got 0. "
+        f"Output: {result.output}"
+    )
+    # Error message must mention the offending title or slug
+    assert "???" in result.output or "slug" in result.output.lower(), (
+        f"Error should mention the title or slug issue. Output: {result.output}"
+    )
+    # No file should exist on disk
+    bad_path = tmp_path / "rules" / "TST-9996-SOP-.md"
+    assert not bad_path.exists(), f"File was created at {bad_path} but should not exist"
+    # Dry-run content MUST NOT be echoed
+    assert "Dry run" not in result.output, (
+        f"Dry-run content was echoed despite failed validation. Output: {result.output}"
+    )
+    assert "Created" not in result.output, (
+        f"'Created' appeared in output despite failed validation. Output: {result.output}"
+    )

--- a/tests/test_create_cmd.py
+++ b/tests/test_create_cmd.py
@@ -1141,3 +1141,128 @@ def test_create_layer_user_subdir_unaffected_by_mapping(tmp_path):
     )
     assert result.exit_code == 0, result.output
     assert (alfred / "MYP" / "MYP-3000-SOP-User-Subdir-Doc.md").exists()
+
+
+# ── FXA-265: Filename validation on create ──────────────────────────────────
+
+
+def test_create_rejects_title_that_slugifies_to_empty(tmp_path, monkeypatch):
+    """Title '???' slugifies to empty string, producing an invalid filename.
+
+    Before the fix, af create silently writes TST-9998-SOP-.md which is
+    invisible to af read / af list / the index (FILENAME_PATTERN title group
+    requires at least one character).
+    """
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["create", "sop", "--prefix", "TST", "--acid", "9998", "--title", "???"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit for empty-slug title, got 0. Output: {result.output}"
+    )
+    # Error message must mention the offending title or slug
+    assert "???" in result.output or "slug" in result.output.lower(), (
+        f"Error should mention the title or slug issue. Output: {result.output}"
+    )
+    # No file should exist on disk (the write must be blocked before filesystem IO)
+    bad_path = tmp_path / "rules" / "TST-9998-SOP-.md"
+    assert not bad_path.exists(), f"File was created at {bad_path} but should not exist"
+    # af read should also report not found (sanity: file isn't accidentally readable)
+    read_result = runner.invoke(cli, ["read", "TST-9998"], catch_exceptions=False)
+    assert read_result.exit_code != 0, (
+        f"af read should not find TST-9998, got exit {read_result.exit_code}"
+    )
+
+
+def test_create_rejects_spec_with_title_that_slugifies_to_empty(tmp_path, monkeypatch):
+    """Spec-file path: title '???' slugifies to empty — filename fails validation."""
+    monkeypatch.chdir(tmp_path)
+
+    spec_file = tmp_path / "spec.yaml"
+    spec_file.write_text(
+        "type: SOP\n"
+        "prefix: TST\n"
+        "acid: '9998'\n"
+        "title: '???'\n"
+        "metadata:\n"
+        "  Applies to: test\n"
+        "  Last updated: '2026-01-01'\n"
+        "  Last reviewed: '2026-01-01'\n"
+        "  Status: Active\n"
+        "sections:\n"
+        "  What Is It?: Test\n"
+        "  Why: Test\n"
+        "  When to Use: Test\n"
+        "  When NOT to Use: Test\n"
+        "  Steps: Test\n"
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["create", "--spec", str(spec_file)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit for spec with empty-slug title, got 0. "
+        f"Output: {result.output}"
+    )
+    # Error message must mention the offending title or slug
+    assert "???" in result.output or "slug" in result.output.lower(), (
+        f"Error should mention the title or slug issue. Output: {result.output}"
+    )
+    # No file should exist on disk
+    bad_path = tmp_path / "rules" / "TST-9998-SOP-.md"
+    assert not bad_path.exists(), f"File was created at {bad_path} but should not exist"
+
+
+def test_create_rejects_title_dashes_and_spaces(tmp_path, monkeypatch):
+    """Title '- - -' slugifies to empty string — filename fails validation.
+
+    All characters are either hyphens or spaces; slugify strips leading/trailing
+    hyphens and collapses runs, leaving an empty string.
+    """
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["create", "sop", "--prefix", "TST", "--acid", "9999", "--title", "- - -"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code != 0, (
+        f"Expected non-zero exit for dash-only title, got 0. Output: {result.output}"
+    )
+    # Error message must be actionable — check for common keywords
+    combined = result.output.lower()
+    assert any(
+        word in combined for word in ("- - -", "slug", "filename", "title", "empty")
+    ), f"Error should mention the title or slug issue. Output: {result.output}"
+    # No file should exist on disk
+    bad_path = tmp_path / "rules" / "TST-9999-SOP-.md"
+    assert not bad_path.exists(), f"File was created at {bad_path} but should not exist"
+
+
+def test_create_allows_title_with_unsafe_chars_that_slugify_nonempty(
+    tmp_path, monkeypatch
+):
+    """Title 'a?b' slugifies to 'ab' (non-empty) — must still create successfully.
+
+    Regression guard: filename validation must not over-block titles that
+    produce a valid slug after unsafe characters are stripped.
+    """
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["create", "sop", "--prefix", "TST", "--acid", "9997", "--title", "a?b"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, (
+        f"Title 'a?b' should slugify to 'ab' (non-empty) and succeed. "
+        f"Output: {result.output}"
+    )
+    expected = tmp_path / "rules" / "TST-9997-SOP-ab.md"
+    assert expected.exists(), f"Expected file at {expected} but it does not exist"


### PR DESCRIPTION
## What

`slugify` returns `""` for titles like `"???"` (every char stripped as path-unsafe) or `"- - -"` (hyphens stripped). Neither `af create` path validated the generated filename against `FILENAME_PATTERN`, so the command wrote `PREFIX-ACID-TYP-.md`, reported "Created", and the file was invisible to the entire CLI — `af read`/`af list`/the index/the duplicate-ACID check never match it, and a later create with the same ACID leaves the orphan behind.

Both create paths (CLI/template and `--spec`) now validate the generated filename via a shared `_validate_generated_filename` helper — mirroring `update_cmd`'s existing rename guard — **before** any filesystem write, dry-run output, or index update. Invalid titles are refused with an actionable `ClickException` naming the title and generated filename.

Also: extracted `_resolve_spec_fields` from `create_cmd` (the spec field-resolution/validation block, pure extraction, zero behavior change) to keep `create_cmd` under the CHG-2302 230-line architecture cap after the guard pushed it to 235 (now 158).

## Tests (TDD, two-worker split)

Failing tests written first by a separate test-writer; RED independently verified before implementation (3 failed: files were created with exit 0):

- `test_create_rejects_title_that_slugifies_to_empty` — CLI path, `"???"` → non-zero exit, no file, `af read` still not-found.
- `test_create_rejects_spec_with_title_that_slugifies_to_empty` — `--spec` path, same contract.
- `test_create_rejects_title_dashes_and_spaces` — `"- - -"` refused.
- `test_create_allows_title_with_unsafe_chars_that_slugify_nonempty` — `"a?b"` → `"ab"` still creates (over-blocking guard).

End-to-end reproduction re-run post-fix: `af create SOP --prefix TST --acid 9998 --title "???"` → exit 1, actionable error, zero files written; valid title creates + indexes normally.

## Verification

- `pytest`: 1415 passed, 2 skipped (includes the CHG-2302 architecture guard)
- `ruff check` / `ruff format --check` (0.15.20, matches CI): clean
- `pyright src/`: 0 errors
- Plan pre-reviewed by trinity triad (COR-1609): GLM 9.4 / DeepSeek 10.0 / MiniMax 9.4, zero blocking

## Scope hints

In scope: `_validate_generated_filename` + its two call sites and the `_resolve_spec_fields` extraction in `src/fx_alfred/commands/create_cmd.py`; the four tests above.
Out of scope: `slugify`'s contract (its `""` return is used elsewhere); repairing pre-existing orphan files; `update_cmd`'s existing rename guard.

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)