### PR TITLE
fix(fxa-276): graceful errors for agent-run decode, unreadable docs, export missing dir

### DIFF
--- a/src/fx_alfred/commands/export_cmd.py
+++ b/src/fx_alfred/commands/export_cmd.py
@@ -349,6 +349,10 @@ def _write_output(text: str, output_path: str | None) -> None:
     target = Path(output_path)
     if target.is_dir():
         raise click.ClickException(f"--output target is a directory: {target}")
+    if not target.parent.is_dir():
+        raise click.ClickException(
+            f"--output directory does not exist: {target.parent}"
+        )
     atomic_write(target, text + "\n")
 
 

--- a/src/fx_alfred/commands/guide_cmd.py
+++ b/src/fx_alfred/commands/guide_cmd.py
@@ -51,7 +51,7 @@ def guide_cmd(ctx: click.Context, output_json: bool):
                     continue
                 if status == "Active":
                     active_docs.append((doc, content, role))
-            except MalformedDocumentError as e:
+            except (OSError, MalformedDocumentError) as e:
                 # Only report malformed errors for filename-pattern-matched docs
                 # (backward-compatible: non-routing docs were never parsed
                 # before this refactor). Metadata-role routing docs that are

--- a/src/fx_alfred/commands/guide_cmd.py
+++ b/src/fx_alfred/commands/guide_cmd.py
@@ -59,8 +59,9 @@ def guide_cmd(ctx: click.Context, output_json: bool):
                 # unreadable, so they are indistinguishable from non-routing.
                 if ROUTING_PATTERN in doc.filename:
                     if not output_json:
+                        issue = "unreadable" if isinstance(e, OSError) else "malformed"
                         click.echo(
-                            f"═══ {label}: {doc.prefix}-{doc.acid} (malformed: {e}) ═══"
+                            f"═══ {label}: {doc.prefix}-{doc.acid} ({issue}: {e}) ═══"
                         )
                         click.echo()
                 continue

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -686,7 +686,7 @@ def _collect_phase_info(
             sig = parse_workflow_signature(parsed)
             loops = parse_workflow_loops(parsed)
             _enforce_branches_gate(doc, parsed)
-        except MalformedDocumentError as e:
+        except (OSError, MalformedDocumentError) as e:
             reason = f"{doc.type_code} malformed: {e}"
             skipped.append({"id": doc_id, "reason": reason})
             if not output_json:

--- a/src/fx_alfred/commands/plan_cmd.py
+++ b/src/fx_alfred/commands/plan_cmd.py
@@ -687,10 +687,11 @@ def _collect_phase_info(
             loops = parse_workflow_loops(parsed)
             _enforce_branches_gate(doc, parsed)
         except (OSError, MalformedDocumentError) as e:
-            reason = f"{doc.type_code} malformed: {e}"
+            issue = "unreadable" if isinstance(e, OSError) else "malformed"
+            reason = f"{doc.type_code} {issue}: {e}"
             skipped.append({"id": doc_id, "reason": reason})
             if not output_json:
-                click.echo(f"Warning: {doc_id} (malformed: {e}). Skipping.")
+                click.echo(f"Warning: {doc_id} ({issue}: {e}). Skipping.")
             continue
 
         phase_info.append((sop_id, doc, parsed, sig, loops))

--- a/src/fx_alfred/core/agent_helpers.py
+++ b/src/fx_alfred/core/agent_helpers.py
@@ -201,6 +201,7 @@ def run_script(root: Path, script_path: str) -> dict[str, Any]:
         [sys.executable, str(path)],
         capture_output=True,
         text=True,
+        errors="replace",
         check=False,
     )
     return {

--- a/tests/test_agent_cmd.py
+++ b/tests/test_agent_cmd.py
@@ -299,3 +299,35 @@ def test_agent_run_text_mode_replays_stdout_stderr_and_exit_code(sample_project)
     assert result.exit_code == 3
     assert "hello stdout" in result.output
     assert "hello stderr" in result.output
+
+
+def test_agent_run_non_decodable_stdout_json_envelope(sample_project):
+    """Script emitting invalid UTF-8 bytes on stdout produces JSON envelope.
+
+    subprocess.run with text=True and no errors= parameter uses strict
+    locale-based decoding. A script that writes raw non-UTF-8 bytes to
+    sys.stdout.buffer causes UnicodeDecodeError instead of the documented
+    JSON envelope.
+
+    After fix (errors="replace"): envelope always produced; stdout carries
+    U+FFFD replacement characters for undecodable bytes.
+    """
+    script = sample_project / "bad_encoding.py"
+    script.write_text(
+        "import sys\nsys.stdout.buffer.write(b'\\xff\\xfe')\nsys.stdout.flush()\n"
+    )
+
+    result = CliRunner().invoke(
+        cli,
+        ["--root", str(sample_project), "agent", "run", "bad_encoding.py", "--json"],
+        env={"ALFRED_AGENT_TOOLS": "1"},
+    )
+
+    # Currently RED: UnicodeDecodeError traceback; output is not valid JSON.
+    # After fix: valid JSON envelope with U+FFFD replacement chars.
+    data = json.loads(result.output)
+    assert data["schema_version"] == "1"
+    assert data["status"] == "ok"
+    assert data["exit_code"] == 0
+    # stdout should contain U+FFFD replacement chars for the invalid bytes
+    assert "�" in data["stdout"]

--- a/tests/test_export_cmd.py
+++ b/tests/test_export_cmd.py
@@ -193,6 +193,29 @@ def test_output_to_directory_fails(project, tmp_path):
     assert result.exit_code == 1
 
 
+def test_output_to_missing_parent_directory_gives_clean_error(project):
+    """Export -o to a path whose parent directory does not exist.
+
+    _write_output calls atomic_write, which uses tempfile.mkstemp in the
+    target's parent directory. When the parent dir is missing, mkstemp
+    raises FileNotFoundError — a raw traceback instead of a user-facing
+    ClickException.
+
+    After fix (pre-validate parent exists): non-zero exit, one-line error
+    mentioning the directory, no traceback in output.
+    """
+    target = project / "missing-dir" / "out.md"
+    result = _run(project, "-o", str(target))
+
+    # Currently RED: FileNotFoundError traceback, exit 1 from the unhandled exception.
+    # After fix: non-zero exit, clean error message mentioning the directory.
+    assert result.exit_code != 0
+    output_lower = (result.output + (result.stderr or "")).lower()
+    assert "missing-dir" in output_lower or "directory" in output_lower
+    # No Python traceback in output
+    assert "Traceback" not in result.output
+
+
 # ── Behavior 7: exit codes ──────────────────────────────────────────────────
 
 

--- a/tests/test_guide_cmd.py
+++ b/tests/test_guide_cmd.py
@@ -1,3 +1,7 @@
+import os
+import sys
+
+
 import pytest
 
 
@@ -292,6 +296,46 @@ def test_guide_logging_failure_does_not_break_command(sample_project, monkeypatc
 
     assert result.exit_code == 0
     assert "Workflow Routing" in result.output
+
+
+def test_guide_unreadable_routing_doc_warns_and_continues(sample_project, monkeypatch):
+    """Guide with a chmod-000 routing doc warns and continues to next layer.
+
+    doc.resolve_resource().read_text() on a file with mode 0000 raises
+    PermissionError (OSError subclass). Currently the except clause only
+    catches MalformedDocumentError, so the PermissionError propagates raw.
+
+    After fix (except widened to OSError): warns naming the file, continues
+    to show PKG routing content. Skip on Windows (no Unix permissions) and
+    when running as root (root bypasses permission bits).
+    """
+    if sys.platform == "win32":
+        pytest.skip("Unix permissions not available on Windows")
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root can read 000-mode files")
+
+    routing_doc = sample_project / "rules" / "FXA-2125-SOP-Workflow-Routing-PRJ.md"
+    routing_doc.write_text(
+        "# SOP-2125: Workflow Routing PRJ\n\n"
+        "**Applies to:** FXA\n"
+        "**Status:** Active\n\n"
+        "---\n\n"
+        "PRJ routing content\n"
+    )
+    routing_doc.chmod(0o000)
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["guide"], catch_exceptions=False)
+
+    # Currently RED: PermissionError traceback, non-zero exit.
+    # After fix: exits 0, warns about the unreadable file, PKG content intact.
+    assert result.exit_code == 0
+    output_lower = result.output.lower()
+    assert "FXA-2125" in result.output  # file named in the warning
+    assert "permission" in output_lower or "error" in output_lower
+    # PKG layer routing doc still shown
+    assert "COR-1103" in result.output
 
 
 # ── FXA-2314: USR sub-project layer via projects.json mapping ─────────────────

--- a/tests/test_plan_cmd.py
+++ b/tests/test_plan_cmd.py
@@ -1,6 +1,8 @@
 """Tests for af plan command (FXA-2134)."""
 
 import json
+import os
+import sys
 from pathlib import Path
 
 import click
@@ -3133,3 +3135,75 @@ def test_plan_all_sop_unchanged(sample_project, monkeypatch):
     assert data["schema_version"] == "1", (
         "schema_version must be '1' when no new-key flags are active and no docs are skipped"
     )
+
+
+def test_plan_unreadable_sop_all_skipped_gate_fires(
+    sample_project, monkeypatch, tmp_path
+):
+    """Plan with a chmod-000 SOP as the only requested ID fires all-skipped gate.
+
+    _collect_phase_info catches only MalformedDocumentError, so read_text()
+    on a 000-mode file raises PermissionError (OSError) raw — traceback
+    instead of the skip/warn contract from FXA-268.
+
+    After fix (except widened to OSError): SOP is skipped with warning;
+    all-skipped gate fires → non-zero exit with diagnostic naming the file.
+    Skip on Windows and root.
+    """
+    if sys.platform == "win32":
+        pytest.skip("Unix permissions not available on Windows")
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root can read 000-mode files")
+
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Test-Workflow")
+    sop_path = rules_dir / "TST-5001-SOP-Test-Workflow.md"
+    sop_path.chmod(0o000)
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(cli, ["plan", "TST-5001"], catch_exceptions=False)
+
+    # Currently RED: PermissionError traceback.
+    # After fix: non-zero exit, all-skipped error names the file.
+    assert result.exit_code != 0
+    assert "TST-5001" in result.output
+    assert "skipped" in result.output.lower()
+
+
+def test_plan_unreadable_sop_mixed_with_readable_warns_and_continues(
+    sample_project, monkeypatch
+):
+    """Plan with both chmod-000 and readable SOPs: warns, continues for readable.
+
+    Same root cause as the all-skipped case: _collect_phase_info only
+    catches MalformedDocumentError. When both a 000-mode SOP and a
+    readable SOP are requested, the read_text PermissionError propagates
+    before the readable SOP can be processed.
+
+    After fix: the unreadable SOP is skipped with warning; the readable SOP
+    produces its normal phased checklist output.
+    """
+    if sys.platform == "win32":
+        pytest.skip("Unix permissions not available on Windows")
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root can read 000-mode files")
+
+    rules_dir = sample_project / "rules"
+    _create_sop_with_steps(rules_dir, "TST", "5001", "Unreadable-SOP")
+    _create_sop_with_steps(rules_dir, "TST", "5002", "Readable-SOP")
+    sop_path = rules_dir / "TST-5001-SOP-Unreadable-SOP.md"
+    sop_path.chmod(0o000)
+
+    monkeypatch.chdir(sample_project)
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["plan", "TST-5001", "TST-5002"], catch_exceptions=False
+    )
+
+    # Currently RED: PermissionError traceback.
+    # After fix: exit 0, warns about TST-5001, TST-5002 content present.
+    assert result.exit_code == 0
+    assert "TST-5001" in result.output  # named in warning
+    assert "TST-5002" in result.output  # readable SOP still rendered
+    assert "First step for 5002" in result.output


### PR DESCRIPTION
## What

Three paths raised raw tracebacks where sibling code already handles the same condition gracefully (found in the 2026-07-02 full-repo review, all reproduced):

1. **`af agent run`** decoded subprocess output with `text=True` (locale, strict) — a script emitting non-decodable bytes crashed with `UnicodeDecodeError` instead of the documented JSON envelope. Now decodes with `errors="replace"`; the envelope always emerges with U+FFFD for bad bytes.
2. **`af guide` / `af plan`** wrapped doc reads in `except MalformedDocumentError` only — a chmod-000 (or deleted-between-scan-and-read) doc raised raw `PermissionError`. Widened to `(MalformedDocumentError, OSError)` matching `_gather_all_sops`'s existing convention: warn + continue; plan's #268 all-skipped/mixed gate semantics apply naturally.
3. **`af export -o missing-dir/out.md`** crashed with `FileNotFoundError` from `mkstemp` inside `atomic_write`. The parent directory is now pre-validated with a one-line `ClickException`, mirroring the existing target-is-a-directory handling.

## Tests (TDD, two-worker split)

RED first (independently verified: 5 failed across 4 files):
- agent-run envelope with replacement chars; guide warn+continue; plan all-skipped gate + mixed warn-continue on unreadable SOP; export clean one-line error. chmod-000 tests are skipif win32/root.
- Guards: normal agent run, readable corpus, existing export target-is-a-directory case.

## Verification

- `pytest`: 1477 passed, 2 skipped; `ruff` clean; `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609): GLM 9.15 / DeepSeek 9.35 / MiniMax 9.0, zero blocking

## Scope hints

In scope: the three error paths (`core/agent_helpers.py` decode kwarg, `guide_cmd.py`/`plan_cmd.py` except-clause widening, `export_cmd.py` parent pre-check); the five tests + guards.
Out of scope: broader error-handling; the warn/skip contracts themselves; atomic_write internals.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)