### PR TITLE
docs(fxa-2324): declare tier-2 loop back-edges (COR-1612/1615/1802)

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -234,6 +234,7 @@
 | 2321 | REF | Session Retrospective 2026 07 04 D1 | Active |
 | 2322 | CHG | Add COR 1005 Engineer Workflow Loops | Completed |
 | 2323 | CHG | Declare Review Loop Back Edges | Completed |
+| 2324 | CHG | Declare Tier 2 Loop Back Edges | Proposed |
 
 ---
 

--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -234,7 +234,7 @@
 | 2321 | REF | Session Retrospective 2026 07 04 D1 | Active |
 | 2322 | CHG | Add COR 1005 Engineer Workflow Loops | Completed |
 | 2323 | CHG | Declare Review Loop Back Edges | Completed |
-| 2324 | CHG | Declare Tier 2 Loop Back Edges | Proposed |
+| 2324 | CHG | Declare Tier 2 Loop Back Edges | Completed |
 
 ---
 

--- a/rules/FXA-2324-CHG-Declare-Tier-2-Loop-Back-Edges.md
+++ b/rules/FXA-2324-CHG-Declare-Tier-2-Loop-Back-Edges.md
@@ -3,7 +3,7 @@
 **Applies to:** FXA project
 **Last updated:** 2026-08-12
 **Last reviewed:** 2026-08-12
-**Status:** Proposed
+**Status:** Completed
 **Date:** 2026-08-12
 **Requested by:** Frank Xu (session request: continue the COR-1005 corpus audit with the tier-2 candidates)
 **Priority:** Medium
@@ -75,3 +75,4 @@ just visibility.
 | Date       | Change          | By          |
 |------------|-----------------|-------------|
 | 2026-08-12 | Initial version | Claude Code |
+| 2026-08-12 | Implemented: four back-edges declared, 1802 extraction fixed, all validation green | Claude Code |

--- a/rules/FXA-2324-CHG-Declare-Tier-2-Loop-Back-Edges.md
+++ b/rules/FXA-2324-CHG-Declare-Tier-2-Loop-Back-Edges.md
@@ -1,0 +1,77 @@
+# CHG-2324: Declare Tier 2 Loop Back-Edges
+
+**Applies to:** FXA project
+**Last updated:** 2026-08-12
+**Last reviewed:** 2026-08-12
+**Status:** Proposed
+**Date:** 2026-08-12
+**Requested by:** Frank Xu (session request: continue the COR-1005 corpus audit with the tier-2 candidates)
+**Priority:** Medium
+**Change Type:** Normal
+**Targets:** src/fx_alfred/rules/COR-1612-SOP-Respond-To-PR-Review-Comments.md, src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md, src/fx_alfred/rules/COR-1802-SOP-Build-Weighted-Decision-Matrix.md
+
+---
+
+## What
+
+Tier-2 retrofit from the COR-1005 corpus audit — three heterogeneous docs, each
+getting its prose loop declared as `Workflow loops:` metadata:
+
+- **COR-1612**: `{id: fix-round, from: 6, to: 1, max_iterations: 10}` — the §6
+  wait→refetch cycle. Budget and exhaustion were already documented (stopping
+  condition #4: 10-round nitpick-spiral fail-safe, escalate with options a/b/c);
+  the step body now names the declared loop. Fully semantics-preserving.
+- **COR-1615**: `{id: restart-on-push, from: 11, to: 1, max_iterations: 10}` —
+  §11 "Restart after every push / Return to Step 1". ⚠️ The SOP documented **no
+  cap of its own**; max 10 is adopted from COR-1612's documented 10-fix-round
+  fail-safe (composed at §10; each restart follows a fix push). This is a new,
+  aligned budget — flagged for owner sign-off.
+- **COR-1802**: two back-edges — `anchor-rework` (4→2) and `recalibrate` (5→2).
+  ⚠️ Both caps (max 2) are **newly proposed** (the doc documented the return
+  paths but no counts); exhaustion paths (escalate to operator) are also new.
+  Additionally, step headings are renamed `### Step N — Title` → `### N. Title`:
+  the old form did not match the step parser, so `af plan COR-1802` extracted
+  the column-0 sub-lists of steps 3/6 as phantom top-level steps and missed the
+  real 8-step structure entirely. The rename fixes that pre-existing extraction
+  defect; prose references ("return to Step 2") remain valid since numbering is
+  unchanged.
+
+## Why
+
+Continuation of FXA-2323 (tier 1). The COR-1005 audit found these three docs
+carry real iteration written as prose — invisible to `af plan`, `--graph`, and
+validation (COR-1005 failure mode ①). COR-1802 additionally renders a wrong
+checklist today (phantom steps), so its retrofit fixes an active defect, not
+just visibility.
+
+## Impact Analysis
+
+- **Systems affected:** three PKG rules docs; this CHG document plus its
+  FXA-0000 PRJ index row (via `af index`); one CHANGELOG Unreleased entry.
+  No code paths change.
+- **Consumers:** `af plan --graph` renders four new back-edges; `af plan
+  COR-1802` output changes from phantom sub-list steps to the real 8 steps —
+  the only behavior-visible change, and it corrects an existing error.
+- **Semantics flags for review:** COR-1615's cap and COR-1802's two caps +
+  exhaustion paths add previously-undocumented budgets (see ⚠️ above). COR-1612
+  is purely declarative.
+- **No cascade:** COR-1005/1602/1600/1601 referenced, not edited.
+- **Rollback plan:** revert the three doc edits, set this CHG to Rolled Back,
+  re-run `af index` so the FXA-0000 row reflects the status, and remove or
+  amend the CHANGELOG Unreleased entry.
+
+## Implementation Plan
+
+1. Declare loops + step-body prose per member; COR-1802 heading renames.
+2. Validate: `af validate` on all three, `af plan --graph` renders all four
+   back-edges, `af plan COR-1802` extracts the real 8 steps, docs drift test,
+   full `make check`.
+3. CHANGELOG Unreleased entry; PR; COR-1615 bot loop to merge-ready.
+
+---
+
+## Change History
+
+| Date       | Change          | By          |
+|------------|-----------------|-------------|
+| 2026-08-12 | Initial version | Claude Code |

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Improvements
 
+- **COR-1612 / COR-1615 / COR-1802 declare their loops** — tier-2 COR-1005
+  retrofit (FXA-2324): the COR-1612 fix-round cycle (6→1, max 10 per its own
+  stopping-condition fail-safe), the COR-1615 restart-on-push cycle (11→1,
+  max 10 adopted from COR-1612's fail-safe), and COR-1802's anchor-rework (4→2)
+  and recalibrate (5→2) back-edges (newly-proposed max 2 caps with operator
+  escalation) are now machine-readable `Workflow loops:` declarations.
+  COR-1802's step headings were also renamed to the parser-recognized `N.` form,
+  fixing `af plan COR-1802` extracting phantom sub-list steps instead of the
+  real 8-step structure.
 - **COR-1600 / COR-1601 declare their review back-edges** — first COR-1005
   retrofit (FXA-2323): both review-loop SOPs now carry machine-readable
   `Workflow loops:` declarations (`revise-resend` 6→5 and `revise-cycle` 7→4,

--- a/src/fx_alfred/rules/COR-1612-SOP-Respond-To-PR-Review-Comments.md
+++ b/src/fx_alfred/rules/COR-1612-SOP-Respond-To-PR-Review-Comments.md
@@ -1,11 +1,12 @@
 # SOP-1612: Respond To PR Review Comments
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-05-15
+**Last updated:** 2026-08-12
 **Last reviewed:** 2026-05-15
 **Status:** Draft
 **Tags:** pr, review
 **Related:** COR-1602 (Multi Model Parallel Review), COR-1615 (GitHub App PR Review Bot Loop)
+**Workflow loops:** [{id: fix-round, from: 6, to: 1, max_iterations: 10, condition: "new actionable comments since the last fix push or red CI for the current head"}]
 **Disposition:** inherit-only
 
 ---
@@ -158,6 +159,8 @@ GitHub only auto-marks line-anchored comments as outdated when the referenced di
 If there was no fix commit, reply only where applicable for Question, Incorrect, or declined Advisory comments.
 
 ### 6. Wait for CI **and the next bot review pass** — agent self-driven loop, no user prompting
+
+This wait→refetch cycle is the declared `fix-round` back-edge (6→1, max 10 rounds per stopping condition #4 below; on hitting the cap, escalate to the user per the cap-hit instructions — do not keep looping).
 
 After every fix push, the agent **MUST** wait 3–5 minutes and self-poll for new comments before handing control back to the user. Asking the user "anything new?" or "should I check again?" is **forbidden** — see §Pitfalls. The agent's job is to drive the loop until a stopping condition is hit.
 
@@ -598,3 +601,4 @@ These are orthogonal mechanisms — none is "bot is smarter." The defensive prac
 | 2026-05-09 | R3: codex bot R2 P2 (PR #122) — §When NOT useful skip rule "PR has fewer than 3 review rounds" contradicted the §Empirical evidence base (PR #119 + #120 both used hints from R1) and the CHG-2279 §Implementation Plan step 4 (eat-our-own-dogfood asks PRs to add hints before observing the bot). Adopters following the rule literally would never use hints from R1, losing the from-start usage pattern the SOP itself records. Narrowed to "small / uncertain scope PRs with no prior signal that the installed bot over-flags"; added explicit caveat that PRs known up-front to be long-running (large CHG/SOP, multi-file refactor) should add hints from R1. CHG-2279 R3. | Claude Opus 4.7 |
 | 2026-05-15 | FXA-2285: add pre-merge sweep routing from COR-1615; GitHub-side review threads must be resolved, outdated, or author-addressed before merge-ready. | Codex |
 | 2026-05-15 | FXA-2285 R2: clarify no-bot repos still route human and code-review-app GitHub threads through the pre-merge gate. | Codex |
+| 2026-08-12 | CHG FXA-2324: declare fix-round back-edge (6→1, max 10 per stopping condition #4) per COR-1005; step 6 names the loop and its cap-hit escalation | Claude Code |

--- a/src/fx_alfred/rules/COR-1612-SOP-Respond-To-PR-Review-Comments.md
+++ b/src/fx_alfred/rules/COR-1612-SOP-Respond-To-PR-Review-Comments.md
@@ -6,7 +6,7 @@
 **Status:** Draft
 **Tags:** pr, review
 **Related:** COR-1602 (Multi Model Parallel Review), COR-1615 (GitHub App PR Review Bot Loop)
-**Workflow loops:** [{id: fix-round, from: 6, to: 1, max_iterations: 10, condition: "new actionable comments since the last fix push or red CI for the current head"}]
+**Workflow loops:** [{id: fix-round, from: 6, to: 1, max_iterations: 10, condition: "new actionable comments since the last fix push"}]
 **Disposition:** inherit-only
 
 ---
@@ -602,3 +602,4 @@ These are orthogonal mechanisms — none is "bot is smarter." The defensive prac
 | 2026-05-15 | FXA-2285: add pre-merge sweep routing from COR-1615; GitHub-side review threads must be resolved, outdated, or author-addressed before merge-ready. | Codex |
 | 2026-05-15 | FXA-2285 R2: clarify no-bot repos still route human and code-review-app GitHub threads through the pre-merge gate. | Codex |
 | 2026-08-12 | CHG FXA-2324: declare fix-round back-edge (6→1, max 10 per stopping condition #4) per COR-1005; step 6 names the loop and its cap-hit escalation | Claude Code |
+| 2026-08-12 | Codex R1: loop condition limited to new actionable comments — CI-only failure routes through the decision tree's investigate-then-Steps-2–5 path, not the 6→1 fetch edge | Claude Code |

--- a/src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md
+++ b/src/fx_alfred/rules/COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md
@@ -1,13 +1,14 @@
 # SOP-1615: GitHub App PR Review Bot Loop
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-06-26
+**Last updated:** 2026-08-12
 **Last reviewed:** 2026-05-15
 **Status:** Active
 **Tags:** pr, review, loop
 **Related:** COR-1602 (Multi Model Parallel Review), COR-1612 (Respond To PR Review Comments), COR-1613 (Council Review)
 **Task tags:** [github, github-app, pull-request, pr-review, review, bot-review, codex, copilot]
 **Authored from:** BAB-1504-SOP-GitHub-Codex-PR-Review-Loop
+**Workflow loops:** [{id: restart-on-push, from: 11, to: 1, max_iterations: 10, condition: "a push created a new headRefOid without a completed review for it"}]
 **Disposition:** inherit-only
 
 ---
@@ -345,7 +346,7 @@ Classify each finding as blocking, advisory, question, or incorrect. Fix blockin
 
 ### 11. Restart after every push
 
-Every push creates a new `headRefOid`. Return to Step 1, then request or wait for a review of that new head. A clean review of the old head does not clear the new one. Do not assume re-review is automatic; some reviewers must be explicitly requested again after a push.
+Every push creates a new `headRefOid`. Return to Step 1 (declared `restart-on-push` back-edge, 11→1; max 10 restarts per PR, adopting COR-1612's documented 10-fix-round fail-safe since each restart follows a fix push — on exhaustion escalate to the user per COR-1612 stopping condition #4), then request or wait for a review of that new head. A clean review of the old head does not clear the new one. Do not assume re-review is automatic; some reviewers must be explicitly requested again after a push.
 
 ### 12. Stop only when the current head is clear
 
@@ -489,3 +490,4 @@ Use the GitHub App PR review bot loop:
 | 2026-05-15 | FXA-2285 R2: clarify no-bot repos do not waive unresolved human or code-review-app GitHub threads. | Codex |
 | 2026-06-26 | FXA-2311: completion criteria now require required-check policy evidence, merge state, review decision, draft/open state, and explicit human-gate handoff. | Codex |
 | 2026-06-26 | FXA-2311 R1 (codex bot P2): added `mergeStateStatus` to the §Commands `gh pr view` field list so operators following the SOP can record the value the completion gate now requires. | Codex |
+| 2026-08-12 | CHG FXA-2324: declare restart-on-push back-edge (11→1) per COR-1005; max 10 restarts adopted from COR-1612's documented 10-fix-round fail-safe (no own cap existed), exhaustion escalates per COR-1612 stopping condition #4 | Claude Code |

--- a/src/fx_alfred/rules/COR-1802-SOP-Build-Weighted-Decision-Matrix.md
+++ b/src/fx_alfred/rules/COR-1802-SOP-Build-Weighted-Decision-Matrix.md
@@ -1,10 +1,11 @@
 # SOP-1802: Build Weighted Decision Matrix
 
 **Applies to:** All projects using the COR document system
-**Last updated:** 2026-05-10
+**Last updated:** 2026-08-12
 **Last reviewed:** 2026-05-10
 **Status:** Active
 **Tags:** plan, decision-record
+**Workflow loops:** [{id: anchor-rework, from: 4, to: 2, max_iterations: 2, condition: "a midpoint anchor cannot be written as testable behavior"}, {id: recalibrate, from: 5, to: 2, max_iterations: 2, condition: "calibration still fails after 3 weight-adjustment cycles"}]
 **Disposition:** inherit-only
 
 ---
@@ -52,11 +53,11 @@ Do not build a weighted matrix when any of the following conditions apply:
 
 ## Steps
 
-### Step 1 — Define the decision
+### 1. Define the decision
 
 State the single question the matrix answers. Name the action set: binary (yes/no) or ordinal (create issue / log / discard). A matrix with > 3 action bands is a smell — split into two decisions.
 
-### Step 2 — Enumerate dimensions (3–6)
+### 2. Enumerate dimensions (3–6)
 
 For each candidate dimension, apply four tests before keeping it:
 
@@ -69,7 +70,7 @@ For each candidate dimension, apply four tests before keeping it:
 
 Discard any dimension that fails any test. If you have > 6 passing dimensions, the decision is probably two decisions — split it.
 
-### Step 3 — Assign weights
+### 3. Assign weights
 
 1. Rank dimensions by importance (forced ranking — no ties)
 2. Assign weights top-down; all must sum to 100%
@@ -78,23 +79,23 @@ Discard any dimension that fails any test. If you have > 6 passing dimensions, t
 5. Warning: weight < 10% → drop or merge
 6. **Equal weights after forced ranking are permitted** when two adjacent-ranked dimensions are genuinely indistinguishable in importance — the ranking still records the tiebreaker for edge cases even when weights are the same.
 
-### Step 4 — Write anchors
+### 4. Write anchors
 
 For each dimension, write three anchor descriptions at 0, 5, and 10:
 
 - **Behaviors, not adjectives.** "First time seen in any context" not "low recurrence"
 - **Anchors must be mutually exclusive** — a real case maps to exactly one anchor
-- If writing a 5 anchor is genuinely difficult, that is a signal the dimension may fail the anchor-testability test from Step 2 — return to Step 2 and consider dropping or splitting the dimension rather than omitting the midpoint anchor
+- If writing a 5 anchor is genuinely difficult, that is a signal the dimension may fail the anchor-testability test from Step 2 — return to Step 2 and consider dropping or splitting the dimension rather than omitting the midpoint anchor (declared `anchor-rework` back-edge, 4→2, max 2 reworks — if anchors still cannot be written after two dimension-set reworks, stop and escalate to the operator: the dimension is likely not behaviorally testable)
 
-### Step 5 — Calibrate with known cases
+### 5. Calibrate with known cases
 
 Collect 3–5 cases where the correct action is already known. Cases come from historical decisions in the consuming SOP's domain, or from expert judgment when no relevant history exists. Score each on every dimension, compute composite, check action. A matrix is not valid until all calibration cases produce the correct action.
 
 If a case produces the wrong action: identify the miscalibrated dimension and adjust. Re-run all cases after each adjustment.
 
-**Termination rule:** if calibration fails after ≥3 adjustment cycles, return to Step 2. Persistent failure means the dimension set is MECE-incomplete, not that weights are slightly off.
+**Termination rule:** if calibration fails after ≥3 adjustment cycles, return to Step 2 (declared `recalibrate` back-edge, 5→2, max 2 returns — if a second dimension-set rework still fails calibration, stop and escalate to the operator: the decision may not reduce to a weighted matrix). Persistent failure means the dimension set is MECE-incomplete, not that weights are slightly off.
 
-### Step 6 — Set action thresholds
+### 6. Set action thresholds
 
 Use boundary cases — the weakest acceptable and the strongest unacceptable — not the clearest extremes:
 
@@ -102,7 +103,7 @@ Use boundary cases — the weakest acceptable and the strongest unacceptable —
 2. Pick the **strongest case that clearly does NOT deserve action X** → its composite is the lower evidence bound (threshold must be > this composite)
 3. Set the threshold in the gap between those two composites. That gap is the **"uncertain" middle band** — strongly preferred. A pure binary threshold (no middle band) is permitted only with explicit written justification. Note: COR-1608/1609/1610 use binary pass/fail (≥9.0) — intentional exceptions, not violations.
 
-### Step 7 — Validate
+### 7. Validate
 
 Run at least:
 
@@ -110,7 +111,7 @@ Run at least:
 - ≥1 case at each threshold boundary (within ±0.5 of cutoff)
 - ≥1 initially-counterintuitive edge case
 
-### Step 8 — Document
+### 8. Document
 
 Use COR-1800's table format for the scoring rubric and action thresholds tables. Required consuming-document sections:
 
@@ -228,3 +229,4 @@ Composite: 0.25×9 + 0.25×10 + 0.15×8 + 0.15×10 + 0.20×9 = 2.25 + 2.5 + 1.2 
 | 2026-05-10 | R5: fix COR-1800 back-reference (codex bot P2). Changed "Built per COR-1802" → "See COR-1802 for the meta-framework" to avoid false compliance claim — COR-1800 pre-dates COR-1802 and lacks the required 0/5/10 anchors and calibration examples sections. | Claude Sonnet 4.6 |
 | 2026-05-10 | R6: (1) remove Step 4 "interpolate linearly" exception — contradicts anchor-testability requirement from Step 2; replaced with guidance to return to Step 2 if midpoint anchor is hard (codex bot P2); (2) sync CHG Step 3 to include equal-weight rule 6 (codex bot P2 on CHG line 84). | Claude Sonnet 4.6 |
 | 2026-05-10 | Issue #139: §Step 8 — clarify "COR-1800 table format" applies to scoring rubric and action thresholds only; calibration examples is an additional COR-1802 requirement not present in COR-1800. Codex bot finding on PR #137. | Claude Sonnet 4.6 |
+| 2026-08-12 | CHG FXA-2324: step headings renamed "Step N —" → "N." so af plan extracts the real 8 steps (previously phantom sub-list steps); declared anchor-rework (4→2) and recalibrate (5→2) back-edges per COR-1005 with newly-proposed max 2 caps and operator-escalation exhaustion paths | Claude Code |


### PR DESCRIPTION
## What

Tier-2 retrofit from the COR-1005 corpus audit, per CHG **FXA-2324** — three
heterogeneous docs get their prose loops declared as `Workflow loops:` metadata:

| Doc | Loop | Budget provenance |
|---|---|---|
| COR-1612 | `fix-round` 6→1, max 10 | its own stopping-condition #4 fail-safe — purely declarative |
| COR-1615 | `restart-on-push` 11→1, max 10 | ⚠️ no own cap existed; adopted from COR-1612's documented fail-safe (composed at §10) |
| COR-1802 | `anchor-rework` 4→2 + `recalibrate` 5→2, max 2 each | ⚠️ newly proposed caps + operator-escalation exhaustion paths |

The two ⚠️ rows add previously-undocumented budgets — deliberately flagged in
the CHG for owner sign-off rather than silently invented.

**COR-1802 also gets a real defect fix**: its `### Step N — Title` headings did
not match the step parser, so `af plan COR-1802` extracted the column-0
sub-lists of steps 3/6 as phantom top-level steps and missed the real 8-step
structure. Headings renamed to `### N. Title`; extraction now shows the true
steps 1–8. Prose references remain valid (numbering unchanged).

## Validation

- `.venv/bin/af validate` clean on all three docs + CHG
- `af plan --graph` renders all four back-edges (`🔁 → 1.1 max 10` ×2, `🔁 → 1.2 max 2` ×2)
- `af plan COR-1802` extracts the real 8 steps (was: phantom sub-lists)
- `make check` green (1506 passed / 2 skipped); docs drift test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyWa4NmteUEbvSa9yw9Bt2