### PR TITLE
fix(fxa-269): af update --dry-run renders difflib.unified_diff

### DIFF
--- a/src/fx_alfred/commands/update_cmd.py
+++ b/src/fx_alfred/commands/update_cmd.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import difflib
 import re
 import sys
 from datetime import date
@@ -402,17 +403,16 @@ def update_cmd(
 
     if dry_run:
         click.echo("Dry run — no changes written.\n")
-        # Show diff-like output
-        old_lines = content.split("\n")
-        new_lines = new_content.split("\n")
-        for i, (old, new) in enumerate(zip(old_lines, new_lines)):
-            if old != new:
-                click.echo(f"- {old}")
-                click.echo(f"+ {new}")
-        # Show extra lines
-        if len(new_lines) > len(old_lines):
-            for line in new_lines[len(old_lines) :]:
-                click.echo(f"+ {line}")
+        diff_lines = list(
+            difflib.unified_diff(
+                content.splitlines(keepends=True),
+                new_content.splitlines(keepends=True),
+                fromfile=f"{doc.filename}",
+                tofile=f"{doc.filename}",
+            )
+        )
+        for line in diff_lines:
+            click.echo(line, nl=False)
         if new_title and new_filename:
             click.echo(f"\nRename: {file_path.name} -> {new_filename}")
         return

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -470,7 +470,7 @@ def test_update_dry_run_no_write(tmp_path, monkeypatch):
 
 
 def test_update_dry_run_shows_diff(tmp_path, monkeypatch):
-    """Dry run shows what would change."""
+    """Dry run shows unified diff with ---/+++ headers and @@ hunk markers."""
     project = _make_project(tmp_path)
     monkeypatch.chdir(project)
     runner = CliRunner()
@@ -480,8 +480,165 @@ def test_update_dry_run_shows_diff(tmp_path, monkeypatch):
         catch_exceptions=False,
     )
     assert result.exit_code == 0
-    assert "- **Status:** Draft" in result.output
-    assert "+ **Status:** Active" in result.output
+    output = result.output
+    # Unified diff markers
+    assert "--- " in output
+    assert "+++ " in output
+    assert "@@" in output
+    # Changed lines appear with unified-diff prefixes (no space after -/+)
+    assert "-**Status:** Draft" in output
+    assert "+**Status:** Active" in output
+
+
+def test_update_dry_run_spec_shrink_shows_deletions(tmp_path, monkeypatch):
+    """--spec replacing a long section with a short one shows deleted lines.
+
+    The old hand-rolled zip-diff only handled the grew-longer case
+    (len(new) > len(old)); shrinking updates never showed removed
+    trailing lines.  Unified diff fixes this.
+    """
+    long_doc = """\
+# TST-2100: Test Document
+
+**Applies to:** All projects
+**Status:** Draft
+**Last updated:** 2026-01-01
+
+---
+
+## What Is It?
+
+Line alpha.
+Line beta.
+Line gamma.
+Line delta.
+Line epsilon.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-01-01 | Initial version | Author |
+"""
+    project = _make_project(tmp_path, long_doc)
+    monkeypatch.chdir(project)
+
+    spec = tmp_path / "shrink.yaml"
+    spec.write_text('sections:\n  "What Is It?": "Short replacement."\n')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--spec", str(spec), "--dry-run"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    output = result.output
+
+    # Unified diff markers
+    assert "--- " in output
+    assert "+++ " in output
+    assert "@@" in output
+
+    # Deleted lines from the old longer section MUST appear
+    assert "-Line alpha." in output
+    assert "-Line beta." in output
+    assert "-Line gamma." in output
+    # New short content appears
+    assert "+Short replacement." in output
+
+
+def test_update_dry_run_spec_insertion_no_cascade(tmp_path, monkeypatch):
+    """--spec inserting a line mid-document does not cascade false -/+ pairs.
+
+    The old zip(old_lines, new_lines) misaligns every subsequent pair
+    after an insertion point, producing bogus -/+ for every line that
+    follows.  Unified diff only shows genuinely changed lines.
+    """
+    project = _make_project(tmp_path)
+    monkeypatch.chdir(project)
+
+    # Add a new metadata field that gets inserted before the --- separator
+    spec = tmp_path / "insert.yaml"
+    spec.write_text('metadata:\n  "Reviewed by": "Alice"\n')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--spec", str(spec), "--dry-run"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    output = result.output
+
+    # Unified diff markers
+    assert "--- " in output
+    assert "+++ " in output
+    assert "@@" in output
+
+    # Count deletion-prefixed lines (excluding the "--- " from-file header).
+    # In unified diff, adding one metadata field + auto-touching Last updated
+    # should produce very few deletions.  The old zip-diff would cascade and
+    # show dozens of bogus -/+ pairs for every line after the insertion.
+    lines = output.split("\n")
+    delete_count = sum(
+        1 for line in lines if line.startswith("-") and not line.startswith("---")
+    )
+    assert delete_count <= 2, (
+        f"Expected ≤2 deletions, got {delete_count} (cascade bug).\nOutput:\n{output}"
+    )
+
+    # The new field appears
+    assert "+**Reviewed by:** Alice" in output
+
+
+@pytest.mark.parametrize(
+    "args,old_marker,new_marker",
+    [
+        (
+            ["update", "TST-2100", "--status", "Active", "--dry-run"],
+            "-**Status:** Draft",
+            "+**Status:** Active",
+        ),
+        (
+            [
+                "update",
+                "TST-2100",
+                "--history",
+                "New entry",
+                "--by",
+                "Tester",
+                "--dry-run",
+            ],
+            None,  # no specific deletion expected
+            "+|",  # the appended history row
+        ),
+    ],
+)
+def test_update_dry_run_unified_format(
+    tmp_path, monkeypatch, args, old_marker, new_marker
+):
+    """Dry-run through --status / --history produces unified diff format.
+
+    Both paths share the same dry-run branch in update_cmd.
+    """
+    project = _make_project(tmp_path)
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+    result = runner.invoke(cli, args, catch_exceptions=False)
+    assert result.exit_code == 0
+    output = result.output
+
+    # Unified diff markers
+    assert "--- " in output
+    assert "+++ " in output
+    assert "@@" in output
+
+    if old_marker is not None:
+        assert old_marker in output
+    assert new_marker in output
 
 
 def test_update_dry_run_rename(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

The `af update --dry-run` preview hand-rolled a diff via `zip(old_lines, new_lines)` plus a grew-longer tail loop: a shrinking update (e.g. a `--spec` section patch replacing a long section with a short one) never showed the removed trailing lines, and any mid-file insertion cascaded into bogus `-`/`+` pairs for every subsequent line — the preview misrepresented the write.

The manual zip-diff is deleted; the preview now uses `difflib.unified_diff` with `fmt_cmd`'s exact idiom (`splitlines(keepends=True)`, filename labels, `click.echo(..., nl=False)`) so both commands' previews are identical in format. Net diff in the region: 11+/11−.

## Tests (TDD, two-worker split)

RED first (independently verified: 5 failed, old bare -/+ format with visible cascade):
- `test_update_dry_run_shows_diff` — rewritten from the old-format pin to the unified contract (`---`/`+++`/`@@`).
- `test_update_dry_run_spec_shrink_shows_deletions` — deleted lines now appear.
- `test_update_dry_run_spec_insertion_no_cascade` — bounded deletion count, no cascading pairs.
- `test_update_dry_run_unified_format[--status/--history]` — shared dry-run branch parametrized.
- Existing `test_update_dry_run_no_write` guard unchanged.

## Verification

- `pytest`: 1430 passed, 2 skipped; `ruff` clean (0.15.20); `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.55/9.4 (R1/R2) / DeepSeek 9.6 / MiniMax 9.3, zero blocking

## Scope hints

In scope: the dry-run preview block in `src/fx_alfred/commands/update_cmd.py`; the five tests.
Out of scope: the actual write path; `fmt_cmd`'s diff; #270's reindex trigger and #275's rename guard (same file, separate PRs next).

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)