### PR TITLE
fix(fxa-272): re-sync KNOWN_OPTIONAL_ORDER with schema.OPTIONAL_METADATA

### DIFF
--- a/src/fx_alfred/core/normalize.py
+++ b/src/fx_alfred/core/normalize.py
@@ -51,9 +51,13 @@ KNOWN_OPTIONAL_ORDER = [
     "Workflow requires",
     "Workflow provides",
     "Workflow loops",
+    "Workflow branches",
     "Always included",
     "Task tags",
     "Tags",
+    "Disposition",
+    "Instantiates",
+    "Overlays",
 ]
 
 

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -4,12 +4,13 @@ import pytest
 
 
 from fx_alfred.core.normalize import (
+    KNOWN_OPTIONAL_ORDER,
     slugify,
     normalize_date,
     sort_metadata,
     strip_trailing_whitespace,
 )
-from fx_alfred.core.schema import DocType
+from fx_alfred.core.schema import OPTIONAL_METADATA, DocType
 
 
 pytestmark = pytest.mark.unit
@@ -91,3 +92,67 @@ def test_strip_trailing_whitespace(lines, expected):
 )
 def test_normalize_date(value, expected):
     assert normalize_date(value) == expected
+
+
+# ---------------------------------------------------------------------------
+# FXA-272: KNOWN_OPTIONAL_ORDER drift tests
+# ---------------------------------------------------------------------------
+
+
+def test_known_optional_order_covers_all_schema_optional_fields():
+    """Every optional-metadata field name across all DocTypes must appear
+    in KNOWN_OPTIONAL_ORDER, otherwise fmt sorts it into the unknown tail."""
+    all_schema_fields: set[str] = set()
+    for field_list in OPTIONAL_METADATA.values():
+        all_schema_fields.update(field_list)
+
+    known = set(KNOWN_OPTIONAL_ORDER)
+    missing = sorted(all_schema_fields - known)
+    assert missing == [], (
+        f"OPTIONAL_METADATA fields missing from KNOWN_OPTIONAL_ORDER: {missing}"
+    )
+
+
+def test_sort_metadata_keeps_workflow_branches_adjacent():
+    """Workflow branches must sort adjacent to Workflow loops, not after Tags.
+    Disposition must sort before truly-unknown fields. X-Custom stays last."""
+    fields = [
+        "Tags",
+        "Workflow loops",
+        "Workflow branches",
+        "Disposition",
+        "X-Custom",
+    ]
+    result = sort_metadata(fields, DocType.SOP)
+
+    # Workflow branches must appear before Tags (i.e. adjacent to Workflow
+    # group, not dumped into the unknown tail after Tags).
+    wb_idx = result.index("Workflow branches")
+    tags_idx = result.index("Tags")
+    assert wb_idx < tags_idx, (
+        f"Workflow branches ({wb_idx}) must sort before Tags ({tags_idx}); got {result}"
+    )
+
+    # Disposition must sort before the truly-unknown X-Custom.
+    disp_idx = result.index("Disposition")
+    x_idx = result.index("X-Custom")
+    assert disp_idx < x_idx, (
+        f"Disposition ({disp_idx}) must sort before X-Custom ({x_idx}); got {result}"
+    )
+
+    # X-Custom must be last.
+    assert result[-1] == "X-Custom", f"X-Custom must be last; got {result}"
+
+
+def test_sort_metadata_idempotent():
+    """Sorting twice must equal sorting once."""
+    fields = [
+        "Tags",
+        "Workflow loops",
+        "Workflow branches",
+        "Disposition",
+        "X-Custom",
+    ]
+    once = sort_metadata(fields, DocType.SOP)
+    twice = sort_metadata(once, DocType.SOP)
+    assert twice == once, f"sort_metadata not idempotent: {once} -> {twice}"


### PR DESCRIPTION
## What

`KNOWN_OPTIONAL_ORDER` (normalize.py) drifted from `schema.OPTIONAL_METADATA`: `Workflow branches`, `Disposition`, `Instantiates`, `Overlays` were missing, so `af fmt --write` / `af tag add` on docs carrying them (e.g. COR-1500's `Disposition:`) sorted these fields into the truly-unknown tail after `Tags`, separating `Workflow branches` from the other `Workflow *` fields.

Order-list-only fix (4 lines): `Workflow branches` beside `Workflow loops`; `Disposition`/`Instantiates`/`Overlays` after `Tags`. A drift test pins union(`OPTIONAL_METADATA.values()`) ⊆ `KNOWN_OPTIONAL_ORDER` so a future schema addition fails fast (same pattern as `test_docs_drift.py`).

Repo-wide audit (per plan): `af fmt --check --root .` reports 197 docs needing formatting **both before and after** this change (verified with the released 1.25.1 binary vs this branch) — pre-existing drift, zero new reformat churn introduced here; not touched in this PR.

## Tests (TDD, two-worker split)

RED first (independently verified: 2 failed / 16 passed):
- `test_known_optional_order_covers_all_schema_optional_fields` — drift guard, failed listing exactly the 4 missing fields.
- `test_sort_metadata_keeps_workflow_branches_adjacent` — ordering regression (Workflow branches was sorting after Tags).
- `test_sort_metadata_idempotent` — guard, passes before and after.

## Verification

- `pytest`: 1424 passed, 2 skipped; `ruff` clean (0.15.20); `pyright src/`: 0 errors; `af validate`: 0 issues
- Plan pre-reviewed by triad (COR-1609): GLM 9.4 / DeepSeek 9.6 / MiniMax 9.4, zero blocking

## Scope hints

In scope: the four entries in `KNOWN_OPTIONAL_ORDER` (`src/fx_alfred/core/normalize.py`); the three tests.
Out of scope: `sort_metadata` logic; `schema.py`; reformatting the 197 pre-existing-drift docs (separate housekeeping if desired).

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)