### PR TITLE
docs(fxa-280): uv sync bootstrap step + af agent execution trust model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,9 @@ Top-level (outside the package): `skills/alfred/` — cross-platform agent-skill
 ## Essential Commands
 
 ```bash
+# Bootstrap (fresh checkout — creates .venv; required before any .venv/bin/* command below)
+uv sync --extra dev
+
 # Dev
 .venv/bin/pytest -v --tb=short        # run tests
 .venv/bin/ruff check .                 # lint

--- a/README.md
+++ b/README.md
@@ -144,11 +144,12 @@ first, then `~/.alfred/agent_helpers.py`. The exact
 `ALFRED_AGENT_TOOLS=1` gate is checked before importing helper code.
 
 **Trust model.** Setting `ALFRED_AGENT_TOOLS=1` is full arbitrary-code-execution
-consent: `af agent call` imports the project's helpers module at lookup time (its
-import-time side effects run merely to resolve a name), `af agent run` accepts
-absolute script paths outside the project root, and execution uses the current
-Python interpreter with no sandboxing. Only set the gate in repositories whose
-`.alfred/` content you trust as you would any executable code.
+consent: `af agent call` imports the PRJ and USR helper modules at lookup time
+(their import-time side effects run merely to resolve a name), `af agent run`
+accepts absolute script paths outside the project root, and execution uses the
+current Python interpreter with no sandboxing. Only set the gate when you trust
+both the repository's `.alfred/` content and your global
+`~/.alfred/agent_helpers.py` as you would any executable code.
 
 Discover reusable skill documents without executing code:
 

--- a/README.md
+++ b/README.md
@@ -143,6 +143,13 @@ ALFRED_AGENT_TOOLS=1 af agent run scripts/check_release.py --json
 first, then `~/.alfred/agent_helpers.py`. The exact
 `ALFRED_AGENT_TOOLS=1` gate is checked before importing helper code.
 
+**Trust model.** Setting `ALFRED_AGENT_TOOLS=1` is full arbitrary-code-execution
+consent: `af agent call` imports the project's helpers module at lookup time (its
+import-time side effects run merely to resolve a name), `af agent run` accepts
+absolute script paths outside the project root, and execution uses the current
+Python interpreter with no sandboxing. Only set the gate in repositories whose
+`.alfred/` content you trust as you would any executable code.
+
 Discover reusable skill documents without executing code:
 
 ```bash

--- a/src/fx_alfred/core/agent_helpers.py
+++ b/src/fx_alfred/core/agent_helpers.py
@@ -1,3 +1,13 @@
+"""Agent helper execution trust model.
+
+Setting ALFRED_AGENT_TOOLS=1 is consent to full arbitrary code execution.
+call_helper imports PRJ/USR helper modules while looking up a helper name.
+That import runs module side effects even when it only resolves a name.
+resolve_script_path allows absolute script paths outside the project root.
+Scripts execute with the current interpreter, sys.executable.
+No sandbox is applied around helper imports, helper calls, or scripts.
+"""
+
 from __future__ import annotations
 
 import asyncio


### PR DESCRIPTION
## What

Two documentation gaps from the 2026-07-02 review (the missing-venv failure was hit live at session start):

1. **Bootstrap**: CLAUDE.md's Essential Commands assumed `.venv/bin/*` exists; a fresh checkout fails every documented dev command. `uv sync --extra dev` now leads the block with a one-line note.
2. **`af agent` trust model**: the execution contract was implicit. README's agent section and a new `core/agent_helpers.py` module docstring now state all four facts: the `ALFRED_AGENT_TOOLS=1` gate is full arbitrary-code-execution consent; `call_helper` imports the helpers module at LOOKUP time (import side effects run merely to resolve a name); `resolve_script_path` permits absolute out-of-root paths; execution uses the current interpreter with no sandboxing. The implementer verified each fact against the code (no discrepancies).

Docs only — no behavior change (`test_docs_drift` green; Essential Commands is not drift-pinned, verified by the plan panel).

## Verification

- `pytest`: 1490 passed, 2 skipped (incl. docs-drift guards); `ruff` clean; `pyright src/`: 0 errors
- Plan pre-reviewed by triad (COR-1609, non-code weights): GLM 9.15 / DeepSeek 9.65 / MiniMax 9.0, zero blocking

## Scope hints

In scope: CLAUDE.md Essential Commands bootstrap line; README trust-model paragraph; `core/agent_helpers.py` module docstring (comment-only src change).
Out of scope: hardening `resolve_script_path`/`call_helper` behavior (explicitly a separate ticket per the issue).

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)