### PR TITLE
fix(fxa-267): branch/loop validation resolves steps via extract_steps_section

### DIFF
--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -22,6 +22,7 @@ from fx_alfred.core.schema import (
     WORKFLOW_LOOPS,
     WORKFLOW_BRANCHES,
 )
+from fx_alfred.core.steps import extract_steps_section
 
 # Token format per the CHG-2204 contract.
 _TOKEN_RE = re.compile(r"^[a-z0-9][a-z0-9:_/-]*$")
@@ -429,10 +430,9 @@ def validate_branches(
 
     # Pull the actual ## Steps lines (in document order) for sub-step
     # presence and contiguity checks.
-    from fx_alfred.core.parser import extract_section as _extract_section
     from fx_alfred.core.parser import iter_lines_with_fence_state
 
-    section = _extract_section(parsed.body, "Steps") if parsed.body else None
+    section = extract_steps_section(parsed.body) if parsed.body else None
     sub_steps_in_order: list[tuple[int, str]] = []  # [(parent, branch), ...]
     plain_step_positions: dict[int, int] = {}  # int_index -> first occurrence
     if section is not None:
@@ -706,10 +706,9 @@ def _parse_step_indices(parsed: ParsedDocument) -> frozenset[int] | None:
     parent step 3 into existence checks for `Workflow loops.from/to: 3`
     (Codex PR #68 R3 inline review).
     """
-    from fx_alfred.core.parser import extract_section
     from fx_alfred.core.steps import parse_top_level_step_indices
 
-    section = extract_section(parsed.body, "Steps")
+    section = extract_steps_section(parsed.body)
     if section is None:
         return None
     return parse_top_level_step_indices(section)

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -397,17 +397,17 @@ def validate_branches(
        presence of *any* branch declaration is a hard error directing
        authors to wait for CHG-2227. ``_gate_open_for_test`` bypasses this
        gate for tests that need to exercise the structural rules below.
-    2. **`from` exists** — must reference an existing integer step in
-       ``## Steps``.
+    2. **`from` exists** — must reference an existing integer step under
+       the recognised steps heading.
     3. **`to.parent == from + 1`** — every sibling's parent integer must
        equal ``from + 1`` (the convention is that branches fork from step
        N to siblings ``(N+1)a``, ``(N+1)b``, ...).
-    4. **Sub-step exists** — every ``to.id`` (e.g. ``3a``) must appear in
-       ``## Steps`` as an actual sub-step line.
-    5. **Siblings contiguous** — sibling lines must appear consecutively in
-       ``## Steps`` (no integer step interleaved between them).
-    6. **No orphan sub-steps** — every sub-step letter present in ``## Steps``
-       must appear in some ``branches.to`` declaration.
+    4. **Sub-step exists** — every ``to.id`` (e.g. ``3a``) must appear under
+       the recognised steps heading as an actual sub-step line.
+    5. **Siblings contiguous** — sibling lines must appear consecutively under
+       the recognised steps heading (no integer step interleaved between them).
+    6. **No orphan sub-steps** — every sub-step letter present under the
+       recognised steps heading must appear in some ``branches.to`` declaration.
     """
     errors: list[BranchError] = []
 
@@ -694,9 +694,10 @@ def parse_workflow_loops(parsed: ParsedDocument) -> list[LoopSignature]:
 def _parse_step_indices(parsed: ParsedDocument) -> frozenset[int] | None:
     """Parse the set of step indices observed in the SOP's Steps section.
 
-    Returns ``None`` if no ``Steps`` heading is present; otherwise a frozenset
-    of the step indices parsed from top-level numbered Markdown lines (e.g.
-    ``1. First``, ``### 1. First``, or ``3a. Sub-step``).
+    Returns ``None`` if no recognised steps heading is present (any of
+    Steps/Rule/Rules/Concepts per :mod:`fx_alfred.core.steps`); otherwise a
+    frozenset of the step indices parsed from top-level numbered Markdown lines
+    (e.g. ``1. First``, ``### 1. First``, or ``3a. Sub-step``).
 
     Delegates to :func:`fx_alfred.core.steps.parse_top_level_step_indices`,
     which is fence-aware: numbered lines inside ```` ``` ```` / ``~~~``

--- a/tests/test_workflow_branches_validate.py
+++ b/tests/test_workflow_branches_validate.py
@@ -330,11 +330,13 @@ def test_branch_validation_fenced_sibling_does_not_count_as_declared() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_branches_respects_rule_heading() -> None:
-    """An SOP with steps under ``## Rule`` and valid ``Workflow branches``
-    metadata must pass validation cleanly — ``validate_branches`` delegates
-    to ``extract_steps_section`` so headings other than ``## Steps`` that the
-    planner accepts (Rule, Rules, Concepts) are recognised.
+@pytest.mark.parametrize("heading", ["Rule", "Rules", "Concepts"])
+def test_branches_respects_rule_heading(heading: str) -> None:
+    """An SOP with steps under any recognised non-Steps heading and valid
+    ``Workflow branches`` metadata must pass validation cleanly —
+    ``validate_branches`` delegates to ``extract_steps_section`` so headings
+    other than ``## Steps`` that the planner accepts (Rule, Rules, Concepts)
+    are recognised.
 
     Before FXA-267, ``validate_branches`` hardcoded ``extract_section(..., "Steps")``
     and produced a spurious "does not reference an existing step" error.
@@ -347,7 +349,7 @@ def test_branches_respects_rule_heading() -> None:
         "\n"
         "---\n"
         "\n"
-        "## Rule\n"
+        f"## {heading}\n"
         "\n"
         "1. Setup\n2. Decision\n3a. Pass\n3b. Fail\n4. After\n"
         "## Change History\n"

--- a/tests/test_workflow_branches_validate.py
+++ b/tests/test_workflow_branches_validate.py
@@ -322,3 +322,41 @@ def test_branch_validation_fenced_sibling_does_not_count_as_declared() -> None:
     branches = parse_workflow_branches(parsed)
     errors = validate_branches(parsed, branches)
     assert any("3b" in e.msg for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# FXA-267: validate_branches delegates to extract_steps_section so all
+# recognised step headings (Steps, Rule, Rules, Concepts) work.
+# ---------------------------------------------------------------------------
+
+
+def test_branches_respects_rule_heading() -> None:
+    """An SOP with steps under ``## Rule`` and valid ``Workflow branches``
+    metadata must pass validation cleanly — ``validate_branches`` delegates
+    to ``extract_steps_section`` so headings other than ``## Steps`` that the
+    planner accepts (Rule, Rules, Concepts) are recognised.
+
+    Before FXA-267, ``validate_branches`` hardcoded ``extract_section(..., "Steps")``
+    and produced a spurious "does not reference an existing step" error.
+    """
+    body = (
+        "# SOP-9999: Test\n"
+        "\n"
+        "**Status:** Active\n"
+        "**Workflow branches:** [{from: 2, to: [{id: 3a, label: pass}, {id: 3b, label: fail}]}]\n"
+        "\n"
+        "---\n"
+        "\n"
+        "## Rule\n"
+        "\n"
+        "1. Setup\n2. Decision\n3a. Pass\n3b. Fail\n4. After\n"
+        "## Change History\n"
+        "\n"
+        "| Date | Change | By |\n"
+        "|------|--------|----|\n"
+        "| 2026-04-27 | Initial | Test |\n"
+    )
+    parsed = parse_metadata(body)
+    branches = parse_workflow_branches(parsed)
+    errors = validate_branches(parsed, branches)
+    assert errors == []

--- a/tests/test_workflow_loops.py
+++ b/tests/test_workflow_loops.py
@@ -1104,24 +1104,26 @@ def test_validate_loops_still_checks_max_iterations_for_cross_sop():
 # ---------------------------------------------------------------------------
 
 
-def test_rule_heading_rejects_nonexistent_loop_target() -> None:
-    """An SOP with steps under ``## Rule`` and a loop targeting nonexistent
-    steps must be rejected — ``_parse_step_indices`` delegates to
-    ``extract_steps_section`` so headings other than ``## Steps`` that the
-    planner accepts are recognised for step membership checks.
+@pytest.mark.parametrize("heading", ["Rule", "Rules", "Concepts"])
+def test_rule_heading_rejects_nonexistent_loop_target(heading: str) -> None:
+    """An SOP with steps under any recognised non-Steps heading and a loop
+    targeting nonexistent steps must be rejected — ``_parse_step_indices``
+    delegates to ``extract_steps_section`` so headings other than ``## Steps``
+    that the planner accepts (Rule, Rules, Concepts) are recognised for step
+    membership checks.
 
     Before FXA-267, ``_parse_step_indices`` hardcoded ``extract_section(..., "Steps")``,
-    returned ``None`` for ``## Rule``, and ``validate_loops`` silently skipped the
-    membership check. A loop with ``from=100, to=99`` (both nonexistent, but
+    returned ``None`` for non-Steps headings, and ``validate_loops`` silently skipped
+    the membership check. A loop with ``from=100, to=99`` (both nonexistent, but
     directionally valid as a back-edge) would validate clean because no
     membership check ran.
 
     After FXA-267, the loop must be rejected with an error naming the
     nonexistent step.
     """
-    body = """---
+    body = f"""---
 
-## Rule
+## {heading}
 
 1. First
 2. Second

--- a/tests/test_workflow_loops.py
+++ b/tests/test_workflow_loops.py
@@ -1095,3 +1095,80 @@ def test_validate_loops_still_checks_max_iterations_for_cross_sop():
     errors = validate_loops(parsed, [cross])
     assert len(errors) == 1
     assert "max_iterations" in errors[0].msg
+
+
+# ---------------------------------------------------------------------------
+# FXA-267: _parse_step_indices delegates to extract_steps_section so all
+# recognised step headings (Steps, Rule, Rules, Concepts) work for loop
+# validation.
+# ---------------------------------------------------------------------------
+
+
+def test_rule_heading_rejects_nonexistent_loop_target() -> None:
+    """An SOP with steps under ``## Rule`` and a loop targeting nonexistent
+    steps must be rejected — ``_parse_step_indices`` delegates to
+    ``extract_steps_section`` so headings other than ``## Steps`` that the
+    planner accepts are recognised for step membership checks.
+
+    Before FXA-267, ``_parse_step_indices`` hardcoded ``extract_section(..., "Steps")``,
+    returned ``None`` for ``## Rule``, and ``validate_loops`` silently skipped the
+    membership check. A loop with ``from=100, to=99`` (both nonexistent, but
+    directionally valid as a back-edge) would validate clean because no
+    membership check ran.
+
+    After FXA-267, the loop must be rejected with an error naming the
+    nonexistent step.
+    """
+    body = """---
+
+## Rule
+
+1. First
+2. Second
+3. Third
+"""
+    parsed = _make_parsed([], body=body)
+    loop = LoopSignature(
+        id="rule-nonexistent",
+        from_step=100,
+        to_step=99,
+        max_iterations=1,
+        condition="x",
+    )
+    errors = validate_loops(parsed, [loop])
+    assert any("does not reference an existing step" in e.msg for e in errors), (
+        f"Expected rejection of nonexistent step, got: {errors}"
+    )
+
+
+def test_parse_step_indices_none_on_unrecognized_heading_preserves_silent_skip() -> (
+    None
+):
+    """When the body has NO recognised steps heading (none of Steps, Rule,
+    Rules, Concepts), ``_parse_step_indices`` returns ``None`` and loop
+    validation silently skips existence checks. This is the contract:
+    SOPs without a steps-like section should not be rejected — the silent
+    skip is intentional, not a bug.
+
+    Pin this behaviour explicitly so the FXA-267 fix (delegating to
+    ``extract_steps_section``) does not accidentally change it.
+    """
+    from fx_alfred.core.workflow import _parse_step_indices
+
+    # "## Other Section" is not in _STEP_HEADINGS — must not count as steps.
+    body = """---
+
+## Introduction
+
+Some introductory text.
+
+## Other Section
+
+1. Not a step — wrong heading
+2. Also not a step
+3. Ditto
+"""
+    parsed = _make_parsed([], body=body)
+    assert _parse_step_indices(parsed) is None, (
+        "A heading not in _STEP_HEADINGS must not produce step indices"
+    )


### PR DESCRIPTION
## What

`core/workflow.py` hardcoded `"Steps"` at two sites — `validate_branches` and `_parse_step_indices` — while the planner resolves numbered steps from any of `Steps`/`Rule`/`Rules`/`Concepts` via the existing shared helper `extract_steps_section` (core/steps.py). Two failure modes (both reproduced in RED tests): a SOP with steps under `## Rule` and valid `Workflow branches` drew spurious "does not reference an existing step in ## Steps" errors while `af plan --graph` rendered fine; and `_parse_step_indices` returned `None`, silently skipping `validate_loops`' from/to existence checks — a loop targeting nonexistent step 99 validated clean.

Fix (3 lines net): both sites call `extract_steps_section` — validator and planner agree by construction. SOPs with no recognized steps heading keep the silent skip (helper returns `None`, same as today).

## Tests (TDD, two-worker split)

RED first (independently verified: 2 failed):
- `test_branches_respects_rule_heading` — `## Rule` + valid branches now validates clean.
- `test_rule_heading_rejects_nonexistent_loop_target` — loop → step 99 under `## Rule` now FAILS loudly.
- Guards: canonical `## Steps` behavior + no-heading silent-skip contract pinned.

## Verification

- `pytest`: 1445 passed, 2 skipped; `ruff` clean (0.15.20); `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.55 (R2) / DeepSeek 9.6 / MiniMax 9.3, zero blocking

## Scope hints

In scope: the two step-section call sites in `src/fx_alfred/core/workflow.py`; the four tests.
Out of scope: `_STEP_HEADINGS` contents; planner-side behavior; SOPs with no steps heading (silent skip preserved by design).

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)