### PR TITLE
fix(fxa-274): atomic writes preserve target file mode; umask default for new files

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ src/fx_alfred/
 │   ├── compose.py         # af plan --task auto-composition; raises CompositionError
 │   ├── dag_graph.py       # nested phase-box DAG renderer
 │   ├── document.py        # Document dataclass, FILENAME_PATTERN
+│   ├── fsmode.py          # resolve_write_mode() — shared atomic-write mode resolution (FXA-274)
 │   ├── mermaid.py         # Mermaid diagram renderer
 │   ├── normalize.py       # slugify(), sort_metadata(), normalize_date(), strip_trailing_whitespace()
 │   ├── parser.py          # parse_metadata(), render_document(), extract_section(), fence-state iterator

--- a/src/fx_alfred/commands/_helpers.py
+++ b/src/fx_alfred/commands/_helpers.py
@@ -3,7 +3,6 @@
 import importlib
 import json
 import os
-import stat
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -12,6 +11,7 @@ import click
 
 from fx_alfred.context import get_root
 from fx_alfred.core.document import Document
+from fx_alfred.core.fsmode import resolve_write_mode
 from fx_alfred.core.scanner import (
     AmbiguousDocumentError,
     DocumentNotFoundError,
@@ -114,13 +114,7 @@ def atomic_write(path: Path, content: str) -> None:
     Raises:
         OSError: If file operations fail (propagated after cleanup).
     """
-    if path.exists():
-        mode = stat.S_IMODE(path.stat().st_mode)
-    else:
-        # Read the process umask via the standard round-trip; this CLI is single-threaded.
-        current_umask = os.umask(0)
-        os.umask(current_umask)
-        mode = 0o666 & ~current_umask
+    mode = resolve_write_mode(path)
 
     fd, tmp_path_str = tempfile.mkstemp(dir=str(path.parent), suffix=".md.tmp")
     try:

--- a/src/fx_alfred/commands/_helpers.py
+++ b/src/fx_alfred/commands/_helpers.py
@@ -3,6 +3,7 @@
 import importlib
 import json
 import os
+import stat
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -113,10 +114,19 @@ def atomic_write(path: Path, content: str) -> None:
     Raises:
         OSError: If file operations fail (propagated after cleanup).
     """
+    if path.exists():
+        mode = stat.S_IMODE(path.stat().st_mode)
+    else:
+        # Read the process umask via the standard round-trip; this CLI is single-threaded.
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+        mode = 0o666 & ~current_umask
+
     fd, tmp_path_str = tempfile.mkstemp(dir=str(path.parent), suffix=".md.tmp")
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
+        os.chmod(tmp_path_str, mode)
         os.replace(tmp_path_str, str(path))
     except Exception:
         # Clean up temp file on any failure

--- a/src/fx_alfred/core/fsmode.py
+++ b/src/fx_alfred/core/fsmode.py
@@ -1,0 +1,30 @@
+"""File-mode resolution for atomic writers (FXA-274 / DeepSeek FIX dedup).
+
+Shared by commands/_helpers.py::atomic_write and core/preferences.py's
+internal writer, both of which need to preserve or infer a Unix file
+mode before replacing a target file via tempfile + os.replace.
+"""
+
+import os
+import stat
+from pathlib import Path
+
+
+def resolve_write_mode(path: Path) -> int:
+    """Resolve the mode to apply to a file about to be atomically replaced.
+
+    If `path` already exists, reuse its current mode so an atomic
+    replace doesn't silently change permissions on an existing file.
+
+    If `path` does not exist yet, infer the mode a plain ``open(path, "w")``
+    would have produced: 0o666 masked by the process umask. There is no
+    direct API to read the umask without changing it, so this does the
+    standard round-trip (set to 0, read the old value back, restore it
+    immediately). The round-trip is process-wide; callers are synchronous
+    CLI paths, so no other thread observes the momentarily-cleared umask.
+    """
+    if path.exists():
+        return stat.S_IMODE(path.stat().st_mode)
+    current_umask = os.umask(0)
+    os.umask(current_umask)
+    return 0o666 & ~current_umask

--- a/src/fx_alfred/core/preferences.py
+++ b/src/fx_alfred/core/preferences.py
@@ -8,6 +8,7 @@ click.ClickException at the CLI boundary.
 from __future__ import annotations
 
 import os
+import stat
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -54,12 +55,21 @@ def load_preferences() -> dict[str, Any]:
 def _atomic_write(path: Path, content: str) -> None:
     """Write content to path via tempfile + os.replace (no .tmp leftover)."""
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        mode = stat.S_IMODE(path.stat().st_mode)
+    else:
+        # Read the process umask via the standard round-trip; this CLI is single-threaded.
+        current_umask = os.umask(0)
+        os.umask(current_umask)
+        mode = 0o666 & ~current_umask
+
     fd, tmp_path = tempfile.mkstemp(
         prefix=".preferences.", suffix=".tmp", dir=str(path.parent)
     )
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             f.write(content)
+        os.chmod(tmp_path, mode)
         os.replace(tmp_path, path)
     except Exception:
         if os.path.exists(tmp_path):

--- a/src/fx_alfred/core/preferences.py
+++ b/src/fx_alfred/core/preferences.py
@@ -8,12 +8,13 @@ click.ClickException at the CLI boundary.
 from __future__ import annotations
 
 import os
-import stat
 import tempfile
 from pathlib import Path
 from typing import Any
 
 import yaml
+
+from fx_alfred.core.fsmode import resolve_write_mode
 
 
 _HEADER_COMMENT = "# Managed by `af star` and `af tag vocab`; safe to edit by hand.\n"
@@ -55,13 +56,7 @@ def load_preferences() -> dict[str, Any]:
 def _atomic_write(path: Path, content: str) -> None:
     """Write content to path via tempfile + os.replace (no .tmp leftover)."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists():
-        mode = stat.S_IMODE(path.stat().st_mode)
-    else:
-        # Read the process umask via the standard round-trip; this CLI is single-threaded.
-        current_umask = os.umask(0)
-        os.umask(current_umask)
-        mode = 0o666 & ~current_umask
+    mode = resolve_write_mode(path)
 
     fd, tmp_path = tempfile.mkstemp(
         prefix=".preferences.", suffix=".tmp", dir=str(path.parent)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,3 +1,5 @@
+import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -222,6 +224,59 @@ def test_atomic_write_preserves_existing(tmp_path):
 
     # Original file should be unchanged
     assert file_path.read_text() == original_content
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="permission bits not portable on Windows"
+)
+def test_atomic_write_preserves_permissions(tmp_path):
+    """atomic_write preserves the target file's permission bits (FXA-274).
+
+    Regression: tempfile.mkstemp creates with mode 0o600; os.replace
+    keeps that mode, so the target's original permissions were silently
+    narrowed to owner-only.
+    """
+    from fx_alfred.commands._helpers import atomic_write
+
+    file_path = tmp_path / "test.md"
+    original_content = "# Original\n"
+    new_content = "# New Content\n"
+
+    file_path.write_text(original_content)
+    file_path.chmod(0o664)
+    assert (file_path.stat().st_mode & 0o777) == 0o664  # precondition
+
+    atomic_write(file_path, new_content)
+
+    assert file_path.read_text() == new_content
+    mode = file_path.stat().st_mode
+    assert (mode & 0o777) == 0o664, f"Expected 0o664, got {oct(mode & 0o777)}"
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="permission bits not portable on Windows"
+)
+def test_atomic_write_new_file_respects_umask(tmp_path):
+    """atomic_write creates new files with umask-respecting permissions (FXA-274).
+
+    Current behaviour (mkstemp default 0o600) ignores the process umask.
+    Fix uses 0o666 & ~umask so group/other read is controlled by umask.
+    """
+    from fx_alfred.commands._helpers import atomic_write
+
+    file_path = tmp_path / "new.md"
+    content = "# New File\n"
+
+    old_umask = os.umask(0o022)
+    try:
+        atomic_write(file_path, content)
+        mode = file_path.stat().st_mode
+        expected = 0o666 & ~0o022  # 0o644
+        assert (mode & 0o777) == expected, (
+            f"Expected {oct(expected)}, got {oct(mode & 0o777)}"
+        )
+    finally:
+        os.umask(old_umask)
 
 
 # ── invoke_index_update tests (FXA-2166) ───────────────────────────────────

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -279,6 +279,32 @@ def test_atomic_write_new_file_respects_umask(tmp_path):
         os.umask(old_umask)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="permission bits not portable on Windows"
+)
+def test_atomic_write_new_file_respects_umask_077(tmp_path):
+    """atomic_write creates new files with umask-respecting permissions (FXA-274).
+
+    Tests a tighter umask (0o077 → expected mode 0o600) to pin the
+    resolve_write_mode new-file branch with a different umask value.
+    """
+    from fx_alfred.commands._helpers import atomic_write
+
+    file_path = tmp_path / "new_restricted.md"
+    content = "# Restricted File\n"
+
+    old_umask = os.umask(0o077)
+    try:
+        atomic_write(file_path, content)
+        mode = file_path.stat().st_mode
+        expected = 0o666 & ~0o077  # 0o600
+        assert (mode & 0o777) == expected, (
+            f"Expected {oct(expected)}, got {oct(mode & 0o777)}"
+        )
+    finally:
+        os.umask(old_umask)
+
+
 # ── invoke_index_update tests (FXA-2166) ───────────────────────────────────
 
 

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+
 import yaml
 import pytest
 
@@ -221,3 +223,30 @@ def test_add_custom_tags_no_write_when_all_already_present():
     result = add_custom_tags(["foo"])
     assert result == ["foo"]
     assert prefs.stat().st_mtime_ns == mtime_before
+
+
+# ── Permission preservation (FXA-274) ───────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="permission bits not portable on Windows"
+)
+def test_atomic_write_preserves_file_mode():
+    """_atomic_write preserves the existing preferences file's permission mode (FXA-274).
+
+    Regression: tempfile.mkstemp creates with mode 0o600; os.replace keeps that
+    mode, so a preferences.yaml with mode 0o640 (group-readable) is silently
+    narrowed to owner-only after any write operation.
+    """
+    prefs_path = preferences_path()
+    prefs_path.parent.mkdir(parents=True, exist_ok=True)
+    prefs_path.write_text("starred_docs:\n- COR-1001\n", encoding="utf-8")
+    prefs_path.chmod(0o640)
+    assert (prefs_path.stat().st_mode & 0o777) == 0o640  # precondition
+
+    add_custom_tags(["test-tag"])
+
+    mode = prefs_path.stat().st_mode
+    assert (mode & 0o777) == 0o640, f"Expected 0o640, got {oct(mode & 0o777)}"
+    # Verify content was actually written (the write path did execute)
+    assert "test-tag" in prefs_path.read_text()

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sys
 
 import yaml
@@ -250,3 +251,30 @@ def test_atomic_write_preserves_file_mode():
     assert (mode & 0o777) == 0o640, f"Expected 0o640, got {oct(mode & 0o777)}"
     # Verify content was actually written (the write path did execute)
     assert "test-tag" in prefs_path.read_text()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="permission bits not portable on Windows"
+)
+def test_atomic_write_new_file_respects_umask():
+    """When preferences.yaml does not exist, the created file's mode
+    honours the process umask (0o666 & ~umask) (FXA-274).
+
+    Coverage-pinning: the resolve_write_mode new-file path was
+    implemented but lacked a test through the preferences write layer.
+    """
+    prefs = preferences_path()
+    assert not prefs.exists(), "precondition: no preferences file yet"
+
+    old_umask = os.umask(0o022)
+    try:
+        add_custom_tags(["test-tag"])
+        mode = prefs.stat().st_mode
+        expected = 0o666 & ~0o022  # 0o644
+        assert (mode & 0o777) == expected, (
+            f"Expected {oct(expected)}, got {oct(mode & 0o777)}"
+        )
+        # Verify content was actually written (the write path did execute)
+        assert "test-tag" in prefs.read_text()
+    finally:
+        os.umask(old_umask)

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -1,5 +1,7 @@
 """Tests for af update command (PRP-2104)."""
 
+import sys
+
 import pytest
 
 
@@ -1218,3 +1220,35 @@ def test_update_rename_real_type_code_format(tmp_path, monkeypatch):
     content = new_path.read_text()
     # H1 should preserve the type_code format from the original document
     assert "# SOP-2100: Renamed Document" in content
+
+
+# ── Permission preservation (FXA-274) ───────────────────────────────────────
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32", reason="permission bits not portable on Windows"
+)
+def test_update_preserves_file_permissions(tmp_path, monkeypatch):
+    """af update preserves the document file's permission bits (FXA-274).
+
+    Regression: atomic_write uses tempfile.mkstemp (mode 0o600); os.replace
+    keeps that mode, silently narrowing a 0o664/0o644 doc to owner-only.
+    """
+    project = _make_project(tmp_path)
+    doc_path = project / "rules" / "TST-2100-SOP-Test-Document.md"
+    doc_path.chmod(0o664)
+    assert (doc_path.stat().st_mode & 0o777) == 0o664  # precondition
+
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--status", "Active"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    content = doc_path.read_text()
+    assert "**Status:** Active" in content
+    mode = doc_path.stat().st_mode
+    assert (mode & 0o777) == 0o664, f"Expected 0o664, got {oct(mode & 0o777)}"


### PR DESCRIPTION
## What

Both atomic-write helpers (`commands/_helpers.py::atomic_write`, `core/preferences.py::_atomic_write`) created temp files via `tempfile.mkstemp` (mode 0600) and `os.replace` kept that mode — the target's original permissions were never copied. Any `af update` / `af fmt --write` / `af tag add|rm` silently reset a group-readable 0644/0664 doc to owner-only 0600 (reproduced in the issue), breaking shared-checkout/CI readers.

Fix (symmetric, ~10 lines each): existing targets keep their permission bits (`stat.S_IMODE` copied onto the temp before replace); new files get a umask-respecting `0o666 & ~umask` instead of mkstemp's 0600. Path-based `os.chmod` only — no `os.fchmod`, per the #273 portability precedent. `export_cmd`'s `atomic_write` call site inherits the fix automatically.

## Tests (TDD, two-worker split)

RED first (independently verified: 4 failed, all "got 0o600"):
- helper: `test_atomic_write_preserves_permissions` (0664 kept), `test_atomic_write_new_file_respects_umask` (umask saved/restored in finally)
- command: `test_update_preserves_file_permissions` (CliRunner, 0664 kept through `af update`)
- preferences: `test_atomic_write_preserves_file_mode` (0640 kept)
- All four `skipif(win32)` — POSIX permission semantics.

## Verification

- `pytest`: 1427 passed, 2 skipped; `ruff` clean (0.15.20); `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.4 / DeepSeek 9.5 / MiniMax 9.7, zero blocking

## Scope hints

In scope: mode handling in the two atomic-write helpers; the four tests.
Out of scope: ownership/ACLs/xattrs; secrets handling (these helpers never write secrets); `export_cmd` (inherits); Windows chmod semantics (tests skipped there).

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)