### PR TITLE
fix(fxa-299): gate stale-tmp cleanup behind the POSIX sentinel

### DIFF
--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -635,6 +635,9 @@ def _archive_tmp_is_stale(path: Path) -> bool:
 
 
 def _cleanup_stale_archive_tmps(log_dir: Path) -> None:
+    """Remove stale POSIX archive tmps; non-POSIX tmps stay inert and abort-bounded."""
+    if fcntl is None:
+        return
     for stale in log_dir.glob("archive.zip.tmp.*"):
         if _archive_tmp_is_stale(stale):
             try:

--- a/src/fx_alfred/core/activity_log.py
+++ b/src/fx_alfred/core/activity_log.py
@@ -635,7 +635,14 @@ def _archive_tmp_is_stale(path: Path) -> bool:
 
 
 def _cleanup_stale_archive_tmps(log_dir: Path) -> None:
-    """Remove stale POSIX archive tmps; non-POSIX tmps stay inert and abort-bounded."""
+    """Remove stale POSIX archive tmps; non-POSIX tmps stay inert.
+
+    On non-POSIX platforms stale tmps are not cleaned because readers only
+    glob ``*.zip`` and ``*.jsonl`` files. This process's own tmp is
+    abort-bounded by ``archive_directory``'s finally-unlink, while tmps from
+    other hard-killed processes may persist until the platform gains fcntl
+    locking.
+    """
     if fcntl is None:
         return
     for stale in log_dir.glob("archive.zip.tmp.*"):

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -1236,8 +1236,9 @@ def test_archive_directory_skips_stale_tmp_cleanup_when_fcntl_unavailable(
     short-circuit before reaching os.kill so the call is statically
     unreachable on those platforms.
 
-    Currently RED: _cleanup_stale_archive_tmps calls _archive_tmp_is_stale
-    which calls os.kill unconditionally, regardless of fcntl availability.
+    Before FXA-299, _cleanup_stale_archive_tmps reached os.kill
+    unconditionally regardless of fcntl availability; the gate makes it
+    unreachable on non-POSIX.
     """
     monkeypatch.setattr(activity_log, "fcntl", None)
 

--- a/tests/test_activity_log.py
+++ b/tests/test_activity_log.py
@@ -1133,6 +1133,14 @@ def test_archive_and_append_succeed_when_fcntl_unavailable(tmp_path, monkeypatch
     assert "old" in summaries
     assert "portable-append" in summaries
 
+    # No archive.zip.tmp.* file leaks into the directory after
+    # archive + append on fcntl-None platforms (FXA-299 panel A299-2).
+    tmp_files = list(log_dir.glob("archive.zip.tmp.*"))
+    assert len(tmp_files) == 0, (
+        f"archive.zip.tmp.* files leaked after archive+append on "
+        f"fcntl-None platform: {[f.name for f in tmp_files]}"
+    )
+
 
 # ---------------------------------------------------------------------------
 # FXA-273: fchmod guard for non-POSIX platforms
@@ -1209,3 +1217,63 @@ def test_iter_records_best_effort_treats_shadow_vanished_before_read_as_unshadow
     records = list(activity_log._iter_records_best_effort(log_dir))
 
     assert [rec[2]["summary"] for rec in records] == ["archived"]
+
+
+# ---------------------------------------------------------------------------
+# FXA-299: Windows-safe staletmp — fcntl-None early return
+# ---------------------------------------------------------------------------
+
+
+def test_archive_directory_skips_stale_tmp_cleanup_when_fcntl_unavailable(
+    tmp_path,
+    monkeypatch,
+):
+    """archive_directory must not call os.kill when fcntl is None.
+
+    When fcntl is unavailable (non-POSIX platform), os.kill(pid, 0) has
+    console-control-event / terminate semantics on Windows instead of the
+    POSIX liveness-probe behaviour.  _cleanup_stale_archive_tmps must
+    short-circuit before reaching os.kill so the call is statically
+    unreachable on those platforms.
+
+    Currently RED: _cleanup_stale_archive_tmps calls _archive_tmp_is_stale
+    which calls os.kill unconditionally, regardless of fcntl availability.
+    """
+    monkeypatch.setattr(activity_log, "fcntl", None)
+
+    kill_calls: list[tuple[int, int]] = []
+
+    def sentinel_kill(pid: int, sig: int) -> None:
+        kill_calls.append((pid, sig))
+        raise AssertionError("os.kill must not be called when fcntl is None")
+
+    monkeypatch.setattr(activity_log.os, "kill", sentinel_kill)
+
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    # Stale tmp from a nonexistent PID — matches the glob + regex pattern
+    # in _cleanup_stale_archive_tmps / _archive_tmp_is_stale.
+    stale_tmp = log_dir / "archive.zip.tmp.123456.dead"
+    stale_tmp.write_text("stale", encoding="utf-8")
+    # Closed-day file so there is something to archive.
+    old_file = log_dir / "2026-06-20.jsonl"
+    old_file.write_text(
+        json.dumps(activity_log.compose_record(summary="old")) + "\n",
+        encoding="utf-8",
+    )
+
+    # archive_directory must succeed without calling os.kill.
+    # On current (unfixed) code this raises AssertionError from the
+    # sentinel_kill recorder — os.kill is reached unconditionally.
+    result = activity_log.archive_directory(log_dir, today="2026-06-21")
+
+    assert result.archived_files == ["2026-06-20.jsonl"]
+    assert not old_file.exists()
+    # os.kill must never have been called.
+    assert len(kill_calls) == 0, (
+        f"os.kill called {len(kill_calls)} time(s) — "
+        "must not be invoked when fcntl is None"
+    )
+    # Stale tmp survives on non-POSIX (acceptable degradation — they
+    # age out only when the platform supports fcntl-based locking).
+    assert stale_tmp.exists()


### PR DESCRIPTION
## What

`_archive_tmp_is_stale` probed process liveness with `os.kill(pid, 0)` — a pure existence probe on POSIX, but console-control-event/`TerminateProcess` semantics on Windows: a stale-tmp PID that happens to match a live same-user process could be disturbed instead of probed. Pre-existing, but newly reachable on Windows after #273 unblocked `archive_directory` there. Flagged 3/3 by the #298 review panel (tracked as this issue).

Fix (3 lines): `_cleanup_stale_archive_tmps` returns early when `fcntl is None` — the module's existing non-POSIX sentinel — so `os.kill` is statically unreachable on Windows. Docstring states the accepted degradation: on non-POSIX platforms stale tmps are not cleaned (no safe liveness probe exists without new platform deps); they are inert to readers and bounded by abort count. POSIX behavior unchanged.

## Tests (TDD, two-worker split)

RED first (independently verified — the sentinel `os.kill` recorder tripped through the full call chain):
- `test_archive_directory_skips_stale_tmp_cleanup_when_fcntl_unavailable` — fcntl=None + stale tmp present → archival succeeds, `os.kill` never called.
- Guards: existing POSIX stale-tmp cleanup tests unchanged; `test_archive_and_append_succeed_when_fcntl_unavailable` strengthened with a no-tmp-leak assertion (panel advisory).

## Verification

- `pytest`: 1472 passed, 2 skipped; `ruff` clean; `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.55 / DeepSeek 9.55 / MiniMax 9.05, zero blocking; panel judged the no-op degradation acceptable vs. heavier alternatives (Windows-native probe, mtime aging)

## Scope hints

In scope: the early-return gate + docstring in `_cleanup_stale_archive_tmps` (`src/fx_alfred/core/activity_log.py`); the two test changes.
Out of scope: a Windows-native liveness probe (explicitly rejected per the issue); mtime-age fallback (possible future hardening); `log_cmd` catch breadth.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)