### PR TITLE
fix(fxa-297): af guide --json emits raw source values; sync FXA-2142 examples

### DIFF
--- a/rules/FXA-2142-CHG-JSON-Output-For-Guide-Plan-Search-Validate.md
+++ b/rules/FXA-2142-CHG-JSON-Output-For-Guide-Plan-Search-Validate.md
@@ -1,14 +1,14 @@
 # CHG-2142: JSON Output For Guide Plan Search Validate
 
 **Applies to:** FXA project
-**Last updated:** 2026-03-22
+**Last updated:** 2026-07-04
 **Last reviewed:** 2026-03-22
 **Status:** Completed
+**Related:** FXA-2140, FXA-2143
 **Date:** 2026-03-22
 **Requested by:** Frank
 **Priority:** High
 **Change Type:** Normal
-**Related:** FXA-2140, FXA-2143
 
 ---
 
@@ -47,7 +47,7 @@ Alfred's README defines it as a tool for "AI agents and humans." Today, agents m
     {
       "doc_id": "COR-1103",
       "title": "Workflow Routing",
-      "source": "PKG",
+      "source": "pkg",
       "status": "Active",
       "role": "routing"
     }
@@ -84,7 +84,7 @@ Alfred's README defines it as a tool for "AI agents and humans." Today, agents m
     {
       "doc_id": "COR-1103",
       "title": "Workflow Routing",
-      "source": "PKG",
+      "source": "pkg",
       "snippet": "...session-start routing SOP..."
     }
   ]
@@ -146,6 +146,7 @@ _To be completed after implementation._
 
 ## Change History
 
-| Date | Change | By |
-|------|--------|----|
-| 2026-03-22 | Initial version | Frank + Claude Code |
+| Date       | Change                                                                                         | By                  |
+|------------|------------------------------------------------------------------------------------------------|---------------------|
+| 2026-03-22 | Initial version                                                                                | Frank + Claude Code |
+| 2026-07-04 | issue #297: sync source examples to raw values (pkg) matching the post-#271/#297 code contract | Claude Code         |

--- a/src/fx_alfred/commands/guide_cmd.py
+++ b/src/fx_alfred/commands/guide_cmd.py
@@ -86,7 +86,7 @@ def guide_cmd(ctx: click.Context, output_json: bool):
             {
                 "doc_id": f"{doc.prefix}-{doc.acid}",
                 "title": doc.title,
-                "source": doc.source.upper(),
+                "source": doc.source,
                 "status": "Active",
                 "role": ROUTING_ROLE_VALUE if role == ROUTING_ROLE_VALUE else "routing",
             }

--- a/tests/test_guide_cmd.py
+++ b/tests/test_guide_cmd.py
@@ -115,6 +115,29 @@ def test_guide_shows_layer_separators(sample_project, monkeypatch):
     assert "PKG:" in result.output
 
 
+def test_guide_text_output_shows_display_labels(sample_project, monkeypatch):
+    """guide text output shows display labels (PKG/USR/PRJ), not raw values.
+
+    Guard: text mode uses SOURCE_LABELS (uppercase) for human readability.
+    The JSON fix (#297) must not affect text output — the ``label`` variable
+    on line 26 of guide_cmd.py is independent of the JSON ``source`` field.
+    """
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["guide"], catch_exceptions=False)
+    assert result.exit_code == 0
+    # Text output uses display labels in separator headers: "PKG:", "USR:", "PRJ:"
+    assert "PKG:" in result.output
+
+    # The raw lowercase "pkg:" must NOT appear as a section header
+    # (guide_cmd.py:26 builds label from source.upper() for text output)
+    for line in result.output.split("\n"):
+        if line.strip().startswith("pkg:"):
+            assert False, (
+                f"Raw source leaked into text section header: {line.strip()!r}"
+            )
+
+
 def test_guide_malformed_routing_continues(sample_project, monkeypatch):
     """Malformed doc shows error, continues to next layer."""
     routing_doc = sample_project / "rules" / "FXA-2125-SOP-Workflow-Routing-PRJ.md"

--- a/tests/test_json_output.py
+++ b/tests/test_json_output.py
@@ -63,7 +63,7 @@ def test_guide_json_has_routing_docs_array(sample_project, monkeypatch):
     # COR-1103 should be in PKG layer
     cor_1103 = next((d for d in routing_docs if d["doc_id"] == "COR-1103"), None)
     assert cor_1103 is not None
-    assert cor_1103["source"] == "PKG"
+    assert cor_1103["source"] == "pkg"
     assert cor_1103["status"] == "Active"
     assert cor_1103["role"] == "routing"
 
@@ -93,7 +93,7 @@ USR routing test content here
     routing_docs = data["routing_docs"]
     usr_doc = next((d for d in routing_docs if d["doc_id"] == "ALF-2207"), None)
     assert usr_doc is not None
-    assert usr_doc["source"] == "USR"
+    assert usr_doc["source"] == "usr"
 
 
 def test_guide_json_includes_prj_routing(sample_project, monkeypatch):
@@ -119,7 +119,7 @@ PRJ routing test content here
     routing_docs = data["routing_docs"]
     prj_doc = next((d for d in routing_docs if d["doc_id"] == "FXA-2125"), None)
     assert prj_doc is not None
-    assert prj_doc["source"] == "PRJ"
+    assert prj_doc["source"] == "prj"
 
 
 def test_guide_json_skips_deprecated(sample_project, monkeypatch):
@@ -145,6 +145,33 @@ Should not appear
     routing_docs = data["routing_docs"]
     deprecated = next((d for d in routing_docs if d["doc_id"] == "FXA-2125"), None)
     assert deprecated is None
+
+
+def test_guide_json_source_values_are_raw(sample_project, monkeypatch):
+    """guide --json emits raw source values (pkg/usr/prj), not display labels.
+
+    Regression: guide --json used doc.source.upper() which produced display
+    labels (PKG/USR/PRJ) while every other JSON surface (list, tag, search,
+    read, where) emitted the raw doc.source value.  The fix (#297) makes
+    guide consistent by emitting the un-modified doc.source.
+    """
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["guide", "--json"], catch_exceptions=False)
+    assert result.exit_code == 0
+
+    data = json.loads(result.output)
+    routing_docs = data.get("routing_docs", [])
+    # Every routing entry's source must be a raw value
+    raw_sources = {"pkg", "usr", "prj"}
+    for doc_entry in routing_docs:
+        assert doc_entry["source"] in raw_sources, (
+            f"Expected raw source in {{pkg, usr, prj}}, got: {doc_entry['source']!r}"
+        )
+        # Negative guard: display labels must never leak into JSON
+        assert doc_entry["source"] != "PKG", (
+            "Display label 'PKG' leaked into guide --json source field"
+        )
 
 
 def test_guide_text_output_unchanged_without_json(sample_project, monkeypatch):

--- a/tests/test_search_cmd.py
+++ b/tests/test_search_cmd.py
@@ -324,3 +324,54 @@ def test_search_text_mode_shows_display_label(sample_project, monkeypatch):
     result2 = runner.invoke(cli, ["search", "AF CLI"], catch_exceptions=False)
     assert result2.exit_code == 0
     assert "PRJ" in result2.output
+
+
+def test_guide_list_search_source_consistent(sample_project, monkeypatch):
+    """Same doc has identical source string in guide, list, and search --json.
+
+    Cross-command consistency: a doc located via guide, list, or search must
+    carry the same ``source`` value so machine consumers can join results
+    across commands without mapping display labels.
+    """
+    import json
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+
+    # guide --json
+    guide_result = runner.invoke(cli, ["guide", "--json"], catch_exceptions=False)
+    assert guide_result.exit_code == 0
+    guide_data = json.loads(guide_result.output)
+    guide_by_id = {d["doc_id"]: d["source"] for d in guide_data.get("routing_docs", [])}
+
+    # list --json
+    list_result = runner.invoke(cli, ["list", "--json"], catch_exceptions=False)
+    assert list_result.exit_code == 0
+    list_data = json.loads(list_result.output)
+    list_by_id = {f"{d['prefix']}-{d['acid']}": d["source"] for d in list_data}
+
+    # search --json (pattern that matches COR-1103, the PKG routing doc)
+    search_result = runner.invoke(
+        cli, ["search", "routing", "--json"], catch_exceptions=False
+    )
+    assert search_result.exit_code == 0
+    search_data = json.loads(search_result.output)
+    search_by_id = {r["doc_id"]: r["source"] for r in search_data.get("results", [])}
+
+    # Every doc present in multiple views must agree on source
+    for doc_id, guide_source in guide_by_id.items():
+        if doc_id in list_by_id:
+            assert guide_source == list_by_id[doc_id], (
+                f"Source mismatch for {doc_id}: "
+                f"guide={guide_source!r}, list={list_by_id[doc_id]!r}"
+            )
+        if doc_id in search_by_id:
+            assert guide_source == search_by_id[doc_id], (
+                f"Source mismatch for {doc_id}: "
+                f"guide={guide_source!r}, search={search_by_id[doc_id]!r}"
+            )
+
+    # At minimum, COR-1103 must be in both guide and list (and maybe search
+    # depending on match) — verify consistency where they intersect.
+    common_ids = set(guide_by_id) & set(list_by_id)
+    assert len(common_ids) >= 1, "Expected at least one doc in both guide and list"


### PR DESCRIPTION
## What

After #271 (PR #296), `af guide --json` was the last JSON surface emitting display labels — `doc.source.upper()` → `"PKG"` — while list/tag/read/where/search all emit raw values (`"pkg"`). Flagged 3/3 by the #296 review panel (tracked as this issue). One-line fix: guide JSON carries raw `doc.source`; text output keeps `SOURCE_LABELS` display labels.

Bundled doc sync: `rules/FXA-2142-CHG-JSON-Output-For-Guide-Plan-Search-Validate.md`'s two `"source": "PKG"` examples updated to the raw contract (they contradicted the code post-#271).

## Tests (TDD, two-worker split)

RED first (independently verified: 5 failed):
- 3 pinning assertions in `test_json_output.py` rewritten `"PKG"/"USR"/"PRJ"` → raw.
- `test_guide_json_source_values_are_raw` — membership + negative guard.
- `test_guide_list_search_source_consistent` — guide/list/search share the vocabulary.
- Guard: `test_guide_text_output_shows_display_labels` (text unchanged).

## Verification

- `pytest`: 1473 passed, 2 skipped; `ruff` clean; `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.8 / DeepSeek 9.75 / MiniMax 9.275, zero blocking

## Scope hints

In scope: the source field of guide JSON (`src/fx_alfred/commands/guide_cmd.py:89`); FXA-2142 examples; the five test changes.
Out of scope: other guide JSON fields; `SOURCE_LABELS`; text-mode output.

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)