### PR TITLE
ci(fxa-2328): semantic-release automation — merge-to-main auto-releases

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -67,18 +67,39 @@ jobs:
           python - "${{ steps.next.outputs.version }}" <<'EOF'
           import datetime
           import re
+          import subprocess
           import sys
 
           version = sys.argv[1]
           path = "src/fx_alfred/CHANGELOG.md"
           text = open(path, encoding="utf-8").read()
+          today = datetime.date.today().isoformat()
+
+          def tag_exists(v):
+              out = subprocess.run(
+                  ["git", "tag", "--list", f"v{v}"],
+                  capture_output=True, text=True, check=True,
+              ).stdout.strip()
+              return out != ""
+
+          # Reconcile an orphaned promotion: a prior run promoted a section,
+          # semantic-release failed, and a later merge changed the computed
+          # bump level (e.g. 1.28.1 -> 1.29.0). The topmost version heading
+          # then names a release that will never be tagged — rename it to the
+          # newly computed version so its notes ship under the real release.
+          top = re.search(r"^## v(\d+\.\d+\.\d+) \([^)]*\)\n", text, re.M)
+          if top and top.group(1) != version and not tag_exists(top.group(1)):
+              print(f"Renaming orphaned untagged v{top.group(1)} section to v{version}.")
+              text = text[: top.start()] + f"## v{version} ({today})\n" + text[top.end():]
+              open(path, "w", encoding="utf-8").write(text)
+
           m = re.search(r"^## Unreleased\n(.*?)(?=^## |\Z)", text, re.M | re.S)
           notes = m.group(1) if m else ""
           existing = re.search(
               rf"^## v{re.escape(version)} \([^)]*\)\n", text, re.M
           )
           if existing and not notes.strip():
-              print(f"v{version} section already present; nothing to promote.")
+              print(f"v{version} section already present; nothing further to promote.")
               sys.exit(0)
           if existing:
               # Retry path: a prior run promoted this version, semantic-release

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -68,16 +68,33 @@ jobs:
           version = sys.argv[1]
           path = "src/fx_alfred/CHANGELOG.md"
           text = open(path, encoding="utf-8").read()
-          if f"## v{version} (" in text:
-              print(f"v{version} section already present; promotion is idempotent — skipping.")
-              sys.exit(0)
           m = re.search(r"^## Unreleased\n(.*?)(?=^## |\Z)", text, re.M | re.S)
-          if not m or not m.group(1).strip():
+          notes = m.group(1) if m else ""
+          existing = re.search(
+              rf"^## v{re.escape(version)} \([^)]*\)\n", text, re.M
+          )
+          if existing and not notes.strip():
+              print(f"v{version} section already present; nothing to promote.")
+              sys.exit(0)
+          if existing:
+              # Retry path: a prior run promoted this version, semantic-release
+              # failed, and a newer merge added fresh Unreleased notes before
+              # the rerun. Fold those notes into the existing section instead
+              # of stranding them under Unreleased.
+              text = text[: m.start()] + "## Unreleased\n\n" + text[m.end():]
+              existing = re.search(
+                  rf"^## v{re.escape(version)} \([^)]*\)\n", text, re.M
+              )
+              text = text[: existing.end()] + notes + text[existing.end():]
+              open(path, "w", encoding="utf-8").write(text)
+              print(f"Folded fresh Unreleased notes into existing v{version} section.")
+              sys.exit(0)
+          if not notes.strip():
               print("No curated Unreleased notes; skipping promotion.")
               sys.exit(0)
           today = datetime.date.today().isoformat()
           promoted = text[: m.start()] + (
-              f"## Unreleased\n\n## v{version} ({today})\n{m.group(1)}"
+              f"## Unreleased\n\n## v{version} ({today})\n{notes}"
           ) + text[m.end():]
           open(path, "w", encoding="utf-8").write(promoted)
           print(f"Promoted Unreleased to v{version} ({today}).")

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -54,6 +54,10 @@ jobs:
       - name: Promote CHANGELOG Unreleased section
         if: steps.next.outputs.version != ''
         run: |
+          # Recovery: a rerun checks out the originally pushed SHA; if a prior
+          # attempt already pushed the promotion, fast-forward onto it so our
+          # push below is not non-fast-forward.
+          git pull --ff-only origin main
           python - "${{ steps.next.outputs.version }}" <<'EOF'
           import datetime
           import re
@@ -62,6 +66,9 @@ jobs:
           version = sys.argv[1]
           path = "src/fx_alfred/CHANGELOG.md"
           text = open(path, encoding="utf-8").read()
+          if f"## v{version} (" in text:
+              print(f"v{version} section already present; promotion is idempotent — skipping.")
+              sys.exit(0)
           m = re.search(r"^## Unreleased\n(.*?)(?=^## |\Z)", text, re.M | re.S)
           if not m or not m.group(1).strip():
               print("No curated Unreleased notes; skipping promotion.")

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -34,6 +34,53 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Compute next version
+        id: next
+        run: |
+          pip install --quiet "python-semantic-release==9.*"
+          CURRENT=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          NEXT=$(semantic-release --noop version --print 2>/dev/null | tail -1)
+          echo "current=$CURRENT next=$NEXT"
+          if [[ -n "$NEXT" && "$NEXT" != "$CURRENT" ]]; then
+            echo "version=$NEXT" >> $GITHUB_OUTPUT
+          else
+            echo "version=" >> $GITHUB_OUTPUT
+          fi
+
+      # Promote the hand-curated `## Unreleased` section to the computed
+      # version BEFORE semantic-release commits and tags, so the wheel built
+      # from the tag ships a CHANGELOG with correct version boundaries
+      # (`af changelog` reads it). Semantic-release's own changelog stays off.
+      - name: Promote CHANGELOG Unreleased section
+        if: steps.next.outputs.version != ''
+        run: |
+          python - "${{ steps.next.outputs.version }}" <<'EOF'
+          import datetime
+          import re
+          import sys
+
+          version = sys.argv[1]
+          path = "src/fx_alfred/CHANGELOG.md"
+          text = open(path, encoding="utf-8").read()
+          m = re.search(r"^## Unreleased\n(.*?)(?=^## |\Z)", text, re.M | re.S)
+          if not m or not m.group(1).strip():
+              print("No curated Unreleased notes; skipping promotion.")
+              sys.exit(0)
+          today = datetime.date.today().isoformat()
+          promoted = text[: m.start()] + (
+              f"## Unreleased\n\n## v{version} ({today})\n{m.group(1)}"
+          ) + text[m.end():]
+          open(path, "w", encoding="utf-8").write(promoted)
+          print(f"Promoted Unreleased to v{version} ({today}).")
+          EOF
+          if ! git diff --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add src/fx_alfred/CHANGELOG.md
+            git commit -m "chore(release): promote CHANGELOG Unreleased to v${{ steps.next.outputs.version }}"
+            git push
+          fi
+
       - name: Semantic Release (version + tag + GitHub Release)
         id: semantic-release
         uses: python-semantic-release/python-semantic-release@v9

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -11,11 +11,15 @@ concurrency:
 
 jobs:
   release:
-    # Recursion guard: semantic-release pushes a `chore(release): ...` commit
-    # back to main; that push must not trigger another release cycle.
+    # Recursion guard, second layer: both generated commits (promotion +
+    # semantic-release version bump) carry `[skip ci]`, which suppresses the
+    # push event at the platform level. The prefix check below is
+    # belt-and-suspenders and deliberately matches only the generated
+    # subject shape — a developer commit merely *mentioning* the text
+    # (e.g. `fix: handle chore(release): commits`) must still release.
     if: |
       github.actor != 'github-actions[bot]' &&
-      !contains(github.event.head_commit.message, 'chore(release):')
+      !startsWith(github.event.head_commit.message, 'chore(release):')
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -103,7 +107,7 @@ jobs:
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
             git add src/fx_alfred/CHANGELOG.md
-            git commit -m "chore(release): promote CHANGELOG Unreleased to v${{ steps.next.outputs.version }}"
+            git commit -m "chore(release): promote CHANGELOG Unreleased to v${{ steps.next.outputs.version }} [skip ci]"
             git push
           fi
 

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Compute next version
         id: next
         run: |
+          # Sync to the current tip FIRST so compute, promotion, and
+          # semantic-release all operate on the same head — a release-worthy
+          # push racing this run would otherwise make the promoted version
+          # diverge from the tagged one. Also absorbs a prior run's promotion
+          # commit on rerun (fast-forward, never a merge).
+          git pull --ff-only origin main
           pip install --quiet "python-semantic-release==9.*"
           CURRENT=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
           NEXT=$(semantic-release --noop version --print 2>/dev/null | tail -1)
@@ -54,10 +60,6 @@ jobs:
       - name: Promote CHANGELOG Unreleased section
         if: steps.next.outputs.version != ''
         run: |
-          # Recovery: a rerun checks out the originally pushed SHA; if a prior
-          # attempt already pushed the promotion, fast-forward onto it so our
-          # push below is not non-fast-forward.
-          git pull --ff-only origin main
           python - "${{ steps.next.outputs.version }}" <<'EOF'
           import datetime
           import re

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -1,0 +1,57 @@
+name: CD Release
+
+on:
+  push:
+    branches: [main]
+
+# One release at a time; never cancel a release mid-flight.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # Recursion guard: semantic-release pushes a `chore(release): ...` commit
+    # back to main; that push must not trigger another release cycle.
+    if: |
+      github.actor != 'github-actions[bot]' &&
+      !contains(github.event.head_commit.message, 'chore(release):')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # PAT, not GITHUB_TOKEN: releases created with the default token do
+          # not fire the `release: published` trigger that publish.yml needs.
+          token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Semantic Release (version + tag + GitHub Release)
+        id: semantic-release
+        uses: python-semantic-release/python-semantic-release@v9
+        with:
+          github_token: ${{ secrets.SEMANTIC_RELEASE_PAT }}
+          git_committer_name: "github-actions[bot]"
+          git_committer_email: "41898282+github-actions[bot]@users.noreply.github.com"
+          # CHANGELOG stays hand-curated in src/fx_alfred/CHANGELOG.md
+          # (`af changelog` reads it); semantic-release must not overwrite it.
+          changelog: false
+
+      - name: Release status summary
+        if: always()
+        run: |
+          if [[ "${{ steps.semantic-release.outputs.version }}" == "" ]]; then
+            echo "## No release" >> $GITHUB_STEP_SUMMARY
+            echo "No release-worthy conventional commits since the last tag." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## Released v${{ steps.semantic-release.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+            echo "publish.yml now runs test -> build -> Trusted Publishing for the new GitHub Release." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,21 @@ markers = [
 
 [tool.ruff]
 target-version = "py310"
+
+[tool.semantic_release]
+tag_format = "v{version}"
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"
+commit_parser = "conventional"
+# Build + PyPI upload are handled by publish.yml (release: published trigger);
+# semantic-release only versions, tags, and creates the GitHub Release.
+build_command = ""
+upload_to_pypi = false
+upload_to_repository = false
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
+minor_tags = ["feat"]
+# `docs` bumps patch: bundled SOP documents ship inside the wheel, so a docs
+# change is a shippable change for this package.
+patch_tags = ["fix", "perf", "docs"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ tag_format = "v{version}"
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 commit_parser = "conventional"
+# Prefix must match cd-release.yml's recursion guard; [skip ci] suppresses
+# the push event at the platform level (psr's default message has neither).
+commit_message = "chore(release): v{version} [skip ci]"
 # Build + PyPI upload are handled by publish.yml (release: published trigger);
 # semantic-release only versions, tags, and creates the GitHub Release.
 build_command = ""

--- a/rules/FXA-0000-REF-Document-Index.md
+++ b/rules/FXA-0000-REF-Document-Index.md
@@ -238,6 +238,7 @@
 | 2325 | CHG | Declare COR 1617 Loop Back Edges | Completed |
 | 2326 | CHG | Loop Declaration Regression Guard | Completed |
 | 2327 | CHG | COR 1615 Agent Execution Ladder | Completed |
+| 2328 | CHG | Semantic Release Automation | Proposed |
 
 ---
 

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -27,7 +27,8 @@ A defined release process ensures consistent, verifiable deployments. Using GitH
 
 - A new version of fx-alfred is ready for public release
 - All tests pass, lint is clean, and dual code review is complete
-- Version has been bumped and changes are pushed to `main`
+- The change has landed (or is about to land) on `main` — the automated path
+  bumps the version itself; only the manual fallback pre-bumps (§Prerequisites)
 
 ---
 

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -1,17 +1,19 @@
 # SOP-2102: Release To PyPI
 
 **Applies to:** FXA project
-**Last updated:** 2026-06-29
-**Last reviewed:** 2026-03-17
+**Last updated:** 2026-08-16
+**Last reviewed:** 2026-08-16
 **Status:** Active
-**Tags:** release, ship
 **Task tags:** release, pypi
+**Tags:** release, ship
 
 ---
 
 ## What Is It?
 
 The process for releasing a new version of fx-alfred to PyPI via GitHub Actions and Trusted Publisher.
+
+Since FXA-2328 the primary path is **automated**: merging a conventional-commit PR to `main` triggers `cd-release.yml` (semantic-release decides the version, tags, and creates the GitHub Release), which fires `publish.yml` (test → build → Trusted Publishing). The manual §Steps below are the fallback for when the automation is unavailable or a hand-crafted release is needed.
 
 ---
 
@@ -33,7 +35,8 @@ A defined release process ensures consistent, verifiable deployments. Using GitH
 
 - Code is not yet reviewed -- complete FXA-2100 (Leader Mediated Development) first
 - Tests or lint are failing
-- Only document changes were made (no code release needed)
+
+Note: bundled SOP document changes ship in the wheel, so `docs(...)` commits DO release (as a patch bump) under the automated path; commit as `chore`/`test`/`ci` when a change genuinely should not release.
 
 ---
 
@@ -50,7 +53,32 @@ A defined release process ensures consistent, verifiable deployments. Using GitH
 
 ---
 
+## Automated Path (Primary, FXA-2328)
+
+1. Land the change on `main` through the normal PR flow with conventional
+   commits (`feat` → minor, `fix`/`perf`/`docs` → patch; `chore`/`test`/`ci`
+   → no release). Update CHANGELOG's `## Unreleased` section and the README
+   "NEW in vX" line (FXA-2136) inside the PR — semantic-release does not
+   write prose.
+2. On merge, `cd-release.yml` runs semantic-release: bumps
+   `pyproject.toml:project.version`, commits `chore(release): ...`, tags
+   `v{version}`, creates the GitHub Release (via `SEMANTIC_RELEASE_PAT`).
+3. The Release event triggers `publish.yml`: test gate → build → Trusted
+   Publishing to PyPI.
+4. Verify: `gh run list --workflow=publish.yml --limit 1` shows success and
+   `pip index versions fx-alfred` (or the PyPI JSON API) lists the new
+   version.
+
+Requirements: the `SEMANTIC_RELEASE_PAT` repository secret must exist (repo
+scope; the default `GITHUB_TOKEN` cannot fire `publish.yml`), and the PAT
+owner must be able to push the release commit to `main`.
+
+---
+
 ## Steps
+
+Manual fallback — use when the automation is unavailable, a release needs
+hand-crafted notes, or `cd-release.yml` is being bypassed deliberately.
 
 1. **Verify readiness**
    ```bash
@@ -170,3 +198,4 @@ pipx upgrade fx-alfred                        # verify on PyPI
 | 2026-05-07 | FXA-2275: promote README check from Prerequisites to a numbered Step (new Step 2). Renumbered subsequent steps 3-7. Reason: README updates were silently skipped twice during v1.12.0 and v1.13.0 release work because the check sat in Prerequisites and was easy to miss when reading top-down. | Claude Code         |
 | 2026-06-26 | Add task tags so COR-1202 can compose release plans from natural-language tasks.                                                                                                                                                                                                                  | Claude Code         |
 | 2026-06-26 | Drop bare `publish` task tag — too generic; `publish docs` etc. wrongly routed to PyPI release (Codex review).                                                                                                                                                                                    | Claude Code         |
+| 2026-08-16 | FXA-2328: automated path (cd-release.yml semantic-release → publish.yml) documented as primary; manual §Steps demoted to fallback; docs-commits-release note added (bundled SOPs ship in the wheel).                                                                                              | Claude Code         |

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -60,9 +60,13 @@ Note: bundled SOP document changes ship in the wheel, so `docs(...)` commits DO 
    → no release). Update CHANGELOG's `## Unreleased` section and the README
    "NEW in vX" line (FXA-2136) inside the PR — semantic-release does not
    write prose.
-2. On merge, `cd-release.yml` runs semantic-release: bumps
+2. On merge, `cd-release.yml` first promotes CHANGELOG's `## Unreleased`
+   notes to a `## v{version} (date)` section (skipped when Unreleased is
+   empty), then runs semantic-release: bumps
    `pyproject.toml:project.version`, commits `chore(release): ...`, tags
    `v{version}`, creates the GitHub Release (via `SEMANTIC_RELEASE_PAT`).
+   The promotion lands before the tag, so the built wheel ships correct
+   version boundaries for `af changelog`.
 3. The Release event triggers `publish.yml`: test gate → build → Trusted
    Publishing to PyPI.
 4. Verify: `gh run list --workflow=publish.yml --limit 1` shows success and

--- a/rules/FXA-2102-SOP-Release-To-PyPI.md
+++ b/rules/FXA-2102-SOP-Release-To-PyPI.md
@@ -42,12 +42,19 @@ Note: bundled SOP document changes ship in the wheel, so `docs(...)` commits DO 
 
 ## Prerequisites
 
+Common to both paths:
+
 - All tests pass (`.venv/bin/pytest -v`)
 - Ruff lint clean (`.venv/bin/ruff check .`)
 - Ruff format clean (`.venv/bin/ruff format --check .`) — if files need formatting, format + commit first
 - Pyright clean (`.venv/bin/pyright src/`) — catches type errors that the publish CI also runs
 - Dual code review passed (Codex + Gemini both ≥ 9/10)
 - README updated per **Step 2** below (FXA-2136 Update README SOP)
+
+Manual fallback only — do **NOT** do these under the automated path (a
+pre-bumped version makes `cd-release.yml` compute `CURRENT == NEXT`, clear
+the release, and skip the CHANGELOG promotion):
+
 - Version bumped in `pyproject.toml`
 - All changes committed and pushed to `main`
 

--- a/rules/FXA-2125-SOP-Workflow-Routing-PRJ.md
+++ b/rules/FXA-2125-SOP-Workflow-Routing-PRJ.md
@@ -116,7 +116,7 @@ Dev install: cd fx_alfred && pip install -e .
 ## Project Golden Rules
 
 ```
-FXA-2102: Release = version bump → push → gh release create → CI publishes to PyPI
+FXA-2102: Release = merge conventional-commit PR to main (no pre-bump) → cd-release.yml auto-versions/tags → publish.yml → PyPI; manual bump + gh release create is the fallback only
 FXA-2100: Leader dispatches GLM (Worker), reviews with Codex+Gemini (Reviewer)
 ALF-2300: Incident = record what happened, impact, resolution, follow-up
 COR-1500: Any code change → TDD: failing test first, then green, then refactor

--- a/rules/FXA-2125-SOP-Workflow-Routing-PRJ.md
+++ b/rules/FXA-2125-SOP-Workflow-Routing-PRJ.md
@@ -4,7 +4,7 @@
 **Last updated:** 2026-04-04
 **Last reviewed:** 2026-03-20
 **Status:** Active
-**Tags:** routing, plan
+**Tags:** plan, routing
 
 ---
 
@@ -42,8 +42,10 @@ What do you need to do in the FXA project?
 
 1. Release a new version?
    └── FXA-2102 (Release To PyPI)
-       Prerequisites: tests pass + ruff clean + version bump + pushed to main + README up to date (FXA-2136)
-       Steps: gh release create → CI auto-publish → verify on PyPI
+       Primary (automated, FXA-2328): merge a conventional-commit PR to main
+         (do NOT pre-bump the version) → cd-release.yml promotes CHANGELOG,
+         bumps, tags, creates the Release → publish.yml → verify on PyPI
+       Manual fallback: version bump + README (FXA-2136) + gh release create
 
 2. Develop a new feature / modify code?
    └── FXA-2100 (Leader Mediated Development)
@@ -96,6 +98,7 @@ What do you need to do in the FXA project?
         Underlying chain (for drop-down debugging): COR-1617 §1 (Auto-pick) → COR-1618 (consent) → COR-1506 (quality) → scope-rank tree
 ```
 
+
 ## Project Context
 
 ```
@@ -108,6 +111,7 @@ Area:        21 (2100-2199)
 Root:        --root /Users/frank/Projects/alfred/fx_alfred
 Dev install: cd fx_alfred && pip install -e .
 ```
+
 
 ## Project Golden Rules
 
@@ -123,6 +127,7 @@ COR-1501: GitHub issue = blueprint template + stack-type-* / stack-area-* label 
 FXA-2276: "follow FXA-2276" is the alfred entry-point for picking the next open issue (full COR-1618 verify_consent_eligibility on every pick; only `follow FXA-2276 for #N` is bypass-eligible per §Normative Bypass)
 ```
 
+
 ## Steps
 
 This is a routing SOP — no procedural steps. The Project Decision Tree above is the primary content. Follow it to determine which SOP applies to your current task.
@@ -131,14 +136,14 @@ This is a routing SOP — no procedural steps. The Project Decision Tree above i
 
 ## Change History
 
-| Date | Change | By |
-|------|--------|----|
-| 2026-03-20 | Initial version per FXA-2220 | Frank + Claude Code |
-| 2026-03-20 | Rewritten: added project decision tree, project context, expanded golden rules | Frank + Claude Code |
-| 2026-03-20 | FXA-2133: Add Why, When to Use, When NOT to Use sections (5W1H migration) | Claude Code |
-| 2026-03-21 | Added Steps section (routing SOP, no procedural steps) | Claude Code |
-| 2026-03-30 | CHG FXA-2153: Translated decision tree from Chinese to English (COR-0002/COR-1401 compliance) | Claude Code |
-| 2026-04-04 | CHG FXA-2190: Remove deprecated FXA-2127 ref from decision tree, fix stale "no remote" golden rule | Claude Code |
-| 2026-05-10 | issue #126: add branch 9 (Create GitHub issue → COR-1501) to decision tree; add COR-1501 traceability line to Golden Rules | Claude Opus 4.7 |
-| 2026-05-16 | issue #162: add branch 10 (Pick next open issue / autonomous loop → FXA-2276) to decision tree; add FXA-2276 line to Golden Rules | Claude Opus 4.7 |
-| 2026-05-16 | issue #163 (bundled with #162 in PR #164): tighten branch 10 header — clarify that only `follow FXA-2276 for #N` is gate-bypassed; `follow FXA-2276` and `follow FXA-2276 once` apply full COR-1618 verify_consent_eligibility on every pick (aligns with the FXA-2276 §Invocation tightening in the same PR) | Claude Opus 4.7 |
+| Date       | Change                                                                                                                                                                                                                                                                                                        | By                  |
+|------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| 2026-03-20 | Initial version per FXA-2220                                                                                                                                                                                                                                                                                  | Frank + Claude Code |
+| 2026-03-20 | Rewritten: added project decision tree, project context, expanded golden rules                                                                                                                                                                                                                                | Frank + Claude Code |
+| 2026-03-20 | FXA-2133: Add Why, When to Use, When NOT to Use sections (5W1H migration)                                                                                                                                                                                                                                     | Claude Code         |
+| 2026-03-21 | Added Steps section (routing SOP, no procedural steps)                                                                                                                                                                                                                                                        | Claude Code         |
+| 2026-03-30 | CHG FXA-2153: Translated decision tree from Chinese to English (COR-0002/COR-1401 compliance)                                                                                                                                                                                                                 | Claude Code         |
+| 2026-04-04 | CHG FXA-2190: Remove deprecated FXA-2127 ref from decision tree, fix stale "no remote" golden rule                                                                                                                                                                                                            | Claude Code         |
+| 2026-05-10 | issue #126: add branch 9 (Create GitHub issue → COR-1501) to decision tree; add COR-1501 traceability line to Golden Rules                                                                                                                                                                                    | Claude Opus 4.7     |
+| 2026-05-16 | issue #162: add branch 10 (Pick next open issue / autonomous loop → FXA-2276) to decision tree; add FXA-2276 line to Golden Rules                                                                                                                                                                             | Claude Opus 4.7     |
+| 2026-05-16 | issue #163 (bundled with #162 in PR #164): tighten branch 10 header — clarify that only `follow FXA-2276 for #N` is gate-bypassed; `follow FXA-2276` and `follow FXA-2276 once` apply full COR-1618 verify_consent_eligibility on every pick (aligns with the FXA-2276 §Invocation tightening in the same PR) | Claude Opus 4.7     |

--- a/rules/FXA-2136-SOP-Update-README.md
+++ b/rules/FXA-2136-SOP-Update-README.md
@@ -12,6 +12,7 @@
 
 The process for keeping README.md in sync with the current state of fx-alfred before each release.
 
+
 ## Why
 
 README is the first thing users and AI agents see. An outdated README with missing commands, wrong version numbers, or stale examples creates confusion and wastes onboarding time.
@@ -24,6 +25,7 @@ README is the first thing users and AI agents see. An outdated README with missi
 - After adding new commands or features
 - After changing existing command behavior
 
+
 ## When NOT to Use
 
 - Patch releases with only bugfixes and no user-facing changes
@@ -33,7 +35,7 @@ README is the first thing users and AI agents see. An outdated README with missi
 
 ## Steps
 
-1. **Check version** — Ensure version in README matches `pyproject.toml`
+1. **Check version** — Manual release path: ensure the version in README matches `pyproject.toml`. Automated path (FXA-2102 §Automated Path): README references the **next** version that `cd-release.yml` will compute — `pyproject.toml` intentionally still holds the old version inside the PR, so do not "fix" the mismatch
 
 2. **Check Commands Reference** — Run `af --help` and compare against README's Commands Reference section. Add any missing commands, remove any deprecated ones.
 
@@ -53,6 +55,7 @@ README is the first thing users and AI agents see. An outdated README with missi
 
 8. **Commit** — If changes were made, commit README.md before proceeding with release.
 
+
 ## Examples
 
 ```bash
@@ -68,7 +71,7 @@ af --help                              # compare against README Commands Referen
 
 ## Change History
 
-| Date | Change | By |
-|------|--------|----|
-| 2026-03-21 | Initial version | Frank + Claude Code |
-| 2026-03-21 | Added Examples section | Claude Code |
+| Date       | Change                 | By                  |
+|------------|------------------------|---------------------|
+| 2026-03-21 | Initial version        | Frank + Claude Code |
+| 2026-03-21 | Added Examples section | Claude Code         |

--- a/rules/FXA-2328-CHG-Semantic-Release-Automation.md
+++ b/rules/FXA-2328-CHG-Semantic-Release-Automation.md
@@ -1,0 +1,92 @@
+# CHG-2328: Semantic Release Automation
+
+**Applies to:** FXA project
+**Last updated:** 2026-08-16
+**Last reviewed:** 2026-08-16
+**Status:** Proposed
+**Date:** 2026-08-16
+**Requested by:** Frank Xu (session request: automate releases; borrow fx_bin's cd-release.yml pattern)
+**Priority:** Medium
+**Change Type:** Normal
+**Targets:** .github/workflows/cd-release.yml (new), pyproject.toml, rules/FXA-2102-SOP-Release-To-PyPI.md, src/fx_alfred/CHANGELOG.md, rules/FXA-0000-REF-Document-Index.md
+
+---
+
+## What
+
+Adopt fx_bin's two-stage auto-release shape, adapted for fx-alfred:
+
+1. **New `.github/workflows/cd-release.yml`** — on every push to `main`,
+   `python-semantic-release@v9` parses conventional commits, decides the next
+   version (feat → minor; fix/perf/docs → patch), bumps
+   `pyproject.toml:project.version`, commits `chore(release): ...`, tags
+   `v{version}`, and creates the GitHub Release using
+   `secrets.SEMANTIC_RELEASE_PAT`. Guards: skip when actor is
+   `github-actions[bot]` or the head commit message contains
+   `chore(release):` (recursion), plus a `release` concurrency group.
+2. **`pyproject.toml` `[tool.semantic_release]`** — version source
+   `project.version` (PEP 621, not poetry); `docs` mapped to **patch** because
+   bundled SOP documents ship in the wheel (a docs change IS a shippable
+   change for this package); changelog generation **disabled** (the action's
+   `changelog: false`) — `src/fx_alfred/CHANGELOG.md` stays hand-curated and
+   `af changelog` keeps reading it.
+3. **Existing `publish.yml` untouched** — the PAT-created GitHub Release
+   fires its `release: [published]` trigger, so the tested path (pytest
+   cov≥95 / ruff / pyright → build → Trusted Publishing) is reused verbatim.
+4. **FXA-2102 SOP updated** — manual steps 1–3 collapse into "merge a
+   conventional-commit PR to main"; manual `gh release create` becomes the
+   fallback path.
+
+Not borrowed from fx_bin: its changelog auto-generation (conflicts with the
+curated narrative CHANGELOG), poetry version plumbing, and the PyPI
+existence-check/publish job (publish.yml already covers it).
+
+
+## Why
+
+FXA-2102 is a 7-step manual procedure (bump, CHANGELOG, README, release
+notes, create release, watch CI, verify). fx_bin has run the semantic-release
+shape successfully; every fx-alfred commit already follows conventional
+format, so version decisions are mechanically derivable. Automation removes
+the human-bump errors (stale versions, forgotten tags) and makes "merge to
+main" the single release action.
+
+
+## Impact Analysis
+
+- **Systems affected:** CI only (one new workflow + one pyproject section +
+  SOP doc). No `af` runtime code changes.
+- **Release cadence:** every merged PR containing feat/fix/perf/docs commits
+  produces a release. test/chore/ci/refactor commits do not.
+- **One-time operator action:** create a classic PAT with `repo` scope and
+  save it as the `SEMANTIC_RELEASE_PAT` repository secret. Without it the
+  workflow fails at checkout; the default `GITHUB_TOKEN` cannot be used
+  because releases it creates do not trigger `publish.yml`.
+- **Branch protection caveat:** semantic-release pushes the version-bump
+  commit directly to `main`; if branch protection later forbids direct
+  pushes, the PAT owner needs bypass permission.
+- **README "NEW in vX" (FXA-2136):** stays a manual, in-PR editorial step;
+  no longer blocks the release mechanics.
+- **Rollback plan:** delete cd-release.yml, remove the pyproject section,
+  revert the FXA-2102 edit, set this CHG to Rolled Back. Manual FXA-2102
+  flow keeps working throughout (it is the documented fallback).
+
+
+## Implementation Plan
+
+1. Add `.github/workflows/cd-release.yml` (adapted from fx_bin, poetry and
+   changelog steps removed).
+2. Add `[tool.semantic_release]` + parser options to pyproject.toml.
+3. Update FXA-2102: automated primary path + manual fallback.
+4. CHANGELOG Unreleased entry; validate (pytest, af validate, actionlint if
+   available); PR under `ryosaeba1985`; COR-1615 loop to closure.
+5. Operator creates `SEMANTIC_RELEASE_PAT`; first real merge validates the
+   chain end-to-end.
+
+---
+
+## Change History
+
+| Date       | Change          | By          |
+|------------|-----------------|-------------|
+| 2026-08-16 | Initial version | Claude Code |

--- a/rules/FXA-2328-CHG-Semantic-Release-Automation.md
+++ b/rules/FXA-2328-CHG-Semantic-Release-Automation.md
@@ -87,6 +87,7 @@ main" the single release action.
 
 ## Change History
 
-| Date       | Change          | By          |
-|------------|-----------------|-------------|
-| 2026-08-16 | Initial version | Claude Code |
+| Date       | Change                                                                                                                                                                                                                                                                                                                                                                   | By          |
+|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| 2026-08-16 | Initial version                                                                                                                                                                                                                                                                                                                                                          | Claude Code |
+| 2026-08-16 | R1 (codex P2 on PR #329): cd-release.yml gains a pre-tag CHANGELOG promotion step — computes the next version with `semantic-release --noop version --print`, promotes `## Unreleased` to `## v{version} (date)` (skip when empty), commits before semantic-release tags, so wheels ship correct version boundaries and Unreleased no longer accumulates shipped changes | Claude Code |

--- a/src/fx_alfred/CHANGELOG.md
+++ b/src/fx_alfred/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+### Improvements
+
+- **Automated releases** (FXA-2328) — new `cd-release.yml` runs
+  python-semantic-release on every push to `main`: conventional commits decide
+  the version (`feat` → minor; `fix`/`perf`/`docs` → patch, since bundled SOPs
+  ship in the wheel), the version bump is committed and tagged, and the
+  GitHub Release it creates fires the existing `publish.yml` Trusted
+  Publishing path unchanged. CHANGELOG stays hand-curated (semantic-release
+  changelog generation disabled). FXA-2102 now documents the automated path
+  as primary with the manual flow as fallback. Requires the
+  `SEMANTIC_RELEASE_PAT` repository secret.
+
 ## v1.28.0 (2026-08-16)
 
 The agent-execution release: COR-1615's PR review-bot loop becomes executable


### PR DESCRIPTION
FXA-2328 — adopts fx_bin's cd-release.yml pattern, adapted for fx-alfred.

## What

- **cd-release.yml (new)**: on push to `main`, python-semantic-release@v9 parses conventional commits, bumps `pyproject.toml:project.version`, commits `chore(release): ...`, tags `v{version}`, and creates the GitHub Release via `SEMANTIC_RELEASE_PAT`. Recursion guard (bot actor / `chore(release):` message) + `release` concurrency group.
- **pyproject `[tool.semantic_release]`**: PEP 621 version source; `feat` → minor, `fix`/`perf`/`docs` → patch (bundled SOPs ship in the wheel, so docs changes ARE shippable); changelog generation **disabled** — `src/fx_alfred/CHANGELOG.md` stays hand-curated for `af changelog`.
- **publish.yml untouched**: the PAT-created Release fires its existing `release: published` trigger — test gate → build → Trusted Publishing reused verbatim.
- **FXA-2102** updated: automated path primary, manual flow fallback.

## Deliberately NOT borrowed from fx_bin

Changelog auto-generation (conflicts with curated narrative), poetry version plumbing, duplicate PyPI publish job.

## ⚠️ Operator action required before merge takes effect

Create a PAT (repo scope) and save as the `SEMANTIC_RELEASE_PAT` repository secret — the default `GITHUB_TOKEN` cannot fire `publish.yml`. Note this PR itself is `ci(...)` → merging it does NOT trigger a release (by design).

## Validation

pytest 1523 passed; ruff clean; `af validate` 343 docs 0 issues; `af fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D57zvUA7BV3hCL1FQftraZ