### PR TITLE
refactor(fxa-279): dead-code and duplication cleanup from the 2026-07-02 review

### DIFF
--- a/src/fx_alfred/commands/fmt_cmd.py
+++ b/src/fx_alfred/commands/fmt_cmd.py
@@ -10,10 +10,9 @@ import click
 
 from fx_alfred.commands._helpers import atomic_write, find_or_fail, scan_or_fail
 from fx_alfred.context import root_option
-from fx_alfred.core.normalize import sort_metadata
+from fx_alfred.core.normalize import reorder_by_canonical_keys, sort_metadata
 from fx_alfred.core.parser import (
     MalformedDocumentError,
-    MetadataField,
     ParsedDocument,
     iter_lines_with_fence_state,
     parse_metadata,
@@ -48,14 +47,7 @@ def normalize_metadata_order(parsed: ParsedDocument, doc_type: DocType | None) -
     canonical_keys = sort_metadata(current_keys, doc_type)
 
     # List-based reorder — preserves all fields including duplicates
-    ordered_fields: list[MetadataField] = []
-    remaining = list(parsed.metadata_fields)
-    for key in canonical_keys:
-        for i, mf in enumerate(remaining):
-            if mf.key == key:
-                ordered_fields.append(remaining.pop(i))
-                break
-    ordered_fields.extend(remaining)
+    ordered_fields = reorder_by_canonical_keys(parsed.metadata_fields, canonical_keys)
 
     # Same objects in same order = no change (dataclass __eq__ compares all fields)
     if ordered_fields == parsed.metadata_fields:

--- a/src/fx_alfred/commands/tag_cmd.py
+++ b/src/fx_alfred/commands/tag_cmd.py
@@ -19,7 +19,7 @@ from fx_alfred.commands._helpers import (
 )
 from fx_alfred.context import root_option
 from fx_alfred.core.document import Document
-from fx_alfred.core.normalize import sort_metadata
+from fx_alfred.core.normalize import reorder_by_canonical_keys, sort_metadata
 from fx_alfred.core.parser import (
     MalformedDocumentError,
     MetadataField,
@@ -98,15 +98,9 @@ def _edit_tags(
             if doc_type is not None:
                 current_keys = [mf.key for mf in parsed.metadata_fields]
                 canonical_keys = sort_metadata(current_keys, doc_type)
-                ordered: list[MetadataField] = []
-                remaining = list(parsed.metadata_fields)
-                for key in canonical_keys:
-                    for i, mf in enumerate(remaining):
-                        if mf.key == key:
-                            ordered.append(remaining.pop(i))
-                            break
-                ordered.extend(remaining)
-                parsed.metadata_fields = ordered
+                parsed.metadata_fields = reorder_by_canonical_keys(
+                    parsed.metadata_fields, canonical_keys
+                )
         else:
             tag_field.value = tags_value
             tag_field.dirty = True

--- a/src/fx_alfred/commands/validate_cmd.py
+++ b/src/fx_alfred/commands/validate_cmd.py
@@ -597,19 +597,14 @@ def validate_cmd(
                     if doc_type is not None
                     else None
                 )
-                if allowed is not None:
-                    if "(" in status_val or ")" in status_val:
-                        issues.append(
-                            f"Invalid Status value '{status_val}' for type "
-                            f"{doc.type_code} (allowed: "
-                            f"{', '.join(sorted(allowed))})"
-                        )
-                    elif status_val not in allowed:
-                        issues.append(
-                            f"Invalid Status value '{status_val}' for type "
-                            f"{doc.type_code} (allowed: "
-                            f"{', '.join(sorted(allowed))})"
-                        )
+                if allowed is not None and (
+                    "(" in status_val or ")" in status_val or status_val not in allowed
+                ):
+                    issues.append(
+                        f"Invalid Status value '{status_val}' for type "
+                        f"{doc.type_code} (allowed: "
+                        f"{', '.join(sorted(allowed))})"
+                    )
 
             # Validate Tags field format (if present)
             tag_field = next(

--- a/src/fx_alfred/core/dag_graph.py
+++ b/src/fx_alfred/core/dag_graph.py
@@ -345,11 +345,14 @@ def _render_phase(
             # -> next-step flows are visually disconnected (Codex P1 review
             # finding). Compute "has next" by scanning for any later
             # non-skipped, non-branch-group-parent step.
+            # (later not in skip_indices and later not in branch_groups) or
+            # (later in branch_groups) is a tautology once the outer filter
+            # already guarantees `later not in skip_indices` — every later
+            # is either in branch_groups or not, so the disjunction is
+            # always True. Simplifies to: is there any later step at all
+            # (skipped ones excluded)?
             has_following_step = any(
-                (later not in skip_indices and later not in branch_groups)
-                or later in branch_groups
-                for later in range(s_idx + 1, step_count)
-                if later not in skip_indices
+                later not in skip_indices for later in range(s_idx + 1, step_count)
             )
             if has_following_step:
                 lines.append(_render_arrow_line(inside_phase=True))

--- a/src/fx_alfred/core/document.py
+++ b/src/fx_alfred/core/document.py
@@ -62,47 +62,37 @@ class Document:
     def filename(self) -> str:
         return f"{self.prefix}-{self.acid}-{self.type_code}-{self.title.replace(' ', '-')}.md"
 
-    @property
-    def tags(self) -> list[str]:
-        """Parse Tags metadata field. Returns [] if absent or unreadable."""
+    def _metadata_value(self, key: str) -> str | None:
+        """Read a single metadata field's raw value from the source file.
+
+        Returns None if the field is absent or the document is unreadable.
+        Applies the same ACID=0000 dummy-H1 substitution used by both the
+        ``tags`` and ``status`` properties so the parser can extract
+        metadata from index docs with non-standard H1s.
+        """
         try:
             content = self.resolve_resource().read_text(encoding="utf-8")
-            # ACID=0000 index docs may have non-standard H1; substitute
-            # a dummy H1 so the parser can extract metadata (same approach
-            # as validate_cmd).
             if self.acid == "0000":
                 lines = content.split("\n")
                 if lines and not H1_PATTERN.match(lines[0]):
                     dummy_h1 = f"# {self.type_code}-{self.acid}: Index"
                     content = dummy_h1 + content[len(lines[0]) :]
             parsed = parse_metadata(content)
-            tag_field = next(
-                (mf for mf in parsed.metadata_fields if mf.key == "Tags"), None
-            )
-            return parse_tags(tag_field.value) if tag_field else []
+            field = next((mf for mf in parsed.metadata_fields if mf.key == key), None)
+            return field.value if field else None
         except (ValueError, OSError, MalformedDocumentError):
-            return []
+            return None
+
+    @property
+    def tags(self) -> list[str]:
+        """Parse Tags metadata field. Returns [] if absent or unreadable."""
+        value = self._metadata_value("Tags")
+        return parse_tags(value) if value else []
 
     @property
     def status(self) -> str:
         """Parse Status metadata field. Returns '' if absent or unreadable."""
-        try:
-            content = self.resolve_resource().read_text(encoding="utf-8")
-            # ACID=0000 index docs may have non-standard H1; substitute
-            # a dummy H1 so the parser can extract metadata (same approach
-            # as tags property).
-            if self.acid == "0000":
-                lines = content.split("\n")
-                if lines and not H1_PATTERN.match(lines[0]):
-                    dummy_h1 = f"# {self.type_code}-{self.acid}: Index"
-                    content = dummy_h1 + content[len(lines[0]) :]
-            parsed = parse_metadata(content)
-            status_field = next(
-                (mf for mf in parsed.metadata_fields if mf.key == "Status"), None
-            )
-            return status_field.value if status_field else ""
-        except (ValueError, OSError, MalformedDocumentError):
-            return ""
+        return self._metadata_value("Status") or ""
 
     def resolve_resource(self) -> Resource:
         """Return a resource that supports read_text().

--- a/src/fx_alfred/core/normalize.py
+++ b/src/fx_alfred/core/normalize.py
@@ -3,6 +3,7 @@
 import re
 from datetime import datetime
 
+from fx_alfred.core.parser import MetadataField
 from fx_alfred.core.schema import DocType, REQUIRED_METADATA
 
 
@@ -75,6 +76,27 @@ def sort_metadata(fields: list[str], doc_type: DocType) -> list[str]:
     ]
     # Truly unknown fields in original relative order
     ordered += [f for f in fields if f not in canonical_set and f not in optional_set]
+    return ordered
+
+
+def reorder_by_canonical_keys(
+    fields: list[MetadataField], canonical_keys: list[str]
+) -> list[MetadataField]:
+    """Stable-reorder metadata fields to match ``canonical_keys``.
+
+    Fields whose key is not in ``canonical_keys`` keep their original
+    relative order, appended at the end. Preserves duplicate keys. Shared
+    by ``af fmt``'s metadata-order normalizer and ``af tag add``'s
+    newly-inserted ``Tags`` field placement.
+    """
+    ordered: list[MetadataField] = []
+    remaining = list(fields)
+    for key in canonical_keys:
+        for i, mf in enumerate(remaining):
+            if mf.key == key:
+                ordered.append(remaining.pop(i))
+                break
+    ordered.extend(remaining)
     return ordered
 
 

--- a/src/fx_alfred/core/scanner.py
+++ b/src/fx_alfred/core/scanner.py
@@ -96,10 +96,7 @@ def _scan_path_dir(
     for f in files:
         if not f.is_file():
             continue
-        try:
-            rel_parts = f.relative_to(directory).parts
-        except ValueError:
-            rel_parts = f.parts
+        rel_parts = f.relative_to(directory).parts
         if rel_parts and rel_parts[0] == "logs":
             continue
         if exclude_subdirs and rel_parts and rel_parts[0] in exclude_subdirs:

--- a/src/fx_alfred/core/skills.py
+++ b/src/fx_alfred/core/skills.py
@@ -4,7 +4,12 @@ import re
 from typing import Any
 
 from fx_alfred.core.document import Document
-from fx_alfred.core.parser import MalformedDocumentError, parse_metadata, parse_tags
+from fx_alfred.core.parser import (
+    MalformedDocumentError,
+    ParsedDocument,
+    parse_metadata,
+    parse_tags,
+)
 from fx_alfred.core.schema import TASK_TAGS
 
 
@@ -30,25 +35,33 @@ def _read_content(doc: Document) -> str:
     return doc.resolve_resource().read_text(encoding="utf-8")
 
 
-def _field_value(doc: Document, field: str) -> str | None:
+def _parsed(doc: Document) -> ParsedDocument | None:
+    """Read + parse a doc's metadata once. None if unreadable/malformed.
+
+    Callers that need multiple fields (task tags, body, ...) from the same
+    doc should call this once and reuse the result, instead of each field
+    accessor re-reading and re-parsing the file from scratch.
+    """
     try:
-        parsed = parse_metadata(_read_content(doc))
+        return parse_metadata(_read_content(doc))
     except (OSError, MalformedDocumentError):
+        return None
+
+
+def _field_value(parsed: ParsedDocument | None, field: str) -> str | None:
+    if parsed is None:
         return None
     field_map = {mf.key: mf.value for mf in parsed.metadata_fields}
     return field_map.get(field)
 
 
-def task_tags(doc: Document) -> list[str]:
-    raw = _field_value(doc, TASK_TAGS)
+def task_tags(parsed: ParsedDocument | None) -> list[str]:
+    raw = _field_value(parsed, TASK_TAGS)
     return parse_tags(raw) if raw else []
 
 
-def _body(doc: Document) -> str:
-    try:
-        return parse_metadata(_read_content(doc)).body
-    except (OSError, MalformedDocumentError):
-        return ""
+def _body(parsed: ParsedDocument | None) -> str:
+    return parsed.body if parsed is not None else ""
 
 
 def _source(doc: Document) -> dict[str, str]:
@@ -59,7 +72,11 @@ def _source(doc: Document) -> dict[str, str]:
     return {"layer": doc.source.upper(), "path": path}
 
 
-def skill_metadata(doc: Document) -> dict[str, Any]:
+def skill_metadata(
+    doc: Document, parsed: ParsedDocument | None = None
+) -> dict[str, Any]:
+    if parsed is None:
+        parsed = _parsed(doc)
     return {
         "id": doc_id(doc),
         "prefix": doc.prefix,
@@ -68,7 +85,7 @@ def skill_metadata(doc: Document) -> dict[str, Any]:
         "title": doc.title,
         "source": _source(doc),
         "tags": doc.tags,
-        "task_tags": task_tags(doc),
+        "task_tags": task_tags(parsed),
     }
 
 
@@ -91,15 +108,19 @@ def _slug(text: str) -> str:
     return _normalize(text).replace(" ", "-")
 
 
-def _score_skill(doc: Document, task: str) -> tuple[int, list[str]]:
+def _score_skill(
+    doc: Document, task: str, parsed: ParsedDocument | None = None
+) -> tuple[int, list[str]]:
+    if parsed is None:
+        parsed = _parsed(doc)
     score = 0
     reasons: list[str] = []
     tokens = _tokenize(task)
 
-    task_tag_set = set(task_tags(doc))
+    task_tag_set = set(task_tags(parsed))
     tag_set = set(doc.tags)
     title_tokens = set(_tokenize(doc.title))
-    body_tokens = set(_tokenize(_body(doc)))
+    body_tokens = set(_tokenize(_body(parsed)))
 
     for token in tokens:
         if token in task_tag_set:
@@ -130,9 +151,10 @@ def list_skills(
 
     results: list[dict[str, Any]] = []
     for doc in skills:
-        item = skill_metadata(doc)
+        parsed = _parsed(doc)
+        item = skill_metadata(doc, parsed)
         if task:
-            score, reasons = _score_skill(doc, task)
+            score, reasons = _score_skill(doc, task, parsed)
             if score <= 0:
                 continue
             item["score"] = score

--- a/src/fx_alfred/core/workflow.py
+++ b/src/fx_alfred/core/workflow.py
@@ -383,8 +383,6 @@ def parse_workflow_branches(parsed: ParsedDocument) -> list[BranchSignature]:
 def validate_branches(
     parsed: ParsedDocument,
     branches: list[BranchSignature],
-    *,
-    _gate_open_for_test: bool = False,
 ) -> list[BranchError]:
     """Validate ``Workflow branches:`` declarations against the SOP body.
 
@@ -395,8 +393,7 @@ def validate_branches(
     1. **Renderer-readiness gate** — if ``_BRANCHES_RENDERER_READY`` is False
        (the default in CHG-2226 until CHG-2227 Phase 8a flips it), the
        presence of *any* branch declaration is a hard error directing
-       authors to wait for CHG-2227. ``_gate_open_for_test`` bypasses this
-       gate for tests that need to exercise the structural rules below.
+       authors to wait for CHG-2227.
     2. **`from` exists** — must reference an existing integer step under
        the recognised steps heading.
     3. **`to.parent == from + 1`** — every sibling's parent integer must
@@ -416,7 +413,7 @@ def validate_branches(
     # non-emptiness. The spec is "MUST NOT author this field until
     # CHG-2227 lands" — authoring an empty list still authors the field.
     field_present = has_workflow_branches_field(parsed)
-    if field_present and not (_BRANCHES_RENDERER_READY or _gate_open_for_test):
+    if field_present and not _BRANCHES_RENDERER_READY:
         errors.append(
             BranchError(
                 msg=(
@@ -434,9 +431,17 @@ def validate_branches(
 
     section = extract_steps_section(parsed.body) if parsed.body else None
     sub_steps_in_order: list[tuple[int, str]] = []  # [(parent, branch), ...]
-    plain_step_positions: dict[int, int] = {}  # int_index -> first occurrence
+    # Plain-step ints only (excluding parent ints injected from sub-step
+    # lines) — used by Rule 2 below per PR #68 Codex F1 finding. The
+    # spec says `from` must reference an EXISTING INTEGER step in
+    # `## Steps`; sub-stepped-only parents (no bare `2.` line) should
+    # NOT satisfy `from: 2`.
+    plain_only_ints: set[int] = set()
+    # Unified ordered view of every step line (plain + sub) — shared across
+    # all branches' Rule 5 contiguity check below (the section doesn't
+    # change per branch, so scan it once).
+    unified: list[tuple[str, int, str | None]] = []
     if section is not None:
-        position = 0  # logical position counting ALL parsed step lines
         # Fenced lines are skipped via the shared CommonMark tracker
         # (CHG-2299; same discipline as parse_top_level_step_indices).
         # Validation-side matching stays permissive — both "3." and
@@ -451,11 +456,10 @@ def validate_branches(
             parent = int(m.group(1))
             sub = m.group(2)
             if sub is None:
-                if parent not in plain_step_positions:
-                    plain_step_positions[parent] = position
+                plain_only_ints.add(parent)
             else:
                 sub_steps_in_order.append((parent, sub))
-            position += 1
+            unified.append(("sub" if sub else "plain", parent, sub))
 
     # Build a lookup set of (parent, branch) pairs that exist in ## Steps.
     sub_steps_set = set(sub_steps_in_order)
@@ -464,13 +468,6 @@ def validate_branches(
     for sig in branches:
         for tgt in sig.to:
             declared.add((tgt.parent, tgt.branch))
-
-    # Plain-step ints only (excluding parent ints injected from sub-step
-    # lines) — used by Rule 2 below per PR #68 Codex F1 finding. The
-    # spec says `from` must reference an EXISTING INTEGER step in
-    # `## Steps`; sub-stepped-only parents (no bare `2.` line) should
-    # NOT satisfy `from: 2`.
-    plain_only_ints = frozenset(plain_step_positions.keys())
 
     for i, sig in enumerate(branches):
         # Rule 2: from references existing INTEGER step (must be a bare
@@ -512,40 +509,20 @@ def validate_branches(
                     )
                 )
 
-        # Rule 5: siblings contiguous in ## Steps. Find positions of declared
-        # siblings; assert they are consecutive (allowing only sub-step lines
-        # between them).
-        sibling_positions = [
-            idx
-            for idx, (parent, branch) in enumerate(sub_steps_in_order)
-            if (parent, branch) in {(t.parent, t.branch) for t in sig.to}
+        # Rule 5: siblings contiguous in ## Steps. Uses the pre-scanned
+        # `unified` ordering (shared across all branches — the section
+        # doesn't change per branch) to verify no plain integer step
+        # appears between the first and last declared sibling.
+        sibling_set = {(t.parent, t.branch) for t in sig.to}
+        sib_unified_positions = [
+            u_idx
+            for u_idx, (kind, p, s) in enumerate(unified)
+            if kind == "sub" and (p, s) in sibling_set
         ]
-        if sibling_positions:
+        if sib_unified_positions:
             expected_parent = sig.from_step + 1
             interleaved_plain = False
-            # Build a unified ordered list of (kind, parent, branch_or_None)
-            # and verify no plain integer step appears between the first and
-            # last declared sibling.
-            unified: list[tuple[str, int, str | None]] = []
-            if section is not None:
-                # Shared fence tracker (CHG-2299); permissive matching as
-                # in the sub-step scan above.
-                for raw, fenced in iter_lines_with_fence_state(section):
-                    if fenced:
-                        continue
-                    m = re.match(r"^(?:###\s+)?(\d+)([a-z])?\.\s+", raw)
-                    if not m:
-                        continue
-                    p = int(m.group(1))
-                    s = m.group(2)
-                    unified.append(("sub" if s else "plain", p, s))
-            sibling_set = {(t.parent, t.branch) for t in sig.to}
-            sib_unified_positions = [
-                u_idx
-                for u_idx, (kind, p, s) in enumerate(unified)
-                if kind == "sub" and (p, s) in sibling_set
-            ]
-            if sib_unified_positions and len(sib_unified_positions) >= 2:
+            if len(sib_unified_positions) >= 2:
                 lo = min(sib_unified_positions)
                 hi = max(sib_unified_positions)
                 for u_idx in range(lo + 1, hi):

--- a/tests/test_workflow_branches_validate.py
+++ b/tests/test_workflow_branches_validate.py
@@ -103,7 +103,7 @@ def test_branches_from_must_be_plain_int_not_substep_only() -> None:
     )
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
-    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    errors = validate_branches(parsed, branches)
     # Should reject `from: 2` because there's no bare `2.` line — only `2a/2b`.
     assert any("from = 2" in e.msg for e in errors)
 
@@ -116,7 +116,7 @@ def test_branches_from_must_exist() -> None:
     )
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
-    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    errors = validate_branches(parsed, branches)
     assert any("from" in e.msg and "99" in e.msg for e in errors)
 
 
@@ -128,7 +128,7 @@ def test_branches_to_must_exist() -> None:
     )
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
-    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    errors = validate_branches(parsed, branches)
     assert any("3z" in e.msg for e in errors)
 
 
@@ -140,7 +140,7 @@ def test_branches_to_parent_must_match_from_plus_one() -> None:
     )
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
-    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    errors = validate_branches(parsed, branches)
     assert any("from + 1" in e.msg or "must be 3" in e.msg for e in errors)
 
 
@@ -152,7 +152,7 @@ def test_branches_parent_mismatch_message_renders_substep_id_cleanly() -> None:
     )
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
-    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    errors = validate_branches(parsed, branches)
     message = "\n".join(e.msg for e in errors)
     assert "id 3a parent" in message
     assert "3'a'" not in message
@@ -177,7 +177,7 @@ def test_branches_orphan_substep_rejected() -> None:
     )
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
-    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    errors = validate_branches(parsed, branches)
     assert any("3b" in e.msg and "orphan" in e.msg.lower() for e in errors)
 
 
@@ -189,7 +189,7 @@ def test_branches_siblings_must_be_contiguous() -> None:
     )
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
-    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    errors = validate_branches(parsed, branches)
     assert any("contiguous" in e.msg.lower() for e in errors)
 
 
@@ -201,7 +201,7 @@ def test_branches_valid_3way_passes_when_gate_open() -> None:
     )
     parsed = parse_metadata(body)
     branches = parse_workflow_branches(parsed)
-    errors = validate_branches(parsed, branches, _gate_open_for_test=True)
+    errors = validate_branches(parsed, branches)
     assert errors == []
 
 


### PR DESCRIPTION
## What

No-behavior-change cleanup of the dead/duplicated machinery found in the 2026-07-02 full-repo review. The existing 1506-test suite is the spec — identical pass set before and after. Net **−8 LoC**.

| # | Item | Outcome |
|---|------|---------|
| 1 | `workflow.validate_branches` dead machinery | Done: plain-step dict+counter → set (plain-only key-set intent preserved); truthiness-only `sibling_positions` removed; `unified` scan hoisted into the single pre-loop pass; dead `_gate_open_for_test` parameter deleted (+ its 8 kwarg-only test call sites). **`_BRANCHES_RENDERER_READY` deliberately kept** — grep showed it is live cross-file infrastructure (imported by `plan_cmd`'s `_enforce_branches_gate`; three real tests monkeypatch it to False and assert the gate fires), so full deletion would cascade outside the declared surface. |
| 2 | `scanner` unreachable `except ValueError` fallback | Done — `rglob`/`iterdir` results are always under the directory. |
| 3 | `tag_cmd`/`fmt_cmd` duplicate reorder loops | Done — extracted `core/normalize.reorder_by_canonical_keys`; both delegate (import direction respected). |
| 4a | `Document` tags/status twin blocks | Done — extracted `_metadata_value(key)`; falsy-collapsing verified equivalent. |
| 4b | `skills.py` re-parse per scoring pass | Done (bounded) — one parse per doc threaded through the pass (was up to 4×); `doc.tags` property calls left as-is (caching on Document = ~20-call-site cascade, rejected). |
| 5 | `dag_graph.has_following_step` tautology | Done — verified algebraically; connector emission unchanged (rendering suites + plain-ASCII goldens identical). |
| 6 | `validate_cmd` duplicate Status-error branches | Done — exactly two identical-message occurrences merged into one guard. |

## Verification

- `pytest`: 1506 passed, 2 skipped (identical to pre-refactor baseline); `ruff` clean; `pyright src/`: 0 errors
- Only test change: the 8 `_gate_open_for_test=True` kwarg removals (no assertion changes); whole-tree grep confirms zero remaining references
- Plan pre-reviewed by triad (COR-1609, non-code weights), two rounds: GLM 9.0 / DeepSeek 9.25 / MiniMax 9.60 (R1 blockings — kwarg-site enumeration, line-drift reconciliation — folded)

## Scope hints

In scope: the six listed surfaces, refactor-only.
Out of scope: any observable behavior change; `_BRANCHES_RENDERER_READY` deletion (live infrastructure, see item 1); Document-level tags caching (item 4b note).

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)