### PR TITLE
docs(fxa-2325): COR-1617 loop back-edges + parser-visible phases (tier-3 retrofit)

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -235,6 +235,7 @@
 | 2322 | CHG | Add COR 1005 Engineer Workflow Loops | Completed |
 | 2323 | CHG | Declare Review Loop Back Edges | Completed |
 | 2324 | CHG | Declare Tier 2 Loop Back Edges | Completed |
+| 2325 | CHG | Declare COR 1617 Loop Back Edges | Completed |
 
 ---
 

--- a/rules/FXA-2325-CHG-Declare-COR-1617-Loop-Back-Edges.md
+++ b/rules/FXA-2325-CHG-Declare-COR-1617-Loop-Back-Edges.md
@@ -81,3 +81,4 @@ step-level back-edges existed only as prose (COR-1005 failure mode ①).
 | 2026-08-12 | Initial version | Claude Code |
 | 2026-08-12 | Implemented: section renamed, 12 steps extract, both back-edges render, validation green | Claude Code |
 | 2026-08-12 | Codex R1: iterate-round max 10 → 13 — COR-1005 exhaustion fires at the hard stop (soft cap + extension), not the soft cap | Claude Code |
+| 2026-08-12 | Codex R2: declarations reordered so iterate-round survives the --todo same-from-step collapse (interim); renderer defect filed as issue #324 | Claude Code |

--- a/rules/FXA-2325-CHG-Declare-COR-1617-Loop-Back-Edges.md
+++ b/rules/FXA-2325-CHG-Declare-COR-1617-Loop-Back-Edges.md
@@ -25,11 +25,13 @@ loop becomes machine-readable:
   pattern, so they remain body content, and every intra- and cross-doc
   "§Phase N" reference stays valid.
 - **Two declared back-edges**, both from Phase 9 (Triage):
-  - `iterate-round` (9→8, `max_iterations: 10`): §8's "gate not met → triage →
-    push R+1 → loop back". Budget and exhaustion were already fully documented —
-    `<max-r-count>` default 10 per COR-1622 §R-count cap, with §Round-count
-    cap's Cases A/B/C (converged / extension / hard stop with operator
-    sign-off) as the exhaustion contract. Purely declarative.
+  - `iterate-round` (9→8, `max_iterations: 13`): §8's "gate not met → triage →
+    push R+1 → loop back". Budget and exhaustion were already fully documented:
+    max 13 is the §Round-count cap **hard stop** (`<max-r-count>` 10 +
+    `<max-r-count-extension>` 3 per COR-1622), matching COR-1005's definition
+    of `max_iterations` as the point where exhaustion behavior fires; the
+    soft-cap/extension logic (Cases A/B/C) is the in-doc contract between
+    rounds 10 and 13. Purely declarative.
   - `replan-blocker` (9→4, `max_iterations: 2`): §9's "plan-review
     architectural blockers go back to phase 4". ⚠️ The return path was
     documented but carried **no count**; max 2 is newly proposed, with a new
@@ -78,3 +80,4 @@ step-level back-edges existed only as prose (COR-1005 failure mode ①).
 |------------|-----------------|-------------|
 | 2026-08-12 | Initial version | Claude Code |
 | 2026-08-12 | Implemented: section renamed, 12 steps extract, both back-edges render, validation green | Claude Code |
+| 2026-08-12 | Codex R1: iterate-round max 10 → 13 — COR-1005 exhaustion fires at the hard stop (soft cap + extension), not the soft cap | Claude Code |

--- a/rules/FXA-2325-CHG-Declare-COR-1617-Loop-Back-Edges.md
+++ b/rules/FXA-2325-CHG-Declare-COR-1617-Loop-Back-Edges.md
@@ -1,0 +1,80 @@
+# CHG-2325: Declare COR-1617 Loop Back-Edges
+
+**Applies to:** FXA project
+**Last updated:** 2026-08-12
+**Last reviewed:** 2026-08-12
+**Status:** Completed
+**Date:** 2026-08-12
+**Requested by:** Frank Xu (session request: tier-3 flagship of the COR-1005 corpus audit)
+**Priority:** Medium
+**Change Type:** Normal
+**Targets:** src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
+
+---
+
+## What
+
+Tier-3 retrofit of the COR-1005 audit — the twelve-phase multi-agent workflow
+loop becomes machine-readable:
+
+- **§Phases → §Steps**: the section is renamed to the parser-recognized heading
+  and the twelve-phase list at its top is un-fenced into flush-left numbered
+  steps (it was inside a code fence, which fence-aware extraction correctly
+  ignores — so `af plan COR-1617` extracted **zero steps**). The `### Phase N`
+  detail subsections are untouched: their headings do not match the step
+  pattern, so they remain body content, and every intra- and cross-doc
+  "§Phase N" reference stays valid.
+- **Two declared back-edges**, both from Phase 9 (Triage):
+  - `iterate-round` (9→8, `max_iterations: 10`): §8's "gate not met → triage →
+    push R+1 → loop back". Budget and exhaustion were already fully documented —
+    `<max-r-count>` default 10 per COR-1622 §R-count cap, with §Round-count
+    cap's Cases A/B/C (converged / extension / hard stop with operator
+    sign-off) as the exhaustion contract. Purely declarative.
+  - `replan-blocker` (9→4, `max_iterations: 2`): §9's "plan-review
+    architectural blockers go back to phase 4". ⚠️ The return path was
+    documented but carried **no count**; max 2 is newly proposed, with a new
+    exhaustion sentence (second re-plan still blocked → halt and surface: the
+    approach, not the plan, is likely wrong). Flagged for owner sign-off.
+- **Deliberate non-declarations, recorded in the doc**: the 12→1 loop restart
+  and Phase 1's idle-with-retry are runtime-paced loops whose exit is
+  governance (COR-1618 consent per tick, COR-1620 stop-marker, `<idle-cap>`),
+  not an iteration budget — per COR-1005 §When NOT to Use. §Phase 12 now says
+  so explicitly, so future audits do not re-flag them.
+
+## Why
+
+COR-1617 is the corpus's flagship loop SOP, yet it was the least
+machine-readable document in the audit: `af plan COR-1617` produced an empty
+checklist (the only numbered list sat inside a code fence), and its two genuine
+step-level back-edges existed only as prose (COR-1005 failure mode ①).
+
+## Impact Analysis
+
+- **Systems affected:** one PKG rules doc; this CHG plus its FXA-0000 PRJ index
+  row (via `af index`); one CHANGELOG Unreleased entry. No code paths change.
+- **Consumers:** `af plan COR-1617` goes from zero steps to the real 12;
+  `--graph` renders both back-edges (ASCII shows one 🔁 annotation per
+  from-step — an existing renderer limitation, both edges present in Mermaid).
+- **Semantics flags for review:** `replan-blocker`'s max 2 + exhaustion
+  sentence are new (⚠️ above). `iterate-round` is purely declarative.
+- **No cascade:** COR-1618/1620/1621/1622/1602/1615 referenced, not edited;
+  cross-doc "§Phase N" references remain valid (numbering unchanged).
+- **Rollback plan:** revert the doc edit, set this CHG to Rolled Back, re-run
+  `af index`, and remove or amend the CHANGELOG Unreleased entry.
+
+## Implementation Plan
+
+1. Rename §Phases → §Steps; un-fence the 12-line list; declare both loops;
+   §9 loop note; §12 non-declaration rationale; Change History row.
+2. Validate: `af validate COR-1617`, `af plan COR-1617` extracts 12 steps,
+   `--graph` renders both back-edges, docs drift test, full `make check`.
+3. CHANGELOG Unreleased entry; PR; COR-1615 bot loop to merge-ready.
+
+---
+
+## Change History
+
+| Date       | Change          | By          |
+|------------|-----------------|-------------|
+| 2026-08-12 | Initial version | Claude Code |
+| 2026-08-12 | Implemented: section renamed, 12 steps extract, both back-edges render, validation green | Claude Code |

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -7,8 +7,8 @@
 - **COR-1617 becomes machine-readable** — tier-3 COR-1005 retrofit (FXA-2325):
   §Phases is renamed §Steps and the twelve-phase list is un-fenced into
   parser-visible numbered steps (`af plan COR-1617` previously extracted zero
-  steps). Two back-edges declared from Triage: `iterate-round` (9→8, budget =
-  the documented §Round-count cap) and `replan-blocker` (9→4, newly-proposed
+  steps). Two back-edges declared from Triage: `iterate-round` (9→8, max 13 =
+  the documented §Round-count cap hard stop) and `replan-blocker` (9→4, newly-proposed
   max 2 with halt-and-surface exhaustion). The 12→1 restart and idle-with-retry
   stay deliberately undeclared as governance-bounded runtime loops, now
   recorded in §Phase 12 per COR-1005 §When NOT to Use.

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Improvements
 
+- **COR-1617 becomes machine-readable** — tier-3 COR-1005 retrofit (FXA-2325):
+  §Phases is renamed §Steps and the twelve-phase list is un-fenced into
+  parser-visible numbered steps (`af plan COR-1617` previously extracted zero
+  steps). Two back-edges declared from Triage: `iterate-round` (9→8, budget =
+  the documented §Round-count cap) and `replan-blocker` (9→4, newly-proposed
+  max 2 with halt-and-surface exhaustion). The 12→1 restart and idle-with-retry
+  stay deliberately undeclared as governance-bounded runtime loops, now
+  recorded in §Phase 12 per COR-1005 §When NOT to Use.
 - **COR-1612 / COR-1615 / COR-1802 declare their loops** — tier-2 COR-1005
   retrofit (FXA-2324): the COR-1612 fix-round cycle (6→1, max 10 per its own
   stopping-condition fail-safe), the COR-1615 restart-on-push cycle (11→1,

--- a/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
+++ b/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
@@ -1,11 +1,12 @@
 # SOP-1617: Multi-Agent Workflow Loop
 
 **Applies to:** All projects with a multi-provider review setup and an autonomous-orchestrator capability
-**Last updated:** 2026-06-26
+**Last updated:** 2026-08-12
 **Last reviewed:** 2026-05-17
 **Status:** Active
 **Tags:** workflow, loop
 **Related:** COR-1602 (Multi Model Parallel Review — composes for plan-review and code-review panels), COR-1615 (GitHub App PR Review Bot Loop — composes for §8 bot polling), COR-1618 (consent auto-pick), COR-1619 (worker dispatch), COR-1620 (loop primitives), COR-1621 (triage), COR-1505 (branch + identity hygiene), COR-1104 (CHG sizing), COR-1622 (parameter schema), COR-1506 (issue quality gate — Phase 1 autonomous picks)
+**Workflow loops:** [{id: iterate-round, from: 9, to: 8, max_iterations: 10, condition: "code-review panel or bot gate not met for the current head after triage"}, {id: replan-blocker, from: 9, to: 4, max_iterations: 2, condition: "plan-review architectural blocker requires re-dispatching the panel after a CHG fix"}]
 **Disposition:** optional-overlay
 
 ---
@@ -57,11 +58,10 @@ The phases below reference parameters by `<key>`. See COR-1622 for the full key 
 
 ---
 
-## Phases
+## Steps
 
-The loop has **12 phases**:
+The loop has **12 phases** (one numbered step per phase; the `### Phase N` subsections below carry each phase's full contract):
 
-```
 1. Auto-pick               ← consent gate per COR-1618
 2. Branch & identity       ← COR-1505
 3. Plan                    ← CHG sizing per COR-1104
@@ -74,7 +74,6 @@ The loop has **12 phases**:
 10. Handoff + merge-watch  ← user merges; merge-watch wake per COR-1620
 11. Retrospective          ← synchronous; no wakeup
 12. Loop restart           ← post-handoff wake per COR-1620
-```
 
 ### Phase-to-SOP routing
 
@@ -251,6 +250,8 @@ Case C is evaluated first: reaching the extended hard-stop round requires operat
 
 Apply COR-1621 to every finding. Plan-review architectural blockers go back to phase 4 (re-dispatch panel after CHG fix); code-review and bot findings flow through the severity tree. Re-dispatch the panel only when blockers (or convergent advisories) were addressed.
 
+Two declared back-edges leave this phase: `iterate-round` (9→8, capped by §Round-count cap — its Cases A/B/C are the budget and exhaustion contract) and `replan-blocker` (9→4, max 2 re-plans — if a second re-planned round still produces architectural blockers, halt and surface to the user: the approach, not the plan, is likely wrong).
+
 ### Phase 10 — Handoff + merge-watch
 
 When the current-head state packet proves all readiness conditions below:
@@ -313,6 +314,8 @@ Output a 3-line nomination (target SOP, evidence — round numbers and finding c
 After phase 10 completes (PR merged + main checked out + main pulled) and phase 11 (Retrospective) finishes, arm a single 60 s wake (per COR-1620's hard floor) whose prompt re-runs phase 1. The 60 s captures the post-handoff burst window where the operator may signal a queued issue immediately after merge.
 
 The wake's prompt MUST include the FIRST stop-marker guard and SECOND branch guard from COR-1620.
+
+The 12→1 restart is deliberately NOT declared as `Workflow loops:` metadata: its exit is governance, not an iteration budget — COR-1618 consent gating on every tick plus the COR-1620 stop-marker bound it, per COR-1005 §When NOT to Use (runtime pacing of a running loop). The same applies to Phase 1's idle-with-retry (bounded by `<idle-cap>` per COR-1622).
 
 ---
 
@@ -393,3 +396,4 @@ This SOP is the PKG-layer generalization of trinity's `TRN-1008-SOP-Multi-Agent-
 | 2026-05-17 | issue #166 R2 (PR #180 codex bot P2): R1's fall-through note from User-driven to "Continuation or Loop-driven" was broken — those rows cover post-merge mandate-carry and scheduled wakeup re-entry respectively, NOT initial user-typed loop-start. Added a 4th trigger row **Loop-start (user-initiated)** explicitly covering bare `pick next issue` / `auto-pick` / `follow FXA-2276` — mandate from invocation, consent gate applies on every pick including the first. Phrase-list table updated 3-row → 4-row; intro sentence updated accordingly. | Claude Opus 4.7 |
 | 2026-06-26 | FXA-2311: Phase 8 now carries a current-head PR state packet; Phase 10 readiness requires current-head review, required checks, pre-merge sweep, merge-state policy, review-decision policy, and explicit human gate state. | Codex |
 | 2026-06-26 | FXA-2311 R2 (codex bot P2): Phase 10 required-check bullet now whitelists allowed `conclusion in {success, skipped, neutral}` and names the full set of completed non-green conclusions (`action_required`, `stale`, `startup_failure`, etc.) as blockers, closing the blacklist gap. | Codex |
+| 2026-08-12 | CHG FXA-2325: §Phases renamed §Steps with the 12-phase list un-fenced into parser-visible numbered steps (af plan previously extracted zero steps); declared iterate-round (9→8, budget = §Round-count cap) and replan-blocker (9→4, max 2 newly proposed) back-edges per COR-1005; §Phase 12 records why 12→1 stays undeclared (governance-bounded, COR-1005 §When NOT to Use) | Claude Code |

--- a/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
+++ b/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
@@ -6,7 +6,7 @@
 **Status:** Active
 **Tags:** workflow, loop
 **Related:** COR-1602 (Multi Model Parallel Review — composes for plan-review and code-review panels), COR-1615 (GitHub App PR Review Bot Loop — composes for §8 bot polling), COR-1618 (consent auto-pick), COR-1619 (worker dispatch), COR-1620 (loop primitives), COR-1621 (triage), COR-1505 (branch + identity hygiene), COR-1104 (CHG sizing), COR-1622 (parameter schema), COR-1506 (issue quality gate — Phase 1 autonomous picks)
-**Workflow loops:** [{id: iterate-round, from: 9, to: 8, max_iterations: 13, condition: "code-review panel or bot gate not met for the current head after triage"}, {id: replan-blocker, from: 9, to: 4, max_iterations: 2, condition: "plan-review architectural blocker requires re-dispatching the panel after a CHG fix"}]
+**Workflow loops:** [{id: replan-blocker, from: 9, to: 4, max_iterations: 2, condition: "plan-review architectural blocker requires re-dispatching the panel after a CHG fix"}, {id: iterate-round, from: 9, to: 8, max_iterations: 13, condition: "code-review panel or bot gate not met for the current head after triage"}]
 **Disposition:** optional-overlay
 
 ---

--- a/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
+++ b/src/fx_alfred/rules/COR-1617-SOP-Multi-Agent-Workflow-Loop.md
@@ -6,7 +6,7 @@
 **Status:** Active
 **Tags:** workflow, loop
 **Related:** COR-1602 (Multi Model Parallel Review — composes for plan-review and code-review panels), COR-1615 (GitHub App PR Review Bot Loop — composes for §8 bot polling), COR-1618 (consent auto-pick), COR-1619 (worker dispatch), COR-1620 (loop primitives), COR-1621 (triage), COR-1505 (branch + identity hygiene), COR-1104 (CHG sizing), COR-1622 (parameter schema), COR-1506 (issue quality gate — Phase 1 autonomous picks)
-**Workflow loops:** [{id: iterate-round, from: 9, to: 8, max_iterations: 10, condition: "code-review panel or bot gate not met for the current head after triage"}, {id: replan-blocker, from: 9, to: 4, max_iterations: 2, condition: "plan-review architectural blocker requires re-dispatching the panel after a CHG fix"}]
+**Workflow loops:** [{id: iterate-round, from: 9, to: 8, max_iterations: 13, condition: "code-review panel or bot gate not met for the current head after triage"}, {id: replan-blocker, from: 9, to: 4, max_iterations: 2, condition: "plan-review architectural blocker requires re-dispatching the panel after a CHG fix"}]
 **Disposition:** optional-overlay
 
 ---
@@ -250,7 +250,7 @@ Case C is evaluated first: reaching the extended hard-stop round requires operat
 
 Apply COR-1621 to every finding. Plan-review architectural blockers go back to phase 4 (re-dispatch panel after CHG fix); code-review and bot findings flow through the severity tree. Re-dispatch the panel only when blockers (or convergent advisories) were addressed.
 
-Two declared back-edges leave this phase: `iterate-round` (9→8, capped by §Round-count cap — its Cases A/B/C are the budget and exhaustion contract) and `replan-blocker` (9→4, max 2 re-plans — if a second re-planned round still produces architectural blockers, halt and surface to the user: the approach, not the plan, is likely wrong).
+Two declared back-edges leave this phase: `iterate-round` (9→8, max 13 = the §Round-count cap hard stop: soft cap `<max-r-count>` 10 + `<max-r-count-extension>` 3 — Cases A/B/C are the budget and exhaustion contract, and Case C at round 13 is where COR-1005 exhaustion fires) and `replan-blocker` (9→4, max 2 re-plans — if a second re-planned round still produces architectural blockers, halt and surface to the user: the approach, not the plan, is likely wrong).
 
 ### Phase 10 — Handoff + merge-watch
 
@@ -396,4 +396,4 @@ This SOP is the PKG-layer generalization of trinity's `TRN-1008-SOP-Multi-Agent-
 | 2026-05-17 | issue #166 R2 (PR #180 codex bot P2): R1's fall-through note from User-driven to "Continuation or Loop-driven" was broken — those rows cover post-merge mandate-carry and scheduled wakeup re-entry respectively, NOT initial user-typed loop-start. Added a 4th trigger row **Loop-start (user-initiated)** explicitly covering bare `pick next issue` / `auto-pick` / `follow FXA-2276` — mandate from invocation, consent gate applies on every pick including the first. Phrase-list table updated 3-row → 4-row; intro sentence updated accordingly. | Claude Opus 4.7 |
 | 2026-06-26 | FXA-2311: Phase 8 now carries a current-head PR state packet; Phase 10 readiness requires current-head review, required checks, pre-merge sweep, merge-state policy, review-decision policy, and explicit human gate state. | Codex |
 | 2026-06-26 | FXA-2311 R2 (codex bot P2): Phase 10 required-check bullet now whitelists allowed `conclusion in {success, skipped, neutral}` and names the full set of completed non-green conclusions (`action_required`, `stale`, `startup_failure`, etc.) as blockers, closing the blacklist gap. | Codex |
-| 2026-08-12 | CHG FXA-2325: §Phases renamed §Steps with the 12-phase list un-fenced into parser-visible numbered steps (af plan previously extracted zero steps); declared iterate-round (9→8, budget = §Round-count cap) and replan-blocker (9→4, max 2 newly proposed) back-edges per COR-1005; §Phase 12 records why 12→1 stays undeclared (governance-bounded, COR-1005 §When NOT to Use) | Claude Code |
+| 2026-08-12 | CHG FXA-2325: §Phases renamed §Steps with the 12-phase list un-fenced into parser-visible numbered steps (af plan previously extracted zero steps); declared iterate-round (9→8, max 13 = §Round-count cap hard stop) and replan-blocker (9→4, max 2 newly proposed) back-edges per COR-1005; §Phase 12 records why 12→1 stays undeclared (governance-bounded, COR-1005 §When NOT to Use) | Claude Code |


### PR DESCRIPTION
## What

Tier-3 flagship retrofit from the COR-1005 corpus audit, per CHG **FXA-2325**.

**Before:** `af plan COR-1617` extracted **zero steps** — the only numbered
list sat inside a code fence (fence-aware extraction correctly ignores it) and
`### Phase N —` headings don't match the step parser.

**After:** §Phases → §Steps with the twelve-phase list un-fenced into
flush-left numbered steps; `af plan` extracts the real 12, and two back-edges
render:

| Loop | Edge | Budget provenance |
|---|---|---|
| `iterate-round` | 9→8, max 10 | documented — `<max-r-count>` per COR-1622 + §Round-count cap Cases A/B/C as the exhaustion contract |
| `replan-blocker` | 9→4, max 2 | ⚠️ return path was documented, count was not; max 2 newly proposed with halt-and-surface exhaustion — flagged for owner sign-off |

**Deliberate non-declarations, recorded in §Phase 12:** the 12→1 restart and
Phase 1 idle-with-retry are governance-bounded runtime loops (COR-1618 consent
per tick, COR-1620 stop-marker, `<idle-cap>`) per COR-1005 §When NOT to Use —
so future audits don't re-flag them.

Zero heading renames: `### Phase N` subsections keep their names, so every
intra- and cross-doc "§Phase N" reference remains valid.

Observed (not fixed here): the ASCII renderer shows one 🔁 annotation per
from-step; both 9→8 and 9→4 are present in the Mermaid output.

## Validation

- `.venv/bin/af validate` clean (COR-1617 + CHG)
- `af plan COR-1617` extracts 12 steps (was 0)
- `af plan --graph COR-1617`: `🔁 → 1.8 max 10` in ASCII; `S1_9 -. yes .-> S1_8` and `S1_9 -. yes .-> S1_4` in Mermaid
- `make check` green (1506 passed / 2 skipped); docs drift test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyWa4NmteUEbvSa9yw9Bt2