### PR TITLE
test(fxa-2326): regression guard for bundled loop declarations

### DIFF
--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -236,6 +236,7 @@
 | 2323 | CHG | Declare Review Loop Back Edges | Completed |
 | 2324 | CHG | Declare Tier 2 Loop Back Edges | Completed |
 | 2325 | CHG | Declare COR 1617 Loop Back Edges | Completed |
+| 2326 | CHG | Loop Declaration Regression Guard | Completed |
 
 ---
 

--- a/rules/FXA-2326-CHG-Loop-Declaration-Regression-Guard.md
+++ b/rules/FXA-2326-CHG-Loop-Declaration-Regression-Guard.md
@@ -1,0 +1,66 @@
+# CHG-2326: Loop Declaration Regression Guard
+
+**Applies to:** FXA project
+**Last updated:** 2026-08-12
+**Last reviewed:** 2026-08-12
+**Status:** Completed
+**Date:** 2026-08-12
+**Requested by:** Frank Xu (session request: add the regression guard test for the COR-1005 retrofit campaign)
+**Priority:** Medium
+**Change Type:** Normal
+**Targets:** tests/test_bundled_loop_declarations.py (new)
+
+---
+
+## What
+
+One data-driven test module pinning the outcome of the COR-1005 retrofit
+campaign (PRs #320–#323) for all eight loop-declaring bundled docs:
+
+- **Loop signatures, in declaration order** — `(id, from, to, max_iterations)`
+  per doc. Order is load-bearing for COR-1617: `iterate-round` must stay last
+  so it survives the `--todo` same-from-step collapse (issue #324).
+- **Step extraction** — each doc keeps a parser-visible Steps section whose
+  top-level indices are exactly `1..N` (contiguous).
+- **Coverage closure** — any bundled doc that starts declaring
+  `Workflow loops:` without being pinned here fails CI, so the table cannot
+  silently rot.
+
+Pattern follows `tests/test_cor1402_literal_drift.py` (per-doc drift guard);
+marker `docs` per the existing test-marker governance.
+
+## Why
+
+The 1500-test engine suite asserts nothing about specific bundled documents'
+loop structure. Both extraction defects fixed during the campaign — COR-1617's
+fenced list (zero steps extracted) and COR-1802's phantom sub-list steps —
+shipped unnoticed precisely because no test would fail. A re-fenced list, a
+heading rename back to `### Step N —`, a budget edit, or a loop reorder in
+COR-1617 would today regress silently; with this guard each fails the first CI
+run.
+
+## Impact Analysis
+
+- **Systems affected:** tests only (one new file, 17 tests). No runtime code,
+  no docs content.
+- **Consumers:** future doc PRs touching loop declarations must update the
+  expectation table — that is the point (a conscious, reviewed change).
+- **Rollback plan:** delete the test file, set this CHG to Rolled Back,
+  re-run `af index`.
+
+## Implementation Plan
+
+1. Author `tests/test_bundled_loop_declarations.py` with the expectation table
+   for the eight docs; non-COR-format bundled files (INIT.md) are skipped in
+   the coverage sweep.
+2. Validate: new module 17/17, full `make check` green (1523 passed).
+3. PR; COR-1615 bot loop to merge-ready.
+
+---
+
+## Change History
+
+| Date       | Change          | By          |
+|------------|-----------------|-------------|
+| 2026-08-12 | Initial version | Claude Code |
+| 2026-08-12 | Implemented: 17 guard tests green, full suite 1523 passed | Claude Code |

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Improvements
 
+- **Loop-declaration regression guard** — `tests/test_bundled_loop_declarations.py`
+  (FXA-2326) pins step-extraction counts and exact loop signatures (in
+  declaration order) for all eight loop-declaring bundled docs, plus a coverage
+  sweep so new declarations must be pinned. The COR-1617 zero-steps and
+  COR-1802 phantom-steps defects would now fail CI on first run.
 - **COR-1617 becomes machine-readable** — tier-3 COR-1005 retrofit (FXA-2325):
   §Phases is renamed §Steps and the twelve-phase list is un-fenced into
   parser-visible numbered steps (`af plan COR-1617` previously extracted zero

--- a/tests/test_bundled_loop_declarations.py
+++ b/tests/test_bundled_loop_declarations.py
@@ -1,0 +1,111 @@
+"""Regression guard for bundled Workflow-loops declarations (FXA-2326).
+
+Locks in the outcome of the COR-1005 retrofit campaign (PRs #320–#323): every
+bundled document that declares ``Workflow loops:`` must keep (a) a
+parser-visible Steps section with the expected contiguous step count and (b)
+its exact loop signatures, in declaration order.
+
+Why order matters: ``af plan --todo`` currently collapses multiple loops
+sharing a ``from`` step to the *last* declaration (issue #324), so COR-1617
+deliberately lists ``iterate-round`` after ``replan-blocker``. A reorder would
+silently hide the primary loop from checklist output.
+
+Why step counts matter: COR-1617 shipped for months with a fenced step list
+(``af plan`` extracted zero steps) and COR-1802's old ``### Step N —``
+headings made the planner extract phantom sub-list steps — both regressions
+this guard would have caught on the first CI run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from fx_alfred.core.parser import MalformedDocumentError, parse_metadata
+from fx_alfred.core.steps import extract_steps_section, parse_top_level_step_indices
+from fx_alfred.core.workflow import parse_workflow_loops
+
+pytestmark = pytest.mark.docs
+
+_RULES = Path(__file__).resolve().parents[1] / "src" / "fx_alfred" / "rules"
+
+# doc filename -> (expected top-level step count,
+#                  [(loop id, from, to, max_iterations), ...] in declaration order)
+EXPECTED: dict[str, tuple[int, list[tuple[str, int, int | str, int]]]] = {
+    "COR-1005-SOP-Engineer-Workflow-Loops.md": (
+        8,
+        [("fix-authoring", 7, 5, 3)],
+    ),
+    "COR-1602-SOP-Workflow-Multi-Model-Parallel-Review.md": (
+        8,
+        [("review-retry", 7, 3, 3)],
+    ),
+    "COR-1600-SOP-Workflow-Direct-Review-Loop.md": (
+        8,
+        [("revise-resend", 6, 5, 5)],
+    ),
+    "COR-1601-SOP-Workflow-Leader-Mediated-Review-Loop.md": (
+        8,
+        [("revise-cycle", 7, 4, 5)],
+    ),
+    "COR-1612-SOP-Respond-To-PR-Review-Comments.md": (
+        8,
+        [("fix-round", 6, 1, 10)],
+    ),
+    "COR-1615-SOP-GitHub-App-PR-Review-Bot-Loop.md": (
+        12,
+        [("restart-on-push", 11, 1, 10)],
+    ),
+    "COR-1802-SOP-Build-Weighted-Decision-Matrix.md": (
+        8,
+        [("anchor-rework", 4, 2, 2), ("recalibrate", 5, 2, 2)],
+    ),
+    "COR-1617-SOP-Multi-Agent-Workflow-Loop.md": (
+        12,
+        # iterate-round MUST stay last (issue #324 --todo collapse mitigation).
+        [("replan-blocker", 9, 4, 2), ("iterate-round", 9, 8, 13)],
+    ),
+}
+
+
+@pytest.mark.parametrize("filename", sorted(EXPECTED))
+def test_loop_declaration_signature(filename: str) -> None:
+    """Each loop-declaring doc keeps its exact loop signatures, in order."""
+    parsed = parse_metadata((_RULES / filename).read_text(encoding="utf-8"))
+    expected_loops = EXPECTED[filename][1]
+    actual = [
+        (loop.id, loop.from_step, loop.to_step, loop.max_iterations)
+        for loop in parse_workflow_loops(parsed)
+    ]
+    assert actual == expected_loops
+
+
+@pytest.mark.parametrize("filename", sorted(EXPECTED))
+def test_steps_extraction_count(filename: str) -> None:
+    """Each loop-declaring doc keeps a parser-visible, contiguous Steps section."""
+    parsed = parse_metadata((_RULES / filename).read_text(encoding="utf-8"))
+    section = extract_steps_section(parsed.body)
+    assert section is not None, f"{filename}: no parser-recognised Steps section"
+    expected_count = EXPECTED[filename][0]
+    indices = parse_top_level_step_indices(section)
+    assert indices == frozenset(range(1, expected_count + 1)), (
+        f"{filename}: extracted step indices {sorted(indices)} != 1..{expected_count}"
+    )
+
+
+def test_expected_covers_every_declaring_doc() -> None:
+    """No bundled doc declares Workflow loops without being pinned here."""
+    declaring: set[str] = set()
+    for p in sorted(_RULES.glob("*.md")):
+        try:
+            parsed = parse_metadata(p.read_text(encoding="utf-8"))
+        except MalformedDocumentError:
+            # Non-COR-format bundled files (e.g. INIT.md) cannot declare loops.
+            continue
+        if any(
+            mf.key == "Workflow loops" and mf.value.strip()
+            for mf in parsed.metadata_fields
+        ):
+            declaring.add(p.name)
+    assert declaring == set(EXPECTED)


### PR DESCRIPTION
## What

Per CHG **FXA-2326**: one data-driven test module
(`tests/test_bundled_loop_declarations.py`, 17 tests) locking in the COR-1005
retrofit campaign (PRs #320–#323):

- **Loop signatures in declaration order** for all 8 loop-declaring docs —
  order is load-bearing for COR-1617, where `iterate-round` must stay last to
  survive the `--todo` same-from-step collapse (#324).
- **Step extraction**: each doc keeps a parser-visible Steps section with
  contiguous `1..N` indices — the COR-1617 zero-steps (fenced list) and
  COR-1802 phantom-steps (`### Step N —` headings) defects would now fail CI
  on first run.
- **Coverage sweep**: a bundled doc that starts declaring `Workflow loops:`
  without being pinned fails the suite.

Pattern follows the existing per-doc drift guard
(`test_cor1402_literal_drift.py`); `docs` marker per test-marker governance.
Tests only — no runtime code, no doc content.

## Validation

- New module: 17/17 passed
- `make check` green: 1523 passed / 2 skipped (was 1506)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyWa4NmteUEbvSa9yw9Bt2