### PR TITLE
fix(fxa-287): af fmt warns on ragged Change History rows

### DIFF
--- a/src/fx_alfred/commands/fmt_cmd.py
+++ b/src/fx_alfred/commands/fmt_cmd.py
@@ -388,6 +388,29 @@ def fmt_cmd(
             docs_error.append(f"{doc.prefix}-{doc.acid}")
             continue
 
+        if check or write_:
+            header_line = next(
+                (
+                    line.strip()
+                    for line in parsed.history_header.split("\n")
+                    if line.strip().startswith("|")
+                    and line.strip().endswith("|")
+                    and "---" not in line
+                ),
+                "",
+            )
+            header_cells = [
+                c.strip() for c in re.split(r"(?<!\\)\|", header_line[1:-1])
+            ]
+            for row in parsed.history_rows if header_line else []:
+                cells = row.effective_cells
+                if len(cells) > len(header_cells):
+                    click.echo(
+                        f"Warning: {doc.prefix}-{doc.acid} Change History row "
+                        f"{cells[0]} has an unescaped pipe; escape it as \\|.",
+                        err=True,
+                    )
+
         # Determine document type
         try:
             doc_type = DocType(doc.type_code)

--- a/src/fx_alfred/commands/fmt_cmd.py
+++ b/src/fx_alfred/commands/fmt_cmd.py
@@ -388,6 +388,7 @@ def fmt_cmd(
             docs_error.append(f"{doc.prefix}-{doc.acid}")
             continue
 
+        # Default diff mode intentionally omits this warning; the diff shows ragged rows.
         if check or write_:
             header_line = next(
                 (

--- a/tests/test_fmt_cmd.py
+++ b/tests/test_fmt_cmd.py
@@ -1678,3 +1678,107 @@ def test_fmt_escaped_pipe_no_ragged_warning(tmp_path):
     # No ragged-row warning on stderr
     stderr = result.stderr or ""
     assert "unescaped pipe" not in stderr.lower()
+
+
+# ── FXA-2287: Multi-Doc Ragged Warning Attribution ─────────────────────────────
+
+
+def test_fmt_multi_doc_ragged_warning_names_only_ragged_doc(tmp_path):
+    """Multi-doc ``--check``: warning on stderr names only the ragged doc, not the clean one.
+
+    When a corpus contains both a clean doc and a ragged doc, the ragged-row
+    warning must attribute the offending doc ID, not the clean one.
+    """
+    project = _make_project(
+        tmp_path,
+        ("TST-2100-SOP-Test-Document.md", FORMATTED_DOC),
+        ("TST-2287-SOP-Ragged-Pipe-Warning.md", RAGGED_PIPE_WARNING_DOC),
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["fmt", "--root", str(project), "--check", "TST-2100", "TST-2287"]
+    )
+
+    # Ragged doc needs formatting → exit 1
+    assert result.exit_code == 1
+
+    stderr = result.stderr or ""
+    # Warning names the ragged doc
+    assert "TST-2287" in stderr, f"expected ragged doc ID in stderr, got: {stderr!r}"
+    # Clean doc ID absent from stderr
+    assert "TST-2100" not in stderr, (
+        f"clean doc ID should not appear in stderr, got: {stderr!r}"
+    )
+
+
+# ── FXA-2287: Header-Wider-Than-Row No False Warning ──────────────────────────
+
+HEADER_WIDER_DOC = """\
+# TST-2288: Header Wider Than Row
+
+**Applies to:** All projects
+**Last updated:** 2026-01-01
+**Last reviewed:** 2026-01-01
+**Status:** Draft
+
+---
+
+## What Is It?
+
+Body content.
+
+---
+
+## Change History
+
+| Date | Change | By | Reviewer | Evidence |
+|------|--------|----|----------|----------|
+| 2026-01-01 | Initial version | Author |
+"""
+
+
+def test_fmt_header_wider_than_row_no_ragged_warning(tmp_path):
+    """Header with more cells than a row does not trigger the ragged-row warning.
+
+    The warning fires only when a row has strictly more cells than the header
+    (``len(row_cells) > len(header_cells)``). A row with fewer cells is
+    missing data, not an unescaped pipe, and must not be flagged.
+    """
+    project = _make_project(
+        tmp_path,
+        ("TST-2288-SOP-Header-Wider-Than-Row.md", HEADER_WIDER_DOC),
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["fmt", "--root", str(project), "--check", "TST-2288"])
+
+    # No ragged-row warning on stderr — strict > trigger is not met
+    stderr = result.stderr or ""
+    assert "unescaped pipe" not in stderr.lower(), (
+        f"unexpected ragged-row warning, got: {stderr!r}"
+    )
+
+
+# ── FXA-2287: No Change History Section Guard ──────────────────────────────────
+
+
+def test_fmt_no_change_history_section_no_ragged_warning(tmp_path):
+    """Doc without a ``## Change History`` section produces no warning and no crash.
+
+    The ragged-row check iterates over history rows only when a header line
+    is found. Documents with no Change History section skip the check
+    entirely and must not raise an exception or emit a spurious warning.
+    """
+    project = _make_project(
+        tmp_path,
+        ("TST-2109-SOP-No-History.md", NO_HISTORY_DOC),
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["fmt", "--root", str(project), "--check", "TST-2109"])
+
+    # No crash — exit 0 (doc is already well-formed)
+    assert result.exit_code == 0
+
+    stderr = result.stderr or ""
+    assert "unescaped pipe" not in stderr.lower(), (
+        f"unexpected ragged-row warning for doc with no history, got: {stderr!r}"
+    )

--- a/tests/test_fmt_cmd.py
+++ b/tests/test_fmt_cmd.py
@@ -1556,3 +1556,125 @@ def test_fmt_workflow_metadata_reordered_canonically(tmp_path):
         if k.startswith("Workflow") and k in workflow_keys
     ]
     assert workflow_keys == canonical_workflow_order
+
+
+# ── FXA-2287: Ragged Change History Row Warning ──────────────────────────────
+
+RAGGED_PIPE_WARNING_DOC = """\
+# TST-2287: Ragged Pipe Warning
+
+**Applies to:** All projects
+**Last updated:** 2026-01-01
+**Last reviewed:** 2026-01-01
+**Status:** Draft
+
+---
+
+## What Is It?
+
+Body content.
+
+---
+
+## Change History
+
+| Date | Change | By |
+|------|--------|----|
+| 2026-01-01 | Initial version | Author |
+| 2026-01-15 | Support CHG | ADR | RFC | inline-PR-body formats | Alice |
+"""
+
+
+def test_fmt_ragged_pipe_warning_on_check(tmp_path):
+    """``--check`` on a doc whose history row has unescaped ``|`` emits warning on stderr.
+
+    When a Change History row parses into more effective cells than the header
+    (unescaped ``|`` in cell text), ``af fmt --check`` prints a warning to
+    stderr naming the doc ID, the row's date, and an escape hint. Exit code
+    is unchanged from the current behaviour (1 because the doc needs changes).
+    """
+    project = _make_project(
+        tmp_path,
+        ("TST-2287-SOP-Ragged-Pipe-Warning.md", RAGGED_PIPE_WARNING_DOC),
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["fmt", "--root", str(project), "--check", "TST-2287"])
+
+    # Exit code unchanged from today: doc needs formatting → exit 1
+    assert result.exit_code == 1
+
+    # Warning on stderr: doc ID, row date, escape hint
+    stderr = result.stderr or ""
+    assert "TST-2287" in stderr, f"expected doc ID in stderr, got: {stderr!r}"
+    assert "2026-01-15" in stderr, f"expected row date in stderr, got: {stderr!r}"
+    assert "unescaped pipe" in stderr.lower() or "\\|" in stderr, (
+        f"expected escape hint in stderr, got: {stderr!r}"
+    )
+
+
+def test_fmt_ragged_pipe_warning_on_write(tmp_path):
+    """``--write`` on a doc with unescaped pipes emits warning on stderr; write proceeds.
+
+    The warning appears on stderr. The file is still written with the current
+    alignment behaviour — table restructuring proceeds exactly as today, and
+    exit code is 0.
+    """
+    project = _make_project(
+        tmp_path,
+        ("TST-2287-SOP-Ragged-Pipe-Warning.md", RAGGED_PIPE_WARNING_DOC),
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["fmt", "--root", str(project), "--write", "TST-2287"])
+
+    # Write succeeds
+    assert result.exit_code == 0
+
+    # Warning on stderr
+    stderr = result.stderr or ""
+    assert "TST-2287" in stderr, f"expected doc ID in stderr, got: {stderr!r}"
+    assert "2026-01-15" in stderr, f"expected row date in stderr, got: {stderr!r}"
+    assert "unescaped pipe" in stderr.lower() or "\\|" in stderr, (
+        f"expected escape hint in stderr, got: {stderr!r}"
+    )
+
+    # File was written (write proceeds as today)
+    content = (project / "rules" / "TST-2287-SOP-Ragged-Pipe-Warning.md").read_text()
+    assert content != RAGGED_PIPE_WARNING_DOC
+    # Original cell content survives the restructured table
+    assert "inline-PR-body" in content
+    assert "2026-01-15" in content
+
+
+def test_fmt_canonical_table_no_ragged_warning(tmp_path):
+    """A canonical well-formed Change History table produces no ragged-row warning."""
+    project = _make_project(
+        tmp_path,
+        ("TST-2100-SOP-Test-Document.md", FORMATTED_DOC),
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["fmt", "--root", str(project), "--check", "TST-2100"])
+
+    # Already formatted — exit 0
+    assert result.exit_code == 0
+    # No ragged-row warning on stderr
+    stderr = result.stderr or ""
+    assert "unescaped pipe" not in stderr.lower()
+
+
+def test_fmt_escaped_pipe_no_ragged_warning(tmp_path):
+    """A table with properly escaped ``\\|`` pipes produces no ragged-row warning.
+
+    Escaped pipes are preserved as literal ``|`` characters inside cells,
+    not split as column separators, so the row has the same cell count
+    as the header.
+    """
+    project = _make_project(
+        tmp_path,
+        ("TST-2111-SOP-Escaped-Pipes.md", ESCAPED_PIPE_DOC),
+    )
+    runner = CliRunner()
+    result = runner.invoke(cli, ["fmt", "--root", str(project), "--check", "TST-2111"])
+
+    # No ragged-row warning on stderr
+    stderr = result.stderr or ""
+    assert "unescaped pipe" not in stderr.lower()


### PR DESCRIPTION
## What

`af fmt --write` silently institutionalizes ragged Change History rows: when a row parses wider than its header (an unescaped `|` in prose — inline code spans do NOT protect pipes, the parser splits on `(?<!\\)\|`), the v1.25.0 alignment extends the header with blank-labeled columns and splits the row's cells. Design-accepted in CHG-2319, footgun flagged in PR #281's review record, and it bit a real document: FXA-2276's history row containing `CHG | ADR | RFC | inline-PR-body` split into six cells and corrupted `row.by` (caught by the codex bot on PR #286).

Fix: when any history row has **strictly more** effective cells than the header (header-wider-than-rows is normal padding — no warning), `af fmt` emits a stderr warning naming the doc ID, the row's date, and an escape-as-`\|` hint, in both `--check` and `--write`. Emission happens from the per-doc loop where the doc ID is in scope. Alignment behavior itself and exit codes are unchanged.

## Tests (TDD, two-worker split)

RED first (independently verified: 2 failed, stderr empty):
- `test_fmt_ragged_pipe_warning_on_check` / `..._on_write` — incident-shape row (`A | B | C` in a cell) → warning with doc ID + row date + `\|` hint on stderr; exit codes unchanged.
- Guards: canonical table and properly escaped `\|` table → no warning.

## Verification

- `pytest`: 1477 passed, 2 skipped; `ruff` clean; `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.0 / DeepSeek 9.3 / MiniMax 9.075, zero blocking

## Scope hints

In scope: ragged-row detection + stderr warning in `src/fx_alfred/commands/fmt_cmd.py`; the four new tests.
Out of scope: the alignment/splitting behavior itself (CHG-2319 design stands); auto-escaping pipes; parser changes.

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)