### PR TITLE
fix(fxa-273): guard os.fchmod so af log-archive works on non-POSIX platforms

### DIFF
--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -780,8 +780,12 @@ def archive_directory(
         fd, tmp_name = tempfile.mkstemp(
             prefix=f"archive.zip.tmp.{os.getpid()}.", dir=log_dir
         )
-        os.fchmod(fd, 0o644)
+        has_fchmod = hasattr(os, "fchmod")
+        if has_fchmod:
+            os.fchmod(fd, 0o644)
         os.close(fd)
+        if not has_fchmod:
+            os.chmod(tmp_name, 0o644)
         tmp_path = Path(tmp_name)
         try:
             with zipfile.ZipFile(tmp_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -1140,13 +1140,12 @@ def test_archive_and_append_succeed_when_fcntl_unavailable(tmp_path, monkeypatch
 
 
 def test_archive_directory_succeeds_when_fchmod_unavailable(tmp_path, monkeypatch):
-    """archive_directory succeeds on platforms where os.fchmod is absent.
+    """Regression guard: archive_directory succeeds when os.fchmod is absent.
 
-    On Windows os.fchmod does not exist. The unconditional call at
-    activity_log.py:783 raises AttributeError. The fix guards with
-    hasattr and falls back to path-based os.chmod after the fd is closed.
-
-    Currently RED — monkeypatch.delattr triggers the AttributeError.
+    On platforms where os.fchmod does not exist (e.g., Windows), the
+    implementation falls back to path-based os.chmod after the fd is
+    closed. This test simulates the missing attribute and verifies the
+    archive is produced correctly with all member content intact.
     """
     monkeypatch.delattr(os, "fchmod", raising=False)
 
@@ -1172,14 +1171,10 @@ def test_archive_directory_succeeds_when_fchmod_unavailable(tmp_path, monkeypatc
 
 
 def test_archive_without_fchmod_writes_readable_archive(tmp_path, monkeypatch):
-    """Archive created without os.fchmod has readable permissions.
+    """Regression guard: archive created without os.fchmod has readable permissions.
 
     When the fchmod fallback path is used, the resulting archive.zip
-    must still be owner-readable (and ideally group+other readable,
-    subject to umask).
-
-    Currently RED — the unconditional os.fchmod raises AttributeError
-    before reaching the permission assertion.
+    must still be owner-readable via the path-based os.chmod call.
     """
     monkeypatch.delattr(os, "fchmod", raising=False)
 
@@ -1196,9 +1191,7 @@ def test_archive_without_fchmod_writes_readable_archive(tmp_path, monkeypatch):
     archive = log_dir / "archive.zip"
     mode = archive.stat().st_mode
     # Readable by owner at minimum.
-    assert mode & 0o400, f"archive not owner-readable: {mode:o}"
-    # At least some read bits set (group/other, subject to umask).
-    assert mode & 0o444 != 0, f"archive has no read bits: {mode:o}"
+    assert (mode & 0o400) != 0, f"archive not owner-readable: {mode:o}"
 
 
 def test_iter_records_best_effort_treats_shadow_vanished_before_read_as_unshadowed(

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -1134,6 +1134,73 @@ def test_archive_and_append_succeed_when_fcntl_unavailable(tmp_path, monkeypatch
     assert "portable-append" in summaries
 
 
+# ---------------------------------------------------------------------------
+# FXA-273: fchmod guard for non-POSIX platforms
+# ---------------------------------------------------------------------------
+
+
+def test_archive_directory_succeeds_when_fchmod_unavailable(tmp_path, monkeypatch):
+    """archive_directory succeeds on platforms where os.fchmod is absent.
+
+    On Windows os.fchmod does not exist. The unconditional call at
+    activity_log.py:783 raises AttributeError. The fix guards with
+    hasattr and falls back to path-based os.chmod after the fd is closed.
+
+    Currently RED — monkeypatch.delattr triggers the AttributeError.
+    """
+    monkeypatch.delattr(os, "fchmod", raising=False)
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    old_file = log_dir / "2026-06-20.jsonl"
+    old_file.write_text(
+        json.dumps(activity_log.compose_record(summary="archived-record")) + "\n",
+        encoding="utf-8",
+    )
+
+    result = activity_log.archive_directory(log_dir, today="2026-06-21")
+
+    assert result.archived_files == ["2026-06-20.jsonl"]
+    assert not old_file.exists()
+
+    # Archive must be readable via iter_records with member content intact.
+    archive = log_dir / "archive.zip"
+    records = list(activity_log.iter_records(archive))
+    assert len(records) == 1
+    _source, _lineno, record = records[0]
+    assert record["summary"] == "archived-record"
+
+
+def test_archive_without_fchmod_writes_readable_archive(tmp_path, monkeypatch):
+    """Archive created without os.fchmod has readable permissions.
+
+    When the fchmod fallback path is used, the resulting archive.zip
+    must still be owner-readable (and ideally group+other readable,
+    subject to umask).
+
+    Currently RED — the unconditional os.fchmod raises AttributeError
+    before reaching the permission assertion.
+    """
+    monkeypatch.delattr(os, "fchmod", raising=False)
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    old_file = log_dir / "2026-06-20.jsonl"
+    old_file.write_text(
+        json.dumps(activity_log.compose_record(summary="permission-test")) + "\n",
+        encoding="utf-8",
+    )
+
+    activity_log.archive_directory(log_dir, today="2026-06-21")
+
+    archive = log_dir / "archive.zip"
+    mode = archive.stat().st_mode
+    # Readable by owner at minimum.
+    assert mode & 0o400, f"archive not owner-readable: {mode:o}"
+    # At least some read bits set (group/other, subject to umask).
+    assert mode & 0o444 != 0, f"archive has no read bits: {mode:o}"
+
+
 def test_iter_records_best_effort_treats_shadow_vanished_before_read_as_unshadowed(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## What

`archive_directory` (activity_log.py:783) called `os.fchmod(fd, 0o644)` unconditionally — the one unguarded Unix-only call in a module that carefully guards every `fcntl` use. On Windows, the first closed-day archival crashed `af log-archive` (and `af log` via its lazy-archival guard, which catches only `ArchiveError`/`OSError`, not `AttributeError`).

Fix: `os.fchmod` is used only when available; otherwise a path-based `os.chmod(tmp_name, 0o644)` runs after the fd closes, before the zip write — same permissions outcome, portable.

Module audit (per issue AC): no other unguarded Unix-only crash path remains — `fcntl`/`flock` already guarded; `os.kill(pid, 0)` in `_archive_tmp_is_stale` sits inside try/except covering `ProcessLookupError`/`PermissionError`/`OSError`.

## Tests (TDD, two-worker split)

RED first (independently verified: 2 failed with `AttributeError: module 'os' has no attribute 'fchmod'` at activity_log.py:783):
- `test_archive_directory_succeeds_when_fchmod_unavailable` — `monkeypatch.delattr(os, "fchmod")` → archival succeeds, archive readable via `iter_records`, member content intact.
- `test_archive_without_fchmod_writes_readable_archive` — resulting archive.zip carries readable permissions.

## Verification

- `pytest`: 1420 passed, 2 skipped (branch base pre-#296; post-merge CI runs the union)
- `ruff check` / `format --check` (0.15.20): clean; `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.6 / DeepSeek 9.5 / MiniMax 9.5, zero blocking

## Scope hints

In scope: the fchmod guard in `archive_directory` (`src/fx_alfred/core/activity_log.py`); the two tests above.
Out of scope: `log_cmd`'s exception-catch breadth (root cause removed); atomic_write permissions (issue #274, separate PR); other modules' platform audits.

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)