### PR TITLE
fix(fxa-270): af update reindexes when Status changes, not only on rename

### DIFF
--- a/src/fx_alfred/commands/update_cmd.py
+++ b/src/fx_alfred/commands/update_cmd.py
@@ -267,9 +267,10 @@ def update_cmd(
 
     # Combined for apply step — CLI wins over spec (spec is the base, CLI overrides)
     field_updates: dict[str, str] = {**spec_field_updates, **cli_field_updates}
+    status_changed = "Status" in field_updates
 
     # Validate effective Status against ALLOWED_STATUSES for the doc type.
-    if "Status" in field_updates and doc_type_enum:
+    if status_changed and doc_type_enum:
         validate_spec_status(doc_type_enum, field_updates["Status"])
 
     # Validate that CLI-requested fields exist (spec may add new ones)
@@ -422,15 +423,17 @@ def update_cmd(
 
     # ── Step 7: Post-write — rename file and auto-index ─────────────────────
 
-    if (
+    renamed = (
         new_title is not None
         and new_file_path is not None
         and new_file_path != file_path
-    ):
+    )
+    if renamed:
+        assert new_file_path is not None
         file_path.rename(new_file_path)
         click.echo(f"Renamed {file_path.name} -> {new_file_path.name}")
-
-        if doc.source == "prj":
-            invoke_index_update(ctx)
     else:
         click.echo(f"Updated {file_path.name}")
+
+    if doc.source == "prj" and (renamed or status_changed):
+        invoke_index_update(ctx)

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -1421,12 +1421,7 @@ def _prebuild_index(runner: CliRunner) -> None:
 
 
 def test_update_status_triggers_reindex(tmp_path, monkeypatch):
-    """af update --status Active reindexes: index row shows new status.
-
-    Currently RED — the index still shows the stale status after a
-    plain --status update because only the rename path triggers
-    invoke_index_update.
-    """
+    """af update --status Active reindexes: index row shows new status (regression guard)."""
     project = _make_project(tmp_path)
     monkeypatch.chdir(project)
     runner = CliRunner()
@@ -1521,3 +1516,69 @@ def test_update_dry_run_status_does_not_reindex(tmp_path, monkeypatch):
 
     after = index_path.read_bytes()
     assert before == after, "dry-run must not modify the index file"
+
+
+def test_update_rename_and_status_calls_invoke_index_once(tmp_path, monkeypatch):
+    """Combined rename + status update triggers invoke_index_update exactly once.
+
+    Both a title change and a status change independently qualify for
+    reindex, but the command must not call invoke_index_update twice.
+    """
+    project = _make_project(tmp_path)
+    monkeypatch.chdir(project)
+
+    # Counting wrapper that delegates to the real invoke_index_update
+    real_invoke = __import__(
+        "fx_alfred.commands._helpers", fromlist=["invoke_index_update"]
+    ).invoke_index_update
+    call_count = 0
+
+    def counting_wrapper(ctx):
+        nonlocal call_count
+        call_count += 1
+        real_invoke(ctx)
+
+    monkeypatch.setattr(
+        "fx_alfred.commands.update_cmd.invoke_index_update",
+        counting_wrapper,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--title", "New Name", "--status", "Active", "-y"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert call_count == 1, f"Expected 1 call to invoke_index_update, got {call_count}"
+
+
+def test_update_usr_status_does_not_reindex(tmp_path, monkeypatch):
+    """USR-layer doc status update does NOT reindex any PRJ index.
+
+    The index is a PRJ-layer artifact; USR-layer changes must not touch it.
+    """
+    project, _user_alfred = _make_usr_project(tmp_path)
+    monkeypatch.chdir(project)
+
+    call_count = 0
+
+    def counting_wrapper(ctx):
+        nonlocal call_count
+        call_count += 1
+
+    monkeypatch.setattr(
+        "fx_alfred.commands.update_cmd.invoke_index_update",
+        counting_wrapper,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--status", "Active"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    assert call_count == 0, (
+        f"Expected 0 calls to invoke_index_update for USR doc, got {call_count}"
+    )

--- a/tests/test_update_cmd.py
+++ b/tests/test_update_cmd.py
@@ -1409,3 +1409,115 @@ def test_update_preserves_file_permissions(tmp_path, monkeypatch):
     assert "**Status:** Active" in content
     mode = doc_path.stat().st_mode
     assert (mode & 0o777) == 0o664, f"Expected 0o664, got {oct(mode & 0o777)}"
+
+
+# ── Fix: Status change triggers reindex (FXA-270) ────────────────────────────
+
+
+def _prebuild_index(runner: CliRunner) -> None:
+    """Pre-build the PRJ index so we can verify it gets updated."""
+    result = runner.invoke(cli, ["index"], catch_exceptions=False)
+    assert result.exit_code == 0, f"af index failed: {result.output}"
+
+
+def test_update_status_triggers_reindex(tmp_path, monkeypatch):
+    """af update --status Active reindexes: index row shows new status.
+
+    Currently RED — the index still shows the stale status after a
+    plain --status update because only the rename path triggers
+    invoke_index_update.
+    """
+    project = _make_project(tmp_path)
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+
+    # Pre-build the index (initial Status: Draft)
+    _prebuild_index(runner)
+
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--status", "Active"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    index_path = project / "rules" / "TST-0000-REF-Document-Index.md"
+    index_content = index_path.read_text()
+    assert "| 2100 | SOP | Test Document | Active |" in index_content
+
+
+def test_update_spec_status_triggers_reindex(tmp_path, monkeypatch):
+    """--spec file patching metadata Status triggers reindex.
+
+    The spec path merges spec_field_updates into field_updates;
+    when 'Status' is in that merged dict, the index must refresh.
+    """
+    project = _make_project(tmp_path)
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+
+    # Pre-build the index (initial Status: Draft)
+    _prebuild_index(runner)
+
+    spec = tmp_path / "patch.yaml"
+    spec.write_text("metadata:\n  Status: Active\n")
+
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--spec", str(spec)],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    index_path = project / "rules" / "TST-0000-REF-Document-Index.md"
+    index_content = index_path.read_text()
+    assert "| 2100 | SOP | Test Document | Active |" in index_content
+
+
+def test_update_field_status_triggers_reindex(tmp_path, monkeypatch):
+    """--field Status triggers reindex.
+
+    The --field option populates cli_field_updates under 'Status';
+    the merged field_updates dict should trigger the same reindex
+    path as --status.
+    """
+    project = _make_project(tmp_path)
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+
+    # Pre-build the index (initial Status: Draft)
+    _prebuild_index(runner)
+
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--field", "Status", "Active"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    index_path = project / "rules" / "TST-0000-REF-Document-Index.md"
+    index_content = index_path.read_text()
+    assert "| 2100 | SOP | Test Document | Active |" in index_content
+
+
+def test_update_dry_run_status_does_not_reindex(tmp_path, monkeypatch):
+    """--dry-run --status Active never reindexes (byte-compare before/after)."""
+    project = _make_project(tmp_path)
+    monkeypatch.chdir(project)
+    runner = CliRunner()
+
+    # Pre-build the index
+    _prebuild_index(runner)
+
+    index_path = project / "rules" / "TST-0000-REF-Document-Index.md"
+    before = index_path.read_bytes()
+
+    result = runner.invoke(
+        cli,
+        ["update", "TST-2100", "--status", "Active", "--dry-run"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+
+    after = index_path.read_bytes()
+    assert before == after, "dry-run must not modify the index file"


### PR DESCRIPTION
## What

The generated PRJ index (`<PREFIX>-0000-REF-Document-Index.md`) renders a Status column, but `update_cmd` triggered `invoke_index_update` only in the rename branch — `af update <ID> --status Active` left the index showing the old status until some unrelated create/rename/`af index` run.

The update path now computes `status_changed` from the merged effective field updates (`{**spec_field_updates, **cli_field_updates}` + `--status`), so all three input paths — `--status`, `--field Status`, `--spec` metadata patch — extend the existing reindex condition. Rename + status together still reindex exactly once; `--dry-run` still returns before any reindex; the indexed-layer condition is unchanged. `--field Title` alone is intentionally NOT a trigger (the index title is filename-derived; rename covers it).

## Tests (TDD, two-worker split)

RED first (independently verified: 3 failed — index row stayed `Draft` after update to `Active`):
- `test_update_status_triggers_reindex` / `test_update_spec_status_triggers_reindex` / `test_update_field_status_triggers_reindex` — all three input paths, against a pre-built index fixture.
- Guards: `test_update_dry_run_status_does_not_reindex` (byte-compare of the index file) and pre-existing `test_update_rename_auto_indexes_prj`.

Note: tests use `Active` (not the issue's `Completed`) — SOP status vocabulary is Draft/Active/Deprecated; trigger semantics identical.

## Verification

- `pytest`: 1440 passed, 2 skipped; `ruff` clean (0.15.20); `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.0 (R2) / DeepSeek 9.6 / MiniMax 9.2, zero blocking

## Scope hints

In scope: the reindex-trigger condition in `src/fx_alfred/commands/update_cmd.py`; the four tests.
Out of scope: reindexing on other fields; index format; #275's rename-collision guard (same file, next PR).

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)